### PR TITLE
fix(sawmills-collector): stop gating lb readiness on telemetry health

### DIFF
--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -312,12 +312,6 @@ spec:
             initialDelaySeconds: {{ .Values.rollout.telemetry.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.rollout.telemetry.probes.liveness.periodSeconds }}
             failureThreshold: {{ .Values.rollout.telemetry.probes.liveness.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: /healthcheck
-              port: 13134
-            initialDelaySeconds: {{ .Values.rollout.telemetry.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.rollout.telemetry.probes.readiness.periodSeconds }}
           resources:
             {{- if .Values.telemetry.resources.requests }}
             requests:

--- a/helm-charts/sawmills-collector/tests/load_balancer_telemetry_probe_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_telemetry_probe_test.yaml
@@ -14,6 +14,8 @@ tests:
       haproxy.mapping.logs_http_10000.to.port: 10518
       haproxy.mapping.logs_http_10000.to.protocol: "TCP"
     asserts:
+      # With HAProxy enabled, LB container order is:
+      # [0]=haproxy, [1]=main-collector, [2]=telemetry-collector
       - equal:
           path: kind
           value: Deployment
@@ -41,6 +43,8 @@ tests:
       haproxy.mapping.logs_http_10000.to.port: 10518
       haproxy.mapping.logs_http_10000.to.protocol: "TCP"
     asserts:
+      # With HAProxy enabled, LB container order is:
+      # [0]=haproxy, [1]=main-collector, [2]=telemetry-collector
       - equal:
           path: kind
           value: StatefulSet

--- a/helm-charts/sawmills-collector/tests/load_balancer_telemetry_probe_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_telemetry_probe_test.yaml
@@ -1,0 +1,57 @@
+suite: test load balancer telemetry probe configuration
+templates:
+  - load-balancer.yaml
+tests:
+  - it: should not gate lb deployment readiness on telemetry sidecar health
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.storage.enabled: false
+      haproxy.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: telemetry-collector
+      - equal:
+          path: spec.template.spec.containers[2].livenessProbe.httpGet.port
+          value: 13134
+      - equal:
+          path: spec.template.spec.containers[2].livenessProbe.httpGet.path
+          value: /healthcheck
+      - notExists:
+          path: spec.template.spec.containers[2].readinessProbe
+
+  - it: should not gate lb statefulset readiness on telemetry sidecar health
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.storage.enabled: true
+      haproxy.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: telemetry-collector
+      - equal:
+          path: spec.template.spec.containers[2].livenessProbe.httpGet.port
+          value: 13134
+      - equal:
+          path: spec.template.spec.containers[2].livenessProbe.httpGet.path
+          value: /healthcheck
+      - notExists:
+          path: spec.template.spec.containers[2].readinessProbe


### PR DESCRIPTION
## Summary
- stop rendering the telemetry sidecar readiness probe in lb pods
- keep telemetry liveness on 13134 so the sidecar still restarts if it wedges
- add helm unit coverage for both deployment and statefulset lb modes

## Why
During BigPanda west rollouts, lb pods were being removed from service because the telemetry sidecar readiness probe on 13134 returned 503, even when the lb data path was healthy. This change stops the telemetry sidecar from deciding lb pod readiness.

## Verification
- helm lint helm-charts/sawmills-collector
- helm template test-release helm-charts/sawmills-collector
- ./tests/run-tests.sh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the telemetry sidecar readiness probe from LB pods so readiness is no longer gated on telemetry health. Keeps liveness on 13134 to restart wedged sidecars and prevents false LB evictions seen in SAW-6720.

- **Bug Fixes**
  - Stop rendering telemetry sidecar readiness in `helm-charts/sawmills-collector/templates/load-balancer.yaml` for both Deployment and StatefulSet.
  - Keep telemetry liveness at `/healthcheck` on port 13134.
  - Add Helm unit tests (`helm-charts/sawmills-collector/tests/load_balancer_telemetry_probe_test.yaml`) to assert no readiness probe, verify liveness, and document container order with HAProxy across both LB modes.

<sup>Written for commit 4e4d182bff4dd61d5640616b29235bc1607f259e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the readiness probe from the telemetry sidecar so load balancer readiness is no longer tied to that sidecar.

* **Tests**
  * Added unit tests verifying load balancer health behavior when the telemetry sidecar is present across deployment modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->