### PR TITLE
fix(sawmills-collector): stop rendering lifecycle patch markers

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -555,9 +555,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
     periodSeconds: {{ $root.Values.rollout.haproxy.probes.readiness.periodSeconds }}
   {{- if $nativeSidecar }}
   lifecycle:
-    {{- if $root.Release.IsUpgrade }}
-    $patch: replace
-    {{- end }}
     preStop:
       exec:
         command:
@@ -566,9 +563,6 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
           - "kill -USR1 1 2>/dev/null || true"
   {{- else }}
   lifecycle:
-    {{- if $root.Release.IsUpgrade }}
-    $patch: replace
-    {{- end }}
     preStop:
       exec:
         command:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -322,9 +322,6 @@ spec:
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:
-            {{- if .Release.IsUpgrade }}
-            $patch: replace
-            {{- end }}
             preStop:
               exec:
                 command:
@@ -333,9 +330,6 @@ spec:
                   - "wget -q -O /dev/null http://${MY_POD_IP}:{{ .Values.rollout.main.drain.port }}{{ .Values.rollout.main.drain.drainPath }} 2>/dev/null || true; /bin/sleep {{ .Values.rollout.main.preStopSleepSeconds }}"
           {{- else if .Values.rollout.main.preStopSleepSeconds }}
           lifecycle:
-            {{- if .Release.IsUpgrade }}
-            $patch: replace
-            {{- end }}
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -192,9 +192,6 @@ spec:
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:
-            {{- if .Release.IsUpgrade }}
-            $patch: replace
-            {{- end }}
             preStop:
               exec:
                 command:

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -70,7 +70,7 @@ tests:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
 
-  - it: should keep lifecycle patch marker on upgrades for old release compatibility
+  - it: should not render lifecycle patch marker on upgrades
     template: deployment.yaml
     values:
       - ../values.yaml
@@ -80,7 +80,7 @@ tests:
       loadBalancer.enabled: true
       rollout.main.drain.enabled: true
     asserts:
-      - isSubset:
+      - isNotSubset:
           path: spec.template.spec.containers[1].lifecycle
           content:
             "$patch": replace

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -113,6 +113,8 @@ tests:
     template: deployment.yaml
     values:
       - ../values.yaml
+    release:
+      upgrade: true
     set:
       loadBalancer.enabled: true
       rollout.main.drain.enabled: false

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -53,7 +53,7 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
           value: 99
 
-  - it: should keep lifecycle patch marker in deployment upgrade mode
+  - it: should not render lifecycle patch marker in deployment upgrade mode
     template: deployment.yaml
     values:
       - ../values.yaml
@@ -65,7 +65,7 @@ tests:
       haproxy.mapping.http_4318.to.port: 4318
       haproxy.mapping.http_4318.to.protocol: "TCP"
     asserts:
-      - isSubset:
+      - isNotSubset:
           path: spec.template.spec.containers[0].lifecycle
           content:
             "$patch": replace
@@ -210,7 +210,7 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
           value: 99
 
-  - it: should keep lifecycle patch markers in load balancer upgrade mode
+  - it: should not render lifecycle patch markers in load balancer upgrade mode
     template: load-balancer.yaml
     values:
       - ../values.yaml
@@ -223,11 +223,11 @@ tests:
       haproxy.mapping.logs_http_10000.to.port: 10518
       haproxy.mapping.logs_http_10000.to.protocol: "TCP"
     asserts:
-      - isSubset:
+      - isNotSubset:
           path: spec.template.spec.containers[0].lifecycle
           content:
             "$patch": replace
-      - isSubset:
+      - isNotSubset:
           path: spec.template.spec.containers[1].lifecycle
           content:
             "$patch": replace
@@ -261,7 +261,7 @@ tests:
           content:
             "$patch": replace
 
-  - it: should keep lifecycle patch marker in native sidecar upgrade mode
+  - it: should not render lifecycle patch marker in native sidecar upgrade mode
     template: load-balancer.yaml
     values:
       - ../values.yaml
@@ -275,7 +275,7 @@ tests:
       haproxy.mapping.logs_http_10000.to.port: 10518
       haproxy.mapping.logs_http_10000.to.protocol: "TCP"
     asserts:
-      - isSubset:
+      - isNotSubset:
           path: spec.template.spec.initContainers[0].lifecycle
           content:
             "$patch": replace


### PR DESCRIPTION
sawmills-collector: stop rendering lifecycle patch markers

Chart `2.9.14` still fails `helm upgrade --install` because Helm renders templates with upgrade semantics for that command. The `.Release.IsUpgrade` guard therefore still emits `$patch: replace`, and Helm 4 rejects it while constructing the typed Kubernetes patch object:

```text
.spec.template.spec.containers[name="main-collector"].lifecycle.$patch: field not declared in schema
```

## What changed

- Remove `$patch: replace` from all lifecycle blocks unconditionally.
- Keep the actual `preStop` lifecycle hooks unchanged.
- Update unit tests so both install-mode and upgrade-mode renders assert that lifecycle blocks do not include `$patch`.

## Why this is needed

`$patch` is strategic-merge metadata, not part of the Deployment schema. The earlier upgrade-only gate is not enough because `helm upgrade --install` sets `.Release.IsUpgrade`, including for the manual-test path. With Helm 4 typed patch validation, any rendered `$patch` under `lifecycle` fails before the Deployment can be applied.

## Compatibility

This is not a runtime behavior change: values, pod shape, preStop commands, probes, selectors, services, and resource names stay the same. The only removed output is schema-invalid patch metadata.

## Testing

- [x] `cd helm-charts/sawmills-collector && ./tests/run-tests.sh`
- [x] `helm lint helm-charts/sawmills-collector`
- [x] install render with LB + HAProxy + drain config has no `$patch` fields
- [x] upgrade render with LB + HAProxy + drain config has no `$patch` fields
- [x] confirmed published `2.9.14` still emits `$patch` with `helm template --is-upgrade`

## Version Impact

- Label: `version:patch`

## Breaking Changes

- [x] No breaking changes

## Documentation Updated

- [x] Not applicable

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Simplified container lifecycle hook behavior to apply uniformly across deployment scenarios, eliminating conditional patch directives that were previously applied only during Helm upgrades. This ensures consistent preStop hook execution in all contexts.

* **Chores**
  * Updated related test assertions to verify consistent lifecycle behavior without upgrade-specific patch markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop rendering `$patch` markers in `lifecycle` blocks for the `sawmills-collector` Helm chart to prevent Helm 4 typed patch validation errors during upgrade and upgrade --install. PreStop hooks are unchanged; rendered manifests now conform to the Deployment schema.

- **Bug Fixes**
  - Removed `$patch: replace` from all `lifecycle` blocks.
  - Expanded tests to assert no `$patch` in install and upgrade renders, including fallback paths (e.g., drain disabled), load balancer, and native sidecar modes.
  - No runtime changes; only removes invalid patch metadata.

<sup>Written for commit fafb88df097777e79ec112d41b9e1b7d3c15089f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

