### PR TITLE
Change rollme to be checksum of the values file

### DIFF
--- a/helm-charts/sawmills-remote-operator/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.0.3"
+version: "2.0.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-remote-operator/templates/deployment.yaml
+++ b/helm-charts/sawmills-remote-operator/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
+        rollme: {{ .Values | toYaml | sha256sum }}
       labels:
         {{- include "sawmills-remote-operator.labels" . | nindent 8 }}
       name: remote-operator


### PR DESCRIPTION
## Summary
rollme annotation changes on every ArgoCD refresh, this causes a drift in ArgoCD and we rather not ignore it
The introduced change makes a sha string out of the entire value files, so on every change to the values file (only), the deployment annotation will change.

## Changes Made
<!-- Check all that apply -->
- [X] Configuration change

@sawmills/engineers Please review this contribution. 