### PR TITLE
chore(charts): bump default image tags to latest (collector 1.770.0, ro 0.247.0)

### DIFF
--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -196,7 +196,7 @@ telemetryExtraEnv: []
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-collector
   pullPolicy: IfNotPresent
-  tag: 1.558.0
+  tag: 1.770.0
 
 # The node selector for the Sawmills collector
 nodeSelector: {}

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -40,7 +40,7 @@ collectorName: ""
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
-  tag: 0.233.0 # Sawmills Remote Operator image tag
+  tag: 0.247.0 # Sawmills Remote Operator image tag
 
 # The address of the Sawmills operator
 operatorAddress: https://controller.sawmills.ai


### PR DESCRIPTION
Bumps default image tags in values.yaml to match latest released versions already live in prod via LD flags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Helm chart default image tags to latest versions: `sawmills-collector` 1.770.0 and `sawmills-remote-operator` 0.247.0. Aligns chart defaults with production to prevent drift and remove overrides.

<sup>Written for commit 7d7af0166ad40f4e0ec34013daf21bc9b1a42c56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sawmills collector image to version 1.770.0
  * Updated Sawmills Remote Operator image to version 0.247.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the default image tags for two Helm charts — `sawmills-collector` (`1.558.0` → `1.770.0`) and `sawmills-remote-operator` (`0.233.0` → `0.247.0`) — to align chart defaults with versions already running in production. The image tag updates in `values.yaml` are correct and functional.

However, the `Chart.yaml` files for both charts were not updated:
- **`appVersion` fields** remain stale and out of sync with the deployed image versions
- **Chart `version` fields** were not incremented, despite explicit comments in both `Chart.yaml` files stating this should happen whenever chart content changes

While the actual Kubernetes deployment behavior is correct (since Kubernetes uses `image.tag` from `values.yaml`, not `appVersion`), the Chart metadata inconsistencies affect Helm release tracking, `helm list` output, and chart versioning practices.

<h3>Confidence Score: 3/5</h3>

- Functionally safe to deploy—image tag updates are correct—but Chart.yaml metadata is inconsistent and violates explicit versioning guidelines.
- The image tag updates in values.yaml are correct and will deploy the intended application versions. However, the Chart.yaml files in both charts have not been updated despite explicit comments stating that both appVersion and version should be incremented whenever chart content changes. This metadata inconsistency affects Helm release tracking, tooling, and chart governance practices. While not a runtime blocker, it represents incomplete work that should be addressed.
- helm-charts/sawmills-collector/Chart.yaml and helm-charts/sawmills-remote-operator/Chart.yaml — both require appVersion and version updates to match the image tag changes.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `helm-charts/sawmills-collector/Chart.yaml`, line 24 ([link](https://github.com/sawmills/helm-charts/blob/7d7af0166ad40f4e0ec34013daf21bc9b1a42c56/helm-charts/sawmills-collector/Chart.yaml#L24)) 

   **Chart.yaml metadata out of sync with image tag update**

   The image tag in `values.yaml` was updated (`1.770.0`), but `Chart.yaml` wasn't updated. The `appVersion` field should reflect the version of the application being deployed and stay in sync with the default image tag. The explicit comment in this file states:

   > "This version number should be incremented each time you make changes to the chart and its templates, including the app version."

   **Suggested fix for `helm-charts/sawmills-collector/Chart.yaml`:**

   
   Also increment the chart `version` from `2.6.12` to `2.6.13`.

   **This same issue applies to `helm-charts/sawmills-remote-operator/Chart.yaml`** — the `appVersion` should be `"0.247.0"` (not `"0.233.0"`) and chart `version` should be incremented from `"2.0.21"` to `"2.0.22"`.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 7d7af01</sub>

<!-- /greptile_comment -->