### PR TITLE
fix: restore $patch:replace to prevent null patch error on upgrade (SAW-7258)

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -555,6 +555,7 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
     periodSeconds: {{ $root.Values.rollout.haproxy.probes.readiness.periodSeconds }}
   {{- if $nativeSidecar }}
   lifecycle:
+    $patch: replace
     preStop:
       exec:
         command:
@@ -563,6 +564,7 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
           - "kill -USR1 1 2>/dev/null || true"
   {{- else }}
   lifecycle:
+    $patch: replace
     preStop:
       exec:
         command:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -322,6 +322,7 @@ spec:
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:
+            $patch: replace
             preStop:
               exec:
                 command:
@@ -330,6 +331,7 @@ spec:
                   - "wget -q -O /dev/null http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
+            $patch: replace
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -192,6 +192,7 @@ spec:
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:
+            $patch: replace
             preStop:
               exec:
                 command:


### PR DESCRIPTION
## Summary
Removing `$patch:replace` from lifecycle blocks in PR #152 causes Helm's 3-way diff to generate `$patch: null` when upgrading from a chart that had it. Kubernetes rejects this with `unknown patch type: nil`.

Restores `$patch:replace` to all lifecycle blocks for backwards compatibility with charts that previously included it.

Closes SAW-7258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `$patch: replace` in all `lifecycle` blocks in the Helm chart to stop Helm upgrades from emitting `$patch: null`. This prevents the "unknown patch type: nil" error and unblocks Development pipeline deploys (SAW-7258).

- **Bug Fixes**
  - Re-added `$patch: replace` to `lifecycle` in `helm-charts/sawmills-collector/templates/_helpers.tpl`, `deployment.yaml`, and `load-balancer.yaml`.
  - Ensures backward compatibility when upgrading from charts that previously included `$patch: replace`.

<sup>Written for commit 150a38843aa7702afc2464a792cc2a7b19c39849. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

