### PR TITLE
fix(sawmills-collector): remove lifecycle patch fields

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -555,6 +555,9 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
     periodSeconds: {{ $root.Values.rollout.haproxy.probes.readiness.periodSeconds }}
   {{- if $nativeSidecar }}
   lifecycle:
+    {{- if $root.Release.IsUpgrade }}
+    $patch: replace
+    {{- end }}
     preStop:
       exec:
         command:
@@ -563,6 +566,9 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
           - "kill -USR1 1 2>/dev/null || true"
   {{- else }}
   lifecycle:
+    {{- if $root.Release.IsUpgrade }}
+    $patch: replace
+    {{- end }}
     preStop:
       exec:
         command:

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -555,7 +555,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
     periodSeconds: {{ $root.Values.rollout.haproxy.probes.readiness.periodSeconds }}
   {{- if $nativeSidecar }}
   lifecycle:
-    $patch: replace
     preStop:
       exec:
         command:
@@ -564,7 +563,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
           - "kill -USR1 1 2>/dev/null || true"
   {{- else }}
   lifecycle:
-    $patch: replace
     preStop:
       exec:
         command:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -322,7 +322,6 @@ spec:
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:
-            $patch: replace
             preStop:
               exec:
                 command:
@@ -331,7 +330,6 @@ spec:
                   - "wget -q -O /dev/null http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
-            $patch: replace
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -322,6 +322,9 @@ spec:
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:
+            {{- if .Release.IsUpgrade }}
+            $patch: replace
+            {{- end }}
             preStop:
               exec:
                 command:
@@ -330,6 +333,9 @@ spec:
                   - "wget -q -O /dev/null http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
+            {{- if .Release.IsUpgrade }}
+            $patch: replace
+            {{- end }}
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -192,6 +192,9 @@ spec:
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:
+            {{- if .Release.IsUpgrade }}
+            $patch: replace
+            {{- end }}
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -192,7 +192,6 @@ spec:
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:
-            $patch: replace
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -47,8 +47,10 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
           pattern: "wget.*13137.*/drain.*sleep"
-      - notExists:
-          path: spec.template.spec.containers[1].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
 
 
   - it: should add backend drain overlay config for load balancer topology
@@ -67,6 +69,21 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
+
+  - it: should keep lifecycle patch marker on upgrades for old release compatibility
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    release:
+      upgrade: true
+    set:
+      loadBalancer.enabled: true
+      rollout.main.drain.enabled: true
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
 
   - it: should keep existing main collector health wiring when load balancer topology is disabled
     template: deployment.yaml
@@ -87,8 +104,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
           value: "15"
-      - notExists:
-          path: spec.template.spec.containers[1].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
 
   - it: should fall back to sleep-based prestop when drain is disabled in load balancer topology
     template: deployment.yaml
@@ -110,8 +129,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
           value: "15"
-      - notExists:
-          path: spec.template.spec.containers[1].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
 
   - it: should still add the backend drain overlay when main collector config comes from s3
     template: deployment.yaml

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -47,6 +47,8 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
           pattern: "wget.*13137.*/drain.*sleep"
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle.$patch
 
 
   - it: should add backend drain overlay config for load balancer topology
@@ -85,6 +87,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
           value: "15"
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle.$patch
 
   - it: should fall back to sleep-based prestop when drain is disabled in load balancer topology
     template: deployment.yaml
@@ -106,6 +110,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[1]
           value: "15"
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle.$patch
 
   - it: should still add the backend drain overlay when main collector config comes from s3
     template: deployment.yaml

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -25,6 +25,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle.$patch
 
   - it: should pin haproxy to numeric non-root user in deployment mode
     template: deployment.yaml
@@ -156,6 +158,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle.$patch
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle.$patch
 
   - it: should pin haproxy to numeric non-root user in load balancer mode
     template: load-balancer.yaml
@@ -205,6 +211,8 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].securityContext.runAsGroup
           value: 99
+      - notExists:
+          path: spec.template.spec.initContainers[0].lifecycle.$patch
 
   - it: should fail template rendering on invalid haproxy probe type
     template: deployment.yaml

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -25,8 +25,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
-      - notExists:
-          path: spec.template.spec.containers[0].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.containers[0].lifecycle
+          content:
+            "$patch": replace
 
   - it: should pin haproxy to numeric non-root user in deployment mode
     template: deployment.yaml
@@ -50,6 +52,23 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
           value: 99
+
+  - it: should keep lifecycle patch marker in deployment upgrade mode
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    release:
+      upgrade: true
+    set:
+      haproxy.enabled: true
+      haproxy.mapping.http_4318.from: 4318
+      haproxy.mapping.http_4318.to.port: 4318
+      haproxy.mapping.http_4318.to.protocol: "TCP"
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].lifecycle
+          content:
+            "$patch": replace
 
   - it: should allow overriding haproxy security context for custom images
     template: deployment.yaml
@@ -158,10 +177,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
-      - notExists:
-          path: spec.template.spec.containers[0].lifecycle.$patch
-      - notExists:
-          path: spec.template.spec.containers[1].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.containers[0].lifecycle
+          content:
+            "$patch": replace
+      - isNotSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
 
   - it: should pin haproxy to numeric non-root user in load balancer mode
     template: load-balancer.yaml
@@ -187,6 +210,28 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
           value: 99
 
+  - it: should keep lifecycle patch markers in load balancer upgrade mode
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    release:
+      upgrade: true
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].lifecycle
+          content:
+            "$patch": replace
+      - isSubset:
+          path: spec.template.spec.containers[1].lifecycle
+          content:
+            "$patch": replace
+
   - it: should pin native sidecar haproxy to numeric non-root user in load balancer mode
     template: load-balancer.yaml
     values:
@@ -211,8 +256,29 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].securityContext.runAsGroup
           value: 99
-      - notExists:
-          path: spec.template.spec.initContainers[0].lifecycle.$patch
+      - isNotSubset:
+          path: spec.template.spec.initContainers[0].lifecycle
+          content:
+            "$patch": replace
+
+  - it: should keep lifecycle patch marker in native sidecar upgrade mode
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    release:
+      upgrade: true
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.nativeSidecar: "true"
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - isSubset:
+          path: spec.template.spec.initContainers[0].lifecycle
+          content:
+            "$patch": replace
 
   - it: should fail template rendering on invalid haproxy probe type
     template: deployment.yaml


### PR DESCRIPTION
sawmills-collector: fix lifecycle patch rendering for installs and upgrades

This fixes fresh installs of `sawmills-collector-chart` failing during `helm upgrade --install` with Kubernetes typed patch errors like `containers[name="main-collector"].lifecycle.$patch: field not declared in schema`, while keeping the upgrade compatibility behavior that motivated the previous change.

## What was the issue?

Chart `2.9.13` rendered literal `$patch: replace` keys under container `lifecycle` blocks for:

- the main collector Deployment
- the load balancer Deployment
- the HAProxy container helper

`$patch` is valid as Kubernetes strategic-merge patch metadata, but it is not a field in the Kubernetes `Container.lifecycle` schema. Helm install renders normal Kubernetes objects, so fresh installs with lifecycle hooks enabled produced invalid Deployments and failed before resources could be created.

## Why was it introduced?

The marker was reintroduced to protect upgrades from older releases whose Helm release history already contained `$patch: replace`. If a later chart removes that key during an upgrade, Helm can generate a patch deletion such as `"$patch": null`, which Kubernetes rejects as an unknown patch type. That solved one upgrade-path problem, but made clean installs render schema-invalid manifests.

## How is it fixed?

This PR gates `$patch: replace` on `.Release.IsUpgrade`:

- Fresh installs render normal Kubernetes lifecycle blocks with no `$patch` key.
- Helm upgrades still render `$patch: replace`, preserving compatibility for releases whose Helm history already includes the marker.
- The actual `preStop` commands and lifecycle behavior stay unchanged.

The tests now cover both sides of the contract:

- install-mode lifecycle blocks must not contain `$patch`
- upgrade-mode lifecycle blocks keep `$patch: replace` for compatibility

## Why this is not a breaking change

This does not change values, resource names, labels, selectors, ports, probes, lifecycle hook commands, or rollout behavior. It only changes when Helm emits strategic-merge patch metadata:

- install path: remove invalid metadata so Kubernetes accepts the object
- upgrade path: preserve metadata so old release-history upgrades do not regress

Because the runtime `preStop` behavior is unchanged and the compatibility marker remains on upgrades, this is a patch-level chart fix rather than a breaking behavior change.

## Testing

- [x] `cd helm-charts/sawmills-collector && ./tests/run-tests.sh`
- [x] `helm lint helm-charts/sawmills-collector`
- [x] install render with LB + HAProxy + drain config has no `$patch` fields
- [x] upgrade render with LB + HAProxy + drain config keeps `$patch: replace` fields
- [x] Pulled OCI `2.9.13` and confirmed it contains unconditional `$patch` fields
- [x] Pulled OCI `2.9.12` and confirmed it does not contain `$patch` fields

## Version Impact

- Label: `version:patch`

## Breaking Changes

- [x] No breaking changes

## Impact Assessment

- Who is affected: sawmills-collector chart installs/upgrades using lifecycle hooks.
- Systems affected: sawmills-collector Helm chart only.
- Rollback plan: revert this PR and republish the previous chart if needed.

## Documentation Updated

- [x] Not applicable (no documentation changes needed)

@sawmills/engineers Please review this contribution.