### PR TITLE
fix(sawmills-collector): pin haproxy to numeric non-root user

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -232,6 +232,8 @@ haproxy:
     auth: "admin:admin"
 ```
 
+The HAProxy container is pinned to numeric UID/GID `99` with `runAsNonRoot` so clusters enforcing non-root pod security can verify the official HAProxy image user.
+
 #### Per-Port TLS Termination
 
 Enable TLS termination for specific HAProxy port mappings. When TLS is enabled on any port, the service switches to LoadBalancer type with AWS internal annotations.

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -203,6 +203,10 @@ Enable HAProxy for advanced load balancing:
 haproxy:
   enabled: true
   image: public.ecr.aws/docker/library/haproxy:3.1
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 99
+    runAsGroup: 99
   max_connections: 60000
   error_limit: 3
   probes:
@@ -232,7 +236,7 @@ haproxy:
     auth: "admin:admin"
 ```
 
-The HAProxy container is pinned to numeric UID/GID `99` with `runAsNonRoot` so clusters enforcing non-root pod security can verify the official HAProxy image user.
+The HAProxy container defaults to numeric UID/GID `99` with `runAsNonRoot` so clusters enforcing non-root pod security can verify the official HAProxy image user. Override `haproxy.securityContext` when using a custom HAProxy image that requires a different numeric user or additional container hardening fields.
 
 #### Per-Port TLS Termination
 

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -504,6 +504,8 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- $readinessType := (dig "probes" "readiness" "type" "http" $root.Values.haproxy) | toString | lower -}}
 {{- $readinessPort := dig "probes" "readiness" "port" 13135 $root.Values.haproxy -}}
 {{- $readinessPath := dig "probes" "readiness" "path" "/healthcheck" $root.Values.haproxy -}}
+{{- $defaultSecurityContext := dict "runAsNonRoot" true "runAsUser" 99 "runAsGroup" 99 -}}
+{{- $securityContext := mergeOverwrite (deepCopy $defaultSecurityContext) (default dict $root.Values.haproxy.securityContext) -}}
 {{- if not (or (eq $livenessType "http") (eq $livenessType "tcp")) -}}
 {{- fail (printf "haproxy.probes.liveness.type must be one of [http, tcp], got %q" $livenessType) -}}
 {{- end -}}
@@ -513,9 +515,7 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 - name: haproxy
   image: {{ $root.Values.haproxy.image }}
   securityContext:
-    runAsNonRoot: true
-    runAsUser: 99
-    runAsGroup: 99
+    {{- toYaml $securityContext | nindent 4 }}
   {{- if $nativeSidecar }}
   restartPolicy: Always
   {{- end }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -512,6 +512,10 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- end -}}
 - name: haproxy
   image: {{ $root.Values.haproxy.image }}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 99
+    runAsGroup: 99
   {{- if $nativeSidecar }}
   restartPolicy: Always
   {{- end }}

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -26,6 +26,62 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
 
+  - it: should pin haproxy to numeric non-root user in deployment mode
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.mapping.http_4318.from: 4318
+      haproxy.mapping.http_4318.to.port: 4318
+      haproxy.mapping.http_4318.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 99
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 99
+
+  - it: should allow overriding haproxy security context for custom images
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.mapping.http_4318.from: 4318
+      haproxy.mapping.http_4318.to.port: 4318
+      haproxy.mapping.http_4318.to.protocol: "TCP"
+      haproxy.securityContext.runAsUser: 1234
+      haproxy.securityContext.runAsGroup: 1234
+      haproxy.securityContext.allowPrivilegeEscalation: false
+      haproxy.securityContext.readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1234
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 1234
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
   - it: should render tcp probes for haproxy in deployment mode when configured
     template: deployment.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -101,6 +101,55 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
 
+  - it: should pin haproxy to numeric non-root user in load balancer mode
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 99
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 99
+
+  - it: should pin native sidecar haproxy to numeric non-root user in load balancer mode
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.nativeSidecar: "true"
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 99
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 99
+
   - it: should fail template rendering on invalid haproxy probe type
     template: deployment.yaml
     values:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -602,6 +602,10 @@ otelCollectorConfig: {}
 haproxy:
   enabled: false
   image: public.ecr.aws/docker/library/haproxy:3.1.15
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 99
+    runAsGroup: 99
   max_connections: 60000
   # Probe configuration for HAProxy sidecar container.
   # type: "http" (default) or "tcp"


### PR DESCRIPTION
sawmills-collector: Pin HAProxy to numeric non-root user

Fixes HAProxy startup on clusters that enforce non-root container execution and cannot verify the official HAProxy image named user.

- Add HAProxy securityContext with runAsNonRoot plus numeric UID/GID 99
- Cover regular LB container and native sidecar render paths with helm-unittest
- Document the HAProxy numeric UID/GID behavior

Verification:
- helm unittest helm-charts/sawmills-collector -f 'tests/haproxy_probe_config_test.yaml' --color
- helm lint helm-charts/sawmills-collector
- helm unittest helm-charts/sawmills-collector --color

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin HAProxy to numeric non-root UID/GID `99` by default and make the `securityContext` configurable to fix startup on clusters enforcing non-root while supporting custom images. Applies to both load balancer and native sidecar modes.

- **Bug Fixes**
  - Default HAProxy `securityContext` to `runAsNonRoot: true`, `runAsUser: 99`, `runAsGroup: 99`; allow overrides via `haproxy.securityContext`.
  - Add helm-unittest coverage for defaults and overrides across deployment, load balancer, and native sidecar render paths.
  - Update README with defaults and guidance on overriding for custom images or hardening.

<sup>Written for commit bd3f7497ebf7f7706e6f78f003ca82b5a3efdcbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HAProxy container security context documentation clarifying non-root execution requirements.

* **New Features**
  * HAProxy container now enforces non-root execution with pinned UID/GID (99) to support clusters with restrictive pod security policies.

* **Tests**
  * Added validation tests for HAProxy security context in both standard and native sidecar deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->