### PR TITLE
fix(sawmills-collector): template keda scaler service FQDN on release namespace

### DIFF
--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -43,11 +43,11 @@ spec:
       metadata:
         {{- if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}
-        {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ tpl (toString $value) $ | quote }}
         {{- end }}
         {{- else}}
         {{- range $key, $value := .Values.keda.scaling.external.metadata }}
-        {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ tpl (toString $value) $ | quote }}
         {{- end }}
         {{- end }}
     {{- end }}

--- a/helm-charts/sawmills-collector/templates/telemetry-keda-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/telemetry-keda-configmap.yaml
@@ -9,6 +9,6 @@ metadata:
 data:
   keda.yaml: |
     {{- with .Values.kedaScaler.telemetryConfig }}
-      {{- toYaml . | nindent 4 }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -1,0 +1,47 @@
+suite: keda scaler address namespace templating
+templates:
+  - keda-hpa.yaml
+tests:
+  - it: external trigger scalerAddress resolves to the release namespace (non-LB path)
+    template: keda-hpa.yaml
+    release:
+      name: my-release
+      namespace: any-ns
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      loadBalancer.enabled: false
+    asserts:
+      - matchRegex:
+          path: spec.triggers[?(@.type=="external")].metadata.scalerAddress
+          pattern: '^my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local:\d+$'
+
+  - it: external trigger scalerAddress resolves to the release namespace (LB path)
+    template: keda-hpa.yaml
+    release:
+      name: my-release
+      namespace: any-ns
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      loadBalancer.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.triggers[?(@.type=="external")].metadata.scalerAddress
+          pattern: '^my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local:\d+$'
+
+  - it: scalerAddress never contains a literal non-release namespace
+    template: keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sawmills-o11y
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.triggers[?(@.type=="external")].metadata.scalerAddress
+          pattern: '\.sawmills-o11y\.svc\.cluster\.local'
+      - notMatchRegex:
+          path: spec.triggers[?(@.type=="external")].metadata.scalerAddress
+          pattern: '\.sawmills\.svc\.cluster\.local'

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -101,3 +101,18 @@ tests:
       - matchRegex:
           path: data["keda.yaml"]
           pattern: '(?m)^\s*metrics/keda:\s*$'
+
+  - it: keda otlp exporter endpoint resolves to the release namespace, not a hardcoded one
+    template: telemetry-keda-configmap.yaml
+    release:
+      name: my-release
+      namespace: any-ns
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local'
+      - notMatchRegex:
+          path: data["keda.yaml"]
+          pattern: '\.sawmills\.svc\.cluster\.local'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -371,7 +371,7 @@ keda:
       enabled: false
       metricType: Value
       metadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.fullname" . }}-keda-otel-scaler.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         # Query by 99p latency of the 90p slowest pod
         query: >-
           quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 > 6000
@@ -379,7 +379,7 @@ keda:
           or vector(5000)
         targetValue: "5000"
       loadBalancerMetadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.fullname" . }}-keda-otel-scaler.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         # Query by queue utilization - scale up if any queue is 70% full
         query: >-
           max((otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"} / otelcol_exporter_queue_capacity{exporter=~"loadbalancing/collector-loadbalancer.*"}) * 100) > 20
@@ -1056,7 +1056,7 @@ kedaScaler:
             - name != "haproxy_server_http_responses_total" and name != "http.server.duration" and name != "otelcol_exporter_queue_size" and name != "otelcol_exporter_queue_capacity" and name != "http.server.request.duration"
     exporters:
       otlp/keda:
-        endpoint: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}
+        endpoint: '{{ include "sawmills-collector.fullname" . }}-keda-otel-scaler.{{ .Release.Namespace }}.svc.cluster.local:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}'
         compression: "none"
         tls:
           insecure: true


### PR DESCRIPTION
## Summary
- `values.yaml` hardcoded the keda-otel-scaler endpoint as `...sawmills.svc.cluster.local:...`, so any release deployed to a namespace other than `sawmills` silently lost its KEDA external scaler signal and the HPA fell back to CPU-only scaling. Bug was latent since the chart init commit and went live when `kedaScaler.enabled` was first flipped to `true` on a non-`sawmills` namespace release (e.g. prod's `sawmills-o11y`, 2026-04-08).
- Replace the three hardcoded FQDNs with an expression that renders the same name/namespace the scaler Service is actually created with: `{{ include "sawmills-collector.fullname" . }}-keda-otel-scaler.{{ .Release.Namespace }}.svc.cluster.local:...`.
- Thread the value through `tpl` in the consuming templates (`keda-hpa.yaml`, `telemetry-keda-configmap.yaml`) so the templated strings resolve at install/upgrade time.
- Add regression tests that render under an arbitrary release/namespace and assert the endpoints contain the release namespace and do **not** contain the old literal default.

## Why
Pinned at HPA ceiling (120/120) with CPU at 130% on staging; `KEDAScalerFailed: got empty metric spec` events plus `otlp/keda` exporter retry storms (`"rpc error: Unavailable, no children to pick from"`). DNS lookup of the hardcoded FQDN resolved into the wrong (or non-existent) namespace, so every collector pod was pushing to a void and KEDA had no external metric to act on.

## Rendered output for the actual prod release (before/after)
- before: `sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418` ❌
- after:  `sawmills-collector-keda-otel-scaler.sawmills-o11y.svc.cluster.local:4418` ✅

## Test plan
- [x] `helm unittest .` — all 117 tests pass, including new coverage in `tests/telemetry_keda_overlay_test.yaml` and new `tests/keda_scaler_address_test.yaml`.
- [x] `helm lint --strict .` — clean.
- [x] `helm template` for release `sawmills-collector` in namespace `sawmills-o11y` — all keda/scaler/endpoint references resolve to `.sawmills-o11y.svc.cluster.local`.
- [ ] Bump chart version and release; verify in staging that `KEDAScalerFailed` events stop and HPA settles below its `maxReplicas`.

## Follow-ups (not in this PR)
- **Hot-patch the cluster now** — the live `sawmills-collector-telemetry-keda-config` ConfigMap and the two `ScaledObject`s still hold the wrong address; patch them directly, or bump chart release to pull this fix.
- Separate bug in `sawmills-collector-otel-scaler-config`: its self-telemetry `otlp` exporter points at `${MY_POD_IP}:19876` (OTEL_PROMETHEUS_PORT) but no OTLP receiver is bound to that port in `service.pipelines` — should either expose Prometheus on that port as the port name suggests, or add an OTLP receiver.
- Consider rolling back collector image `1.830.0 → 1.828.0` or lowering `s3tablesexporter.MaxCommitRetries` back from `20 → 5` (SAW-7101, d65e12f0) — that knob change is what pushed CPU above 80% in the first place, which is what made the broken KEDA signal a user-visible incident rather than a silent misconfiguration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix KEDA scaler endpoints to use the Helm release namespace, so non-`sawmills` deployments keep external metrics and don’t fall back to CPU-only HPA scaling. Replaces hardcoded FQDNs with templates that match the scaler Service name and namespace.

- **Bug Fixes**
  - Template `scalerAddress` and OTLP endpoint in `values.yaml` to `{{ include "sawmills-collector.fullname" . }}-keda-otel-scaler.{{ .Release.Namespace }}...`.
  - Render these values via `tpl` in `keda-hpa.yaml` and `telemetry-keda-configmap.yaml`.
  - Add tests to assert endpoints use `.Release.Namespace` and never the old `.sawmills` FQDN.

<sup>Written for commit 795abc6bcb2cffa55de86a18a916f00fadbcd9a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KEDA metadata configuration now supports dynamic templating for flexible setup
  * Scaler service addresses are now dynamically configured based on release namespace instead of hardcoded values

* **Tests**
  * Added test coverage for KEDA scaler address resolution across different namespace and load balancer configurations
  * Added validation tests for telemetry KEDA configuration rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->