### PR TITLE
refactor(haproxy): remove DD-API-KEY injection from metrics proxy (SAW-7169)

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -156,18 +156,20 @@ frontend logs_http_frontend_{{ $config.from }}
   {{ if .timeout.client }}timeout client {{ .timeout.client }}{{- end }}
   {{- end }}
   {{- end }}
-  {{- if $siblingEnabled }}
-  # Sibling fallback: detect forwarded requests to prevent routing loops (max 1 hop)
-  acl is_sibling_hop hdr(X-Sibling-Hop) -m found
-  use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
-  {{- end }}
   {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
+  # Placed before sibling-hop check so distribution_points/sketches are always proxied,
+  # even on sibling-retried requests that would otherwise 405 on the direct backend.
   acl is_distribution_points path_beg /api/v1/distribution_points
   acl is_sketches path_beg /api/v1/sketches
   acl is_beta_sketches path_beg /api/beta/sketches
   http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
   use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
+  {{- if $siblingEnabled }}
+  # Sibling fallback: detect forwarded requests to prevent routing loops (max 1 hop)
+  acl is_sibling_hop hdr(X-Sibling-Hop) -m found
+  use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
   default_backend logs_http_{{ $config.from }}
 
@@ -231,7 +233,7 @@ backend logs_http_{{ $config.from }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http
-  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt sni str({{ $to.metrics_proxy_endpoint }}) verifyhost {{ $to.metrics_proxy_endpoint }}
 {{- end }}
 
 {{- if $siblingEnabled }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -157,16 +157,13 @@ frontend logs_http_frontend_{{ $config.from }}
   {{- end }}
   {{- end }}
   {{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
-  {{- if not $to.metrics_proxy_api_key }}
-  {{- fail (printf "metrics_proxy_api_key is required when metrics_proxy_endpoint is set (port mapping %s)" $name) }}
-  {{- end }}
-  # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
+  # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog.
+  # The DD agent's own DD-API-KEY header passes through transparently (same as fallback).
   # Placed before sibling-hop check so distribution_points/sketches are always proxied,
   # even on sibling-retried requests that would otherwise 405 on the direct backend.
   acl is_distribution_points path_beg /api/v1/distribution_points
   acl is_sketches path_beg /api/v1/sketches
   acl is_beta_sketches path_beg /api/beta/sketches
-  http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
   use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
   {{- end }}
   {{- if $siblingEnabled }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -161,14 +161,12 @@ frontend logs_http_frontend_{{ $config.from }}
   acl is_sibling_hop hdr(X-Sibling-Hop) -m found
   use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
-  {{- if $to.metrics_proxy_endpoint }}
+  {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
   acl is_distribution_points path_beg /api/v1/distribution_points
   acl is_sketches path_beg /api/v1/sketches
   acl is_beta_sketches path_beg /api/beta/sketches
-  {{- if $to.metrics_proxy_api_key }}
   http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
-  {{- end }}
   use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
   {{- end }}
   default_backend logs_http_{{ $config.from }}
@@ -229,11 +227,11 @@ backend logs_http_{{ $config.from }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
 
-{{- if $to.metrics_proxy_endpoint }}
+{{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http
-  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify none
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt
 {{- end }}
 
 {{- if $siblingEnabled }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -156,7 +156,10 @@ frontend logs_http_frontend_{{ $config.from }}
   {{ if .timeout.client }}timeout client {{ .timeout.client }}{{- end }}
   {{- end }}
   {{- end }}
-  {{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
+  {{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
+  {{- if not $to.metrics_proxy_api_key }}
+  {{- fail (printf "metrics_proxy_api_key is required when metrics_proxy_endpoint is set (port mapping %s)" $name) }}
+  {{- end }}
   # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
   # Placed before sibling-hop check so distribution_points/sketches are always proxied,
   # even on sibling-retried requests that would otherwise 405 on the direct backend.
@@ -229,7 +232,7 @@ backend logs_http_{{ $config.from }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
 
-{{- if and $to.metrics_proxy_endpoint $to.metrics_proxy_api_key (ne $mode "tcp") }}
+{{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
 # Datadog metrics direct backend: forwards distribution_points/sketches to DD API
 backend datadog_metrics_direct_{{ $config.from }}
   mode http

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -161,6 +161,16 @@ frontend logs_http_frontend_{{ $config.from }}
   acl is_sibling_hop hdr(X-Sibling-Hop) -m found
   use_backend logs_http_{{ $config.from }}_direct if is_sibling_hop
   {{- end }}
+  {{- if $to.metrics_proxy_endpoint }}
+  # Metrics proxy: forward unsupported DD metrics endpoints directly to Datadog
+  acl is_distribution_points path_beg /api/v1/distribution_points
+  acl is_sketches path_beg /api/v1/sketches
+  acl is_beta_sketches path_beg /api/beta/sketches
+  {{- if $to.metrics_proxy_api_key }}
+  http-request set-header DD-API-KEY {{ $to.metrics_proxy_api_key }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
+  use_backend datadog_metrics_direct_{{ $config.from }} if is_distribution_points or is_sketches or is_beta_sketches
+  {{- end }}
   default_backend logs_http_{{ $config.from }}
 
 backend logs_http_{{ $config.from }}
@@ -218,6 +228,13 @@ backend logs_http_{{ $config.from }}
   {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
   {{- end }}
+
+{{- if $to.metrics_proxy_endpoint }}
+# Datadog metrics direct backend: forwards distribution_points/sketches to DD API
+backend datadog_metrics_direct_{{ $config.from }}
+  mode http
+  server datadog {{ $to.metrics_proxy_endpoint }}:443 ssl verify none
+{{- end }}
 
 {{- if $siblingEnabled }}
 # Direct backend for sibling-forwarded requests (no sibling tier to prevent loops)


### PR DESCRIPTION
## Summary
- Remove `DD-API-KEY` header injection and `metrics_proxy_api_key` validation from HAProxy metrics proxy config
- The DD agent already sends its own `DD-API-KEY` header — HAProxy forwards it transparently, same as fallback

## Changes
- Removed `http-request set-header DD-API-KEY` line for distribution_points/sketches/beta paths
- Removed `fail` validation for missing `metrics_proxy_api_key`
- ACL routing and backend unchanged — still forwards to `api.<site>:443` with SSL

## Companion PR
- Sawmills/collectors-service#783 removes `MetricsProxyAPIKey` field and injection logic

## Test plan
- [ ] E2E: deploy to staging, send distribution_points, verify 202 from Datadog without injected key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `DD-API-KEY` injection from the HAProxy metrics proxy and rely on the Datadog agent’s header while still forwarding unsupported metrics endpoints directly to Datadog. Aligns with SAW-7169 to send `/api/v1/distribution_points` (and related paths) straight to DD and avoid 405s.

- **Refactors**
  - Removed `http-request set-header DD-API-KEY` for `distribution_points`, `sketches`, and `beta/sketches`.
  - Removed `metrics_proxy_api_key` fail validation (no longer needed).
  - Kept ACL routing to `api.<site>:443` with TLS verification; ACLs stay before the sibling-hop check.

<sup>Written for commit d6d7871871219e57d130cd437d429857bb6b1dd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified HAProxy metrics proxy configuration by removing the requirement for explicit API key when metrics proxy is enabled.
  * Updated header handling to allow Datadog agent headers to pass through automatically, reducing manual configuration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->