### PR TITLE
feat: wire backend drain rollout behavior

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -484,7 +484,7 @@ rollout:
       port: 13137
       readinessPath: /ready
       drainPath: /drain
-      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
       duration: 15s
     preStopSleepSeconds: 15
@@ -503,7 +503,7 @@ rollout:
       port: 13137
       readinessPath: /ready
       drainPath: /drain
-      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
       duration: 15s
 ```
@@ -512,6 +512,7 @@ With that topology enabled, the chart:
 
 * Adds a separate `backend_drain` config overlay as an extra `--config`, including S3-backed main collector configs.
 * Preserves the main collector extension list by defaulting to `health_check`, `cgroupruntime`, and appending `backend_drain` unless `otelCollectorConfig.service.extensions` already specifies a custom list.
+* When the main collector config comes from S3, mirror any extra `service.extensions` entries in `rollout.main.drain.serviceExtensions`, because the chart cannot inspect or merge the remote extension list for you.
 * Configures the drain-aware readiness server to mirror the normal `health_check` endpoint until drain starts, so readiness still tracks real collector health.
 * Switches the main collector readiness probe to the drain-aware endpoint.
 * Uses a `preStop.httpGet` hook to call `/drain`, which flips readiness immediately and blocks for the configured drain duration.

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -479,8 +479,45 @@ rollout:
         enabled: true
         periodSeconds: 5
         failureThreshold: 12
+    drain:
+      enabled: true
+      port: 13137
+      readinessPath: /ready
+      drainPath: /drain
+      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      serviceExtensions: [health_check, cgroupruntime]
+      duration: 15s
     preStopSleepSeconds: 15
 ```
+
+### Backend Drain Wiring For LB Topology
+
+When `loadBalancer.enabled: true`, the chart can protect backend collector rollouts with a dedicated drain listener on the main collector:
+
+```yaml
+rollout:
+  terminationGracePeriodSeconds: 60
+  main:
+    drain:
+      enabled: true
+      port: 13137
+      readinessPath: /ready
+      drainPath: /drain
+      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      serviceExtensions: [health_check, cgroupruntime]
+      duration: 15s
+```
+
+With that topology enabled, the chart:
+
+* Adds a separate `backend_drain` config overlay as an extra `--config`, including S3-backed main collector configs.
+* Preserves the main collector extension list by defaulting to `health_check`, `cgroupruntime`, and appending `backend_drain` unless `otelCollectorConfig.service.extensions` already specifies a custom list.
+* Configures the drain-aware readiness server to mirror the normal `health_check` endpoint until drain starts, so readiness still tracks real collector health.
+* Switches the main collector readiness probe to the drain-aware endpoint.
+* Uses a `preStop.httpGet` hook to call `/drain`, which flips readiness immediately and blocks for the configured drain duration.
+* Leaves liveness and startup probes on the normal `health_check` endpoint (`13133`) so crash detection stays unchanged.
+
+Keep `rollout.main.drain.duration` below `rollout.terminationGracePeriodSeconds` so the collector still has time to receive and process `SIGTERM` after the drain hook returns.
 
 ### Pod Disruption Budget
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -487,6 +487,7 @@ rollout:
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
       duration: 15s
+      shutdownReserve: 10s
     preStopSleepSeconds: 15
 ```
 
@@ -506,6 +507,7 @@ rollout:
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
       duration: 15s
+      shutdownReserve: 10s
 ```
 
 With that topology enabled, the chart:
@@ -518,7 +520,7 @@ With that topology enabled, the chart:
 * Uses a `preStop.httpGet` hook to call `/drain`, which flips readiness immediately and blocks for the configured drain duration.
 * Leaves liveness and startup probes on the normal `health_check` endpoint (`13133`) so crash detection stays unchanged.
 
