### PR TITLE
fix(sawmills-collector): broaden headless migration cleanup

### DIFF
--- a/helm-charts/sawmills-collector/templates/load-balancer-headless-service-migration-hook.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-headless-service-migration-hook.yaml
@@ -1,11 +1,11 @@
-{{- if and .Release.IsUpgrade .Values.loadBalancer.enabled .Values.loadBalancer.service.headless.enabled }}
+{{- if and .Release.IsUpgrade (or .Values.service.headless.enabled .Values.loadBalancer.service.headless.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sawmills-collector.fullname" . }}-headless-migration
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-3"
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "sawmills-collector.fullname" . }}-headless-migration
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-2"
@@ -33,7 +33,7 @@ metadata:
   name: {{ include "sawmills-collector.fullname" . }}-headless-migration
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-1"
@@ -53,7 +53,7 @@ metadata:
   name: {{ include "sawmills-collector.fullname" . }}-headless-migration
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "sawmills-collector.loadBalancerSelectorLabels" . | nindent 8 }}
+        {{- include "sawmills-collector.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "sawmills-collector.fullname" . }}-headless-migration
       restartPolicy: Never

--- a/helm-charts/sawmills-collector/tests/load_balancer_headless_migration_hook_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_headless_migration_hook_test.yaml
@@ -1,4 +1,4 @@
-suite: Load Balancer Headless Service Migration Hook
+suite: Headless Service Migration Hook
 templates:
   - templates/load-balancer-headless-service-migration-hook.yaml
 values:
@@ -17,8 +17,11 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not render when LB headless service is disabled
+  - it: should not render when both headless services are disabled
     set:
+      service:
+        headless:
+          enabled: false
       loadBalancer:
         enabled: true
         service:
@@ -37,6 +40,25 @@ tests:
         service:
           headless:
             enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-headless-migration
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+
+  - it: should render cleanup hook resources on non-LB headless upgrade
+    release:
+      upgrade: true
+    set:
+      loadBalancer:
+        enabled: false
+      service:
+        headless:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 4

--- a/helm-charts/sawmills-collector/tests/load_balancer_headless_migration_hook_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_headless_migration_hook_test.yaml
@@ -18,6 +18,8 @@ tests:
           count: 0
 
   - it: should not render when both headless services are disabled
+    release:
+      upgrade: true
     set:
       service:
         headless:


### PR DESCRIPTION
sawmills-collector: broaden headless migration cleanup

Extends the SAW-6765 cleanup hook so upgrades that render the non-LB headless Service also delete the legacy broken `-headless` Service before Helm applies manifests.

Description
- run the pre-upgrade cleanup hook when either collector or LB headless services are enabled
- switch hook labels to generic chart labels so the job works in non-LB mode too
- add regression coverage for the non-LB upgrade path that hit Fireblocks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the headless Service rendering bug in the `sawmills-collector` Helm chart that caused immutable `clusterIP` upgrade failures (SAW-6765). Broadens the pre-upgrade cleanup to run for both LB and non-LB headless modes and removes the legacy `-headless` Service before apply.

- Bug Fixes
  - Corrected casing in LB headless Service (`ClusterIP` → `clusterIP`).
  - Renamed LB headless Service to `<fullname>-lb-headless`; updated `lbHeadlessSvcFQDN`.
  - Expanded tests to cover LB and non-LB paths, assert `spec.clusterIP: None`, exercise the upgrade guard, and ensure no-render when headless is disabled.

- Migration
  - Added a pre-upgrade cleanup hook (SA/Role/RoleBinding/Job) that deletes `<fullname>-headless` with `--ignore-not-found`.
  - Hook triggers when either `service.headless.enabled` or `loadBalancer.service.headless.enabled` is true and uses generic chart and selector labels.

<sup>Written for commit 1cbb8458b485fdd1c83dfe0d453097554d06ee75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the pre-upgrade migration hook to correctly trigger when headless services are configured, enabling proper service migration across a wider range of deployment scenarios.

* **Tests**
  * Enhanced test coverage with additional scenarios validating migration hook behavior when different combinations of headless services are enabled or disabled during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->