### PR TITLE
fix: use exec preStop for drain to prevent strategic merge conflicts (SAW-7258)

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -555,7 +555,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
     periodSeconds: {{ $root.Values.rollout.haproxy.probes.readiness.periodSeconds }}
   {{- if $nativeSidecar }}
   lifecycle:
-    $patch: replace
     preStop:
       exec:
         command:
@@ -564,7 +563,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
           - "kill -USR1 1 2>/dev/null || true"
   {{- else }}
   lifecycle:
-    $patch: replace
     preStop:
       exec:
         command:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -327,7 +327,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - "wget -q -O /dev/null http://localhost:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
+                  - "wget -q -O /dev/null http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
             preStop:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -327,7 +327,7 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - "curl -sf http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} || true; sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
+                  - "wget -q -O /dev/null http://localhost:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
             preStop:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -322,15 +322,14 @@ spec:
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:
-            $patch: replace
             preStop:
-              httpGet:
-                path: {{ .Values.rollout.main.drain.drainPath }}
-                port: {{ .Values.rollout.main.drain.port }}
-                scheme: HTTP
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "curl -sf http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} || true; sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
-            $patch: replace
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -192,7 +192,6 @@ spec:
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:
-            $patch: replace
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -46,7 +46,7 @@ tests:
           value: -c
       - matchRegex:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
-          pattern: "curl.*13137.*/drain.*sleep"
+          pattern: "wget.*13137.*/drain.*sleep"
 
 
   - it: should add backend drain overlay config for load balancer topology

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -39,14 +39,15 @@ tests:
           path: spec.template.spec.containers[1].startupProbe.httpGet.path
           value: /healthcheck
       - equal:
-          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.port
-          value: 13137
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[0]
+          value: /bin/sh
       - equal:
-          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.path
-          value: /drain
-      - equal:
-          path: spec.template.spec.containers[1].lifecycle.preStop.httpGet.scheme
-          value: HTTP
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
+          value: -c
+      - matchRegex:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
+          pattern: "curl.*13137.*/drain.*sleep"
+
 
   - it: should add backend drain overlay config for load balancer topology
     template: backend-drain-configmap.yaml


### PR DESCRIPTION
## Summary
- Changes drain preStop from `httpGet` to `exec` (curl-based) to prevent Kubernetes strategic merge patch conflicts during upgrades
- Removes ineffective `$patch: replace` directives from all lifecycle blocks
- Both old (sleep) and new (curl drain) preStop hooks use `exec` type — no handler type conflict

## Context
Customers upgrading from pre-drain chart versions (exec sleep preStop) to drain-enabled versions (httpGet preStop) hit:
```
spec.template.spec.containers[1].lifecycle.preStop.httpGet: Forbidden: may not specify more than 1 handler type
```
Helm's strategic merge patch merges old `exec` with new `httpGet` instead of replacing. Affected customers: Nexxen, Applied.

## Locally verified
| Scenario | Result |
|---|---|
| exec sleep → exec curl drain (normal) | ✅ |
| exec sleep → exec curl drain (`--reuse-values`) | ✅ |
| exec sleep → httpGet drain (`--reuse-values`) | ❌ (the old bug) |

Closes SAW-7258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collector graceful shutdown by switching the drain trigger to a command-based invocation and harmonizing preStop lifecycle behavior across deployment and load‑balancer manifests.
* **Tests**
  * Updated drain tests to match the new command-driven shutdown flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches drain preStop from httpGet to exec (wget + sleep) to avoid Kubernetes strategic merge conflicts during Helm upgrades and eliminate “may not specify more than 1 handler type” errors. The exec hook now targets the drain endpoint via the pod IP (`MY_POD_IP`) to fix Development pipeline deployments (SAW-7258).

- **Bug Fixes**
  - Removed ineffective `$patch: replace` from all lifecycle blocks.
  - Updated tests to assert exec-based drain using `wget` and verified upgrades from exec sleep → exec wget, including with `--reuse-values`.

<sup>Written for commit 98d0cff612e69d46012ecca448dd4d36eb0b6f1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