-Keep `rollout.main.drain.duration` below `rollout.terminationGracePeriodSeconds` so the collector still has time to receive and process `SIGTERM` after the drain hook returns.
+Keep `rollout.main.drain.duration + rollout.main.drain.shutdownReserve` below `rollout.terminationGracePeriodSeconds` so the collector still has explicit post-drain shutdown time before kubelet force-kills the pod.
 
 ### Pod Disruption Budget
 

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -170,6 +170,32 @@ Generate merged telemetry configuration with external labels
 {{- end -}}
 
 {{/*
+Convert a Go-style duration string into milliseconds.
+Supported units: ms, s, m, h. Composite values are allowed, e.g. 1m30s.
+*/}}
+{{- define "sawmills-collector.durationToMilliseconds" -}}
+{{- $duration := toString . -}}
+{{- $matches := regexFindAll "[0-9]+(?:ms|s|m|h)" $duration -1 -}}
+{{- if or (eq (len $matches) 0) (ne (join "" $matches) $duration) -}}
+{{- fail (printf "unsupported duration %q; use Go-style duration values such as 15s, 1m, or 1500ms" $duration) -}}
+{{- end -}}
+{{- $total := 0 -}}
+{{- range $match := $matches -}}
+  {{- $value := atoi (regexFind "[0-9]+" $match) -}}
+  {{- if hasSuffix "ms" $match -}}
+    {{- $total = add $total $value -}}
+  {{- else if hasSuffix "s" $match -}}
+    {{- $total = add $total (mul $value 1000) -}}
+  {{- else if hasSuffix "m" $match -}}
+    {{- $total = add $total (mul $value 60000) -}}
+  {{- else if hasSuffix "h" $match -}}
+    {{- $total = add $total (mul $value 3600000) -}}
+  {{- end -}}
+{{- end -}}
+{{- $total -}}
+{{- end -}}
+
+{{/*
 Static NO_PROXY entries that are always added when proxy.http or proxy.https is set.
 */}}
 {{- define "sawmills-collector.addNoProxy" -}}

--- a/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
@@ -1,0 +1,36 @@
+{{- $serviceExtensions := list }}
+{{- if and (kindIs "map" .Values.otelCollectorConfig) (hasKey .Values.otelCollectorConfig "service") (kindIs "map" .Values.otelCollectorConfig.service) (hasKey .Values.otelCollectorConfig.service "extensions") }}
+{{- $serviceExtensions = deepCopy .Values.otelCollectorConfig.service.extensions }}
+{{- else }}
+{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") .Values.rollout.main.drain.serviceExtensions) }}
+{{- end }}
+{{- $filteredServiceExtensions := list }}
+{{- range $serviceExtensions }}
+{{- if . }}
+{{- $filteredServiceExtensions = append $filteredServiceExtensions . }}
+{{- end }}
+{{- end }}
+{{- if not (has "backend_drain" $filteredServiceExtensions) }}
+{{- $filteredServiceExtensions = append $filteredServiceExtensions "backend_drain" }}
+{{- end }}
+{{- if and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sawmills-collector.fullname" . }}-backend-drain-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    extensions:
+      backend_drain:
+        endpoint: ${env:MY_POD_IP}:{{ .Values.rollout.main.drain.port }}
+        readiness_path: {{ .Values.rollout.main.drain.readinessPath }}
+        drain_path: {{ .Values.rollout.main.drain.drainPath }}
+        health_check_endpoint: {{ .Values.rollout.main.drain.healthCheckEndpoint }}
+        drain_duration: {{ .Values.rollout.main.drain.duration }}
+    service:
+      extensions:
+{{- toYaml $filteredServiceExtensions | nindent 8 }}
+{{- end }}

--- a/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
 {{- $serviceExtensions := list }}
 {{- if and (kindIs "map" .Values.otelCollectorConfig) (hasKey .Values.otelCollectorConfig "service") (kindIs "map" .Values.otelCollectorConfig.service) (hasKey .Values.otelCollectorConfig.service "extensions") }}
 {{- $serviceExtensions = deepCopy .Values.otelCollectorConfig.service.extensions }}
@@ -13,7 +14,6 @@
 {{- if not (has "backend_drain" $filteredServiceExtensions) }}
 {{- $filteredServiceExtensions = append $filteredServiceExtensions "backend_drain" }}
 {{- end }}
-{{- if and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,4 +1,11 @@
 {{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+{{- if $mainCollectorDrainEnabled }}
+{{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.duration | atoi }}
+{{- $terminationGracePeriodMs := mul (int .Values.rollout.terminationGracePeriodSeconds) 1000 }}
+{{- if ge $drainDurationMs $terminationGracePeriodMs }}
+{{- fail (printf "rollout.main.drain.duration (%s) must be less than rollout.terminationGracePeriodSeconds (%ds)" .Values.rollout.main.drain.duration (int .Values.rollout.terminationGracePeriodSeconds)) }}
+{{- end }}
+{{- end }}
 {{- if eq .Values.mode "daemonSet" }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,9 +1,10 @@
 {{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
 {{- if $mainCollectorDrainEnabled }}
 {{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.duration | atoi }}
+{{- $shutdownReserveMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.shutdownReserve | atoi }}
 {{- $terminationGracePeriodMs := mul (int .Values.rollout.terminationGracePeriodSeconds) 1000 }}
-{{- if ge $drainDurationMs $terminationGracePeriodMs }}
-{{- fail (printf "rollout.main.drain.duration (%s) must be less than rollout.terminationGracePeriodSeconds (%ds)" .Values.rollout.main.drain.duration (int .Values.rollout.terminationGracePeriodSeconds)) }}
+{{- if ge (add $drainDurationMs $shutdownReserveMs) $terminationGracePeriodMs }}
+{{- fail (printf "rollout.main.drain.duration (%s) plus rollout.main.drain.shutdownReserve (%s) must be less than rollout.terminationGracePeriodSeconds (%ds)" .Values.rollout.main.drain.duration .Values.rollout.main.drain.shutdownReserve (int .Values.rollout.terminationGracePeriodSeconds)) }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.mode "daemonSet" }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
 {{- if eq .Values.mode "daemonSet" }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -237,9 +238,16 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.otelConfig.s3path }}
+          {{- if or .Values.otelConfig.s3path $mainCollectorDrainEnabled }}
           args:
+            {{- if .Values.otelConfig.s3path }}
             - "--config={{ .Values.otelConfig.s3path }}{{- if .Values.otelConfig.encryptionKey }}@{{ .Values.otelConfig.encryptionKey }}{{- end }}"
+            {{- else }}
+            - "--config=file:/etc/otel/config.yaml"
+            {{- end }}
+            {{- if $mainCollectorDrainEnabled }}
+            - "--config=file:/etc/otel/backend-drain-config.yaml"
+            {{- end }}
           {{- end }}
           env:
             - name: MY_POD_NAME
@@ -286,8 +294,13 @@ spec:
             failureThreshold: {{ .Values.rollout.main.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
+              {{- if $mainCollectorDrainEnabled }}
+              path: {{ .Values.rollout.main.drain.readinessPath }}
+              port: {{ .Values.rollout.main.drain.port }}
+              {{- else }}
               path: /healthcheck
               port: 13133
+              {{- end }}
             initialDelaySeconds: {{ .Values.rollout.main.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.rollout.main.probes.readiness.periodSeconds }}
           {{- if .Values.rollout.main.probes.startup.enabled }}
@@ -299,7 +312,14 @@ spec:
             periodSeconds: {{ .Values.rollout.main.probes.startup.periodSeconds }}
             failureThreshold: {{ .Values.rollout.main.probes.startup.failureThreshold }}
           {{- end }}
-          {{- if .Values.rollout.main.preStopSleepSeconds }}
+          {{- if $mainCollectorDrainEnabled }}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: {{ .Values.rollout.main.drain.drainPath }}
+                port: {{ .Values.rollout.main.drain.port }}
+                scheme: HTTP
+          {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
             preStop:
               exec:
@@ -320,6 +340,11 @@ spec:
           {{- if not .Values.otelConfig.s3path }}
             - name: sawmills-collector-config
               mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+          {{- end }}
+          {{- if $mainCollectorDrainEnabled }}
+            - name: sawmills-backend-drain-config
+              mountPath: /etc/otel/backend-drain-config.yaml
               subPath: config.yaml
           {{- end }}
             - name: sawmills-livetail-config
@@ -346,6 +371,14 @@ spec:
         - name: sawmills-collector-config
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+        {{- end }}
+        {{- if $mainCollectorDrainEnabled }}
+        - name: sawmills-backend-drain-config
+          configMap:
+            name: {{ include "sawmills-collector.fullname" . }}-backend-drain-config
             items:
               - key: config.yaml
                 path: config.yaml

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -161,8 +161,9 @@ tests:
     set:
       loadBalancer.enabled: true
       rollout.main.drain.enabled: true
-      rollout.main.drain.duration: 60s
+      rollout.main.drain.duration: 50s
+      rollout.main.drain.shutdownReserve: 10s
       rollout.terminationGracePeriodSeconds: 60
     asserts:
       - failedTemplate:
-          errorMessage: 'rollout.main.drain.duration (60s) must be less than rollout.terminationGracePeriodSeconds (60s)'
+          errorMessage: 'rollout.main.drain.duration (50s) plus rollout.main.drain.shutdownReserve (10s) must be less than rollout.terminationGracePeriodSeconds (60s)'

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -1,0 +1,121 @@
+suite: backend drain wiring
+templates:
+  - deployment.yaml
+  - backend-drain-configmap.yaml
+tests:
+  - it: should wire backend drain readiness and prestop only for load balancer topology
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].args[0]
+          value: --config=file:/etc/otel/config.yaml
+      - equal:
+          path: spec.template.spec.containers[1].args[1]
+          value: --config=file:/etc/otel/backend-drain-config.yaml
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13137
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /ready
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.port
+          value: 13137
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.path
+          value: /drain
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.scheme
+          value: HTTP
+
+  - it: should add backend drain overlay config for load balancer topology
+    template: backend-drain-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://127.0.0.1:13133/healthcheck\n\s+drain_duration: 15s\n'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
+
+  - it: should keep existing main collector health wiring when load balancer topology is disabled
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[0]
+          value: /bin/sleep
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
+          value: "15"
+
+  - it: should still add the backend drain overlay when main collector config comes from s3
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      otelConfig.s3path: s3://test-bucket/config.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].args[0]
+          value: --config=s3://test-bucket/config.yaml
+      - equal:
+          path: spec.template.spec.containers[1].args[1]
+          value: --config=file:/etc/otel/backend-drain-config.yaml
+
+  - it: should preserve explicit main collector service extensions when configured inline
+    template: backend-drain-configmap.yaml
+    values:
+      - ../values.yaml
+      - fixtures/backend_drain_inline_extensions.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- basicauth/client\n\s+- backend_drain\n'
+
+  - it: should not render backend drain overlay when load balancer topology is disabled
+    template: backend-drain-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -9,6 +9,7 @@ tests:
       - ../values.yaml
     set:
       loadBalancer.enabled: true
+      rollout.main.drain.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[1].name
@@ -53,6 +54,7 @@ tests:
       - ../values.yaml
     set:
       loadBalancer.enabled: true
+      rollout.main.drain.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -140,3 +142,27 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not render backend drain overlay when drain is explicitly disabled
+    template: backend-drain-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      rollout.main.drain.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when drain duration consumes the full termination grace period
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      rollout.main.drain.enabled: true
+      rollout.main.drain.duration: 60s
+      rollout.terminationGracePeriodSeconds: 60
+    asserts:
+      - failedTemplate:
+          errorMessage: 'rollout.main.drain.duration (60s) must be less than rollout.terminationGracePeriodSeconds (60s)'

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -60,7 +60,7 @@ tests:
           count: 1
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://127.0.0.1:13133/healthcheck\n\s+drain_duration: 15s\n'
+          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n'
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -83,6 +83,27 @@ tests:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
           value: "15"
 
+  - it: should fall back to sleep-based prestop when drain is disabled in load balancer topology
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      rollout.main.drain.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[0]
+          value: /bin/sleep
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
+          value: "15"
+
   - it: should still add the backend drain overlay when main collector config comes from s3
     template: deployment.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/fixtures/backend_drain_inline_extensions.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/backend_drain_inline_extensions.yaml
@@ -1,0 +1,5 @@
+otelCollectorConfig:
+  service:
+    extensions:
+      - health_check
+      - basicauth/client

--- a/helm-charts/sawmills-collector/tests/fixtures/backend_drain_inline_extensions.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/backend_drain_inline_extensions.yaml
@@ -1,3 +1,8 @@
+rollout:
+  main:
+    drain:
+      enabled: true
+
 otelCollectorConfig:
   service:
     extensions:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -105,9 +105,13 @@ rollout:
       serviceExtensions:
         - health_check
         - cgroupruntime
-      # Keep this below rollout.terminationGracePeriodSeconds so the collector
-      # still has time to handle SIGTERM after the drain hook returns.
+      # Keep drain.duration + shutdownReserve below
+      # rollout.terminationGracePeriodSeconds so the collector still has time
+      # to handle SIGTERM after the drain hook returns.
       duration: 15s
+      # Reserve explicit post-drain shutdown time inside the pod termination
+      # grace period for collector shutdown and kubelet bookkeeping.
+      shutdownReserve: 10s
 
   # Telemetry collector specific settings
   telemetry:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -98,7 +98,7 @@ rollout:
       readinessPath: /ready
       drainPath: /drain
       # Backend drain readiness proxies this health endpoint until drain starts.
-      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       # Preserve the standard collector extensions when rendering the
       # backend_drain overlay, especially for S3-backed main configs where the
       # chart cannot inspect the remote file directly.

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -86,7 +86,28 @@ rollout:
         initialDelaySeconds: 0
         periodSeconds: 5
         failureThreshold: 12
+    # Sleep-based fallback used when backend drain mode is disabled or the
+    # deployment is not using the loadBalancer topology.
     preStopSleepSeconds: 15
+    drain:
+      # When loadBalancer.enabled=true, the chart adds a small backend_drain
+      # overlay config and switches the main collector readiness/preStop hooks
+      # to this dedicated endpoint.
+      enabled: true
+      port: 13137
+      readinessPath: /ready
+      drainPath: /drain
+      # Backend drain readiness proxies this health endpoint until drain starts.
+      healthCheckEndpoint: http://127.0.0.1:13133/healthcheck
+      # Preserve the standard collector extensions when rendering the
+      # backend_drain overlay, especially for S3-backed main configs where the
+      # chart cannot inspect the remote file directly.
+      serviceExtensions:
+        - health_check
+        - cgroupruntime
+      # Keep this below rollout.terminationGracePeriodSeconds so the collector
+      # still has time to handle SIGTERM after the drain hook returns.
+      duration: 15s
 
   # Telemetry collector specific settings
   telemetry:


### PR DESCRIPTION
## Summary
- wire backend drain overlay and main-collector readiness/preStop hooks for LB topology
- preserve existing service.extensions and append backend_drain
- document and test the new backend drain behavior

## Testing
- helm unittest helm-charts/sawmills-collector -f tests/backend_drain_test.yaml
- helm lint helm-charts/sawmills-collector
- helm template test-release helm-charts/sawmills-collector --set loadBalancer.enabled=true
- ./tests/run-tests.sh
- trunk check --fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend drain flow for the main collector in LB topology to stop connection‑refused bursts during rollouts by flipping readiness immediately, draining briefly, and reserving post‑drain shutdown time. Implements SAW-6828 so backend rollouts are safe without changing LB logic.

- **New Features**
  - Add `backend_drain` overlay `ConfigMap`; append to `service.extensions` (preserves existing). For S3-backed configs, mirror extras via `rollout.main.drain.serviceExtensions`.
  - Switch main readiness to port `13137` path `/ready`; `preStop` uses HTTP GET to `/drain`. Liveness/startup stay on `13133` `/healthcheck`; readiness mirrors health until drain starts.
  - Mount overlay and pass extra `--config` (works with S3 or inline configs). Gate behind `loadBalancer.enabled: true` and `rollout.main.drain.enabled: true`; fallback to `preStopSleepSeconds` otherwise.
  - Add `shutdownReserve` and duration parsing; render fails if `rollout.main.drain.duration + rollout.main.drain.shutdownReserve` ≥ `rollout.terminationGracePeriodSeconds`.
  - README updated; Helm tests cover probes/preStop wiring, overlay rendering, S3 + overlay args, extension preservation, opt‑out behavior, and grace‑budget validation.

<sup>Written for commit ec9f591515fb2a8974f8de5150d02d036402edf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable graceful drain for the main collector: drain endpoints, port, readiness switching, drain duration, and fallback preStop sleep; duration validation against pod termination grace period.
  * Automatic overlay for load‑balancer topologies that preserves and augments service extensions with backend drain.

* **Documentation**
  * Guidance on drain wiring, readiness/liveness semantics, preStop sequencing, and timing constraints.

* **Tests**
  * Tests and fixtures validating probes, preStop drain calls, overlay rendering, extension preservation, and duration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->