### PR TITLE
feat(haproxy): forward DD distribution_points and sketches directly to Datadog

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -156,18 +156,20 @@ frontend logs_http_frontend_{{ $config.from }}
   {{ if .timeout.client }}timeout client {{ .timeout.client }}{{- end }}
   {{- end }}
   {{- end }}
-  {{- if $siblingEnabled }}
-  # Sibling fallback: detect forwarded requests to prevent routing loops (max 1 hop)
-  acl is_sibling_hop hdr(X-Sibling-Hop) -m found
-  use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
-  {{- end }}
   {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
+  # Placed before sibling-hop check so distribution_points/sketches are always proxied,
+  # even on sibling-retried requests that would otherwise 405 on the direct backend.
   acl is_distribution_points path_beg /api/v1/distribution_points
   acl is_sketches path_beg /api/v1/sketches
   acl is_beta_sketches path_beg /api/beta/sketches
   http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
   use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
+  {{- if $siblingEnabled }}
+  # Sibling fallback: detect forwarded requests to prevent routing loops (max 1 hop)
+  acl is_sibling_hop hdr(X-Sibling-Hop) -m found
+  use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
   default_backend logs_http_{{ $config.from }}
 
@@ -231,7 +233,7 @@ backend logs_http_{{ $config.from }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http
-  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt sni str({{ $to.metrics_proxy_endpoint }}) verifyhost {{ $to.metrics_proxy_endpoint }}
 {{- end }}
 
 {{- if $siblingEnabled }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -161,14 +161,12 @@ frontend logs_http_frontend_{{ $config.from }}
   acl is_sibling_hop hdr(X-Sibling-Hop) -m found
   use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
-  {{- if $to.metrics_proxy_endpoint }}
+  {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
   acl is_distribution_points path_beg /api/v1/distribution_points
   acl is_sketches path_beg /api/v1/sketches
   acl is_beta_sketches path_beg /api/beta/sketches
-  {{- if $to.metrics_proxy_api_key }}
   http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
-  {{- end }}
   use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
   {{- end }}
   default_backend logs_http_{{ $config.from }}
@@ -229,11 +227,11 @@ backend logs_http_{{ $config.from }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
 
-{{- if $to.metrics_proxy_endpoint }}
+{{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http
-  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify none
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 {{- end }}
 
 {{- if $siblingEnabled }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -156,7 +156,10 @@ frontend logs_http_frontend_{{ $config.from }}
   {{ if .timeout.client }}timeout client {{ .timeout.client }}{{- end }}
   {{- end }}
   {{- end }}
-  {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
+  {{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
+  {{- if not $to.metrics_proxy_api_key }}
+  {{- fail (printf "metrics_proxy_api_key is required when metrics_proxy_endpoint is set (port mapping %s)" $name) }}
+  {{- end }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
   # Placed before sibling-hop check so distribution_points/sketches are always proxied,
   # even on sibling-retried requests that would otherwise 405 on the direct backend.
@@ -229,7 +232,7 @@ backend logs_http_{{ $config.from }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
 
-{{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
+{{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -161,6 +161,16 @@ frontend logs_http_frontend_{{ $config.from }}
   acl is_sibling_hop hdr(X-Sibling-Hop) -m found
   use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
+  {{- if $to.metrics_proxy_endpoint }}
+  # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
+  acl is_distribution_points path_beg /api/v1/distribution_points
+  acl is_sketches path_beg /api/v1/sketches
+  acl is_beta_sketches path_beg /api/beta/sketches
+  {{- if $to.metrics_proxy_api_key }}
+  http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
+  use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
   default_backend logs_http_{{ $config.from }}
 
 backend logs_http_{{ $config.from }}
@@ -218,6 +228,13 @@ backend logs_http_{{ $config.from }}
   {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
+
+{{- if $to.metrics_proxy_endpoint }}
+# Datadog metrics direct backend: forwards distribution_points/sketches to DD API
+backend datadog_metrics_direct_{{ $config.from }}
+  mode http
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify none
+{{- end }}
 
 {{- if $siblingEnabled }}
 # Direct backend for sibling-forwarded requests (no sibling tier to prevent loops)


### PR DESCRIPTION
## Summary
- Add path-based ACL routing in HAProxy to proxy `/api/v1/distribution_points`, `/api/v1/sketches`, and `/api/beta/sketches` directly to Datadog's API
- Inject `DD-API-KEY` header from collector-service-provided config
- Non-matching paths continue to the collector as before

## Problem
The collector's Datadog receiver returns 405 for `/api/v1/distribution_points` (not implemented). Customers like BigID use distribution metrics (~2,313 timeseries) that silently fail. SAW-7169.

## How it works
When `metrics_proxy_endpoint` and `metrics_proxy_api_key` are set on a port mapping:
```haproxy
acl is_distribution_points path_beg /api/v1/distribution_points
acl is_sketches path_beg /api/v1/sketches
acl is_beta_sketches path_beg /api/beta/sketches
http-request set-header DD-API-KEY <key> if is_distribution_points or is_sketches or is_beta_sketches
use_backend datadog_metrics_direct_<port> if is_distribution_points or is_sketches or is_beta_sketches

backend datadog_metrics_direct_<port>
  server datadog <endpoint>:443 ssl verify none
```

## Companion PRs
- collectors-service: injects `metrics_proxy_endpoint` and `metrics_proxy_api_key` from DD destination config

## Test plan
- [x] `helm template` renders correctly with proxy fields set
- [x] `helm template` renders without proxy section when fields not set (backward compatible)
- [x] E2E: Docker HAProxy + echo server confirms 202 on distribution_points with correct DD-API-KEY header
- [x] Non-proxied paths (/api/v2/series) still route to collector backend (503 in test = expected, no collector running)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datadog metrics proxy support with automatic routing for metrics endpoints, improving delivery reliability.
  * Optional API key injection for outgoing metrics requests to simplify authentication.
  * Direct HTTPS connectivity to configured Datadog endpoints with explicit certificate verification for secure transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward unsupported Datadog metrics endpoints from HAProxy directly to Datadog and inject the API key to prevent 405s and deliver distribution/sketch metrics (SAW-7169). Non-matching paths still go to the collector; misconfig (endpoint without key) now fails at Helm render.

- **New Features**
  - Routes `distribution_points` and `sketches` paths to `datadog_metrics_direct_<port>` when `metrics_proxy_endpoint` and `metrics_proxy_api_key` are set and mode != TCP; ACLs run before the sibling-hop check.
  - Injects `DD-API-KEY` from `metrics_proxy_api_key` for these paths.
  - Secures backend with HTTPS: `ssl verify required`, system CA (`/etc/ssl/certs/ca-certificates.crt`), SNI, and `verifyhost`.
  - Helm template is backward compatible; proxy is omitted when values are unset.

- **Bug Fixes**
  - Fail-fast at Helm render if `metrics_proxy_endpoint` is set without `metrics_proxy_api_key`.

<sup>Written for commit 20d73ac66e2aeadeea0cf78a2938f5657492bd53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

