### PR TITLE
sawmills-collector: Fix LB queue KEDA scaling

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.12
+version: 2.6.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -180,12 +180,16 @@ keda:
   pollingInterval: 30
   cooldownPeriod: 0
   annotations: {}
-  # For migrating an existing HPA to KEDA without admission conflicts:
+  # For non-Helm-owned HPA ownership transfer:
   # annotations:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   # advanced:
   #   horizontalPodAutoscalerConfig:
   #     name: <existing-hpa-name>
+  #
+  # For Helm-managed HPAs from this chart, use a two-step migration:
+  # 1. Upgrade with autoscaling.enabled=false and keda.enabled=false to prune the standard HPA.
+  # 2. Upgrade with keda.enabled=true after the standard HPA has been removed.
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -179,6 +179,13 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  annotations: {}
+  # For migrating an existing HPA to KEDA without admission conflicts:
+  # annotations:
+  #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  # advanced:
+  #   horizontalPodAutoscalerConfig:
+  #     name: sawmills-collector
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -185,7 +185,7 @@ keda:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   # advanced:
   #   horizontalPodAutoscalerConfig:
-  #     name: sawmills-collector
+  #     name: <existing-hpa-name>
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -193,6 +193,22 @@ keda:
         serverAddress: http://prometheus:9090
         query: sum(rate(http_requests_total[2m]))
         threshold: "100.50"
+    external:
+      enabled: false
+      metricType: Value
+      loadBalancerMetricType: AverageValue
+      metadata:
+        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        query: >-
+          quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 > 6000
+          or quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 < 3500
+          or vector(5000)
+        targetValue: "5000"
+      loadBalancerMetadata:
+        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        # targetValue is queued LB batches per desired collector pod.
+        query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+        targetValue: "300"
 ```
 
 ### HAProxy Load Balancing

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,4 +1,7 @@
 {{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+{{- $telemetryOtelConfig := default (dict) .Values.telemetryOtelConfig }}
+{{- $telemetryOtelS3Path := default "" $telemetryOtelConfig.s3path }}
+{{- $telemetryOtelEncryptionKey := default "" $telemetryOtelConfig.encryptionKey }}
 {{- if $mainCollectorDrainEnabled }}
 {{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.duration | atoi }}
 {{- $shutdownReserveMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.shutdownReserve | atoi }}
@@ -147,10 +150,10 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.telemetryOtelConfig.s3path .Values.kedaScaler.enabled }}
+          {{- if or $telemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:
-            {{- if .Values.telemetryOtelConfig.s3path }}
-            - "--config={{ .Values.telemetryOtelConfig.s3path }}{{- if .Values.telemetryOtelConfig.encryptionKey }}@{{ .Values.telemetryOtelConfig.encryptionKey }}{{- end }}"
+            {{- if $telemetryOtelS3Path }}
+            - "--config={{ $telemetryOtelS3Path }}{{- if $telemetryOtelEncryptionKey }}@{{ $telemetryOtelEncryptionKey }}{{- end }}"
             {{- else }}
             - "--config=file:/etc/otel/config.yaml"
             {{- end }}

--- a/helm-charts/sawmills-collector/templates/hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.autoscaling (eq .Values.autoscaling.enabled true) }}
+{{- if and .Values.autoscaling (eq .Values.autoscaling.enabled true) (not (and .Values.keda (eq .Values.keda.enabled true))) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/revision: {{ .Release.Revision | quote }}
+    {{- with .Values.keda.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
@@ -22,9 +25,12 @@ spec:
   advanced:
     {{- with .horizontalPodAutoscalerConfig }}
     horizontalPodAutoscalerConfig:
+      {{- with .name }}
+      name: {{ . | quote }}
+      {{- end }}
       {{- with .behavior }}
       behavior:
-        {{ toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -39,7 +39,11 @@ spec:
     {{- end }}
     {{- if .Values.keda.scaling.external.enabled }}
     - type: external
+      {{- if .Values.loadBalancer.enabled }}
+      metricType: {{ .Values.keda.scaling.external.loadBalancerMetricType | default .Values.keda.scaling.external.metricType }}
+      {{- else }}
       metricType: {{ .Values.keda.scaling.external.metricType }}
+      {{- end }}
       metadata:
         {{- if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.loadBalancer.enabled }}
 {{- include "sawmills-collector.validateLoadBalancerQueueCompression" . }}
+{{- $lbTelemetryOtelConfig := default (dict) .Values.loadBalancer.telemetryOtelConfig }}
+{{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
+{{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
 apiVersion: apps/v1
 {{- if .Values.loadBalancer.storage.enabled }}
 kind: StatefulSet
@@ -233,10 +236,10 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.loadBalancer.telemetryOtelConfig.s3path .Values.kedaScaler.enabled }}
+          {{- if or $lbTelemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:
-            {{- if .Values.loadBalancer.telemetryOtelConfig.s3path }}
-            - "--config={{ .Values.loadBalancer.telemetryOtelConfig.s3path }}{{- if .Values.loadBalancer.telemetryOtelConfig.encryptionKey }}@{{ .Values.loadBalancer.telemetryOtelConfig.encryptionKey }}{{- end }}"
+            {{- if $lbTelemetryOtelS3Path }}
+            - "--config={{ $lbTelemetryOtelS3Path }}{{- if $lbTelemetryOtelEncryptionKey }}@{{ $lbTelemetryOtelEncryptionKey }}{{- end }}"
             {{- else }}
             - "--config=file:/etc/otel/config.yaml"
             {{- end }}

--- a/helm-charts/sawmills-collector/tests/hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/hpa_test.yaml
@@ -1,0 +1,30 @@
+suite: Main HPA Tests
+templates:
+  - templates/hpa.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders the standard HPA when autoscaling is enabled and KEDA is disabled
+    set:
+      autoscaling:
+        enabled: true
+      keda:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME
+
+  - it: does not render the standard HPA when KEDA is enabled
+    set:
+      autoscaling:
+        enabled: true
+      keda:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -82,6 +82,33 @@ tests:
           path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].periodSeconds
           value: 60
 
+  - it: renders KEDA HPA ownership transfer settings
+    set:
+      loadBalancer:
+        enabled: true
+      keda:
+        enabled: true
+        annotations:
+          scaledobject.keda.sh/transfer-hpa-ownership: "true"
+        advanced:
+          horizontalPodAutoscalerConfig:
+            name: sawmills-collector
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["scaledobject.keda.sh/transfer-hpa-ownership"]
+          value: "true"
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.name
+          value: sawmills-collector
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+
   - it: keeps non-LB external latency scaler on Value
     set:
       loadBalancer:

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -1,0 +1,108 @@
+suite: KEDA HPA Tests
+templates:
+  - templates/keda-hpa.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders LB external queue scaler with AverageValue
+    set:
+      loadBalancer:
+        enabled: true
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.triggers[0].type
+          value: external
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "300"
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.selectPolicy
+          value: Max
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].value
+          value: 100
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].value
+          value: 20
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.selectPolicy
+          value: Min
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].value
+          value: 10
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].value
+          value: 5
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].periodSeconds
+          value: 60
+
+  - it: keeps non-LB external latency scaler on Value
+    set:
+      loadBalancer:
+        enabled: false
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.triggers[0].type
+          value: external
+      - equal:
+          path: spec.triggers[0].metricType
+          value: Value
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: vector\(5000\)
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "5000"

--- a/helm-charts/sawmills-collector/tests/legacy_values_upgrade_test.yaml
+++ b/helm-charts/sawmills-collector/tests/legacy_values_upgrade_test.yaml
@@ -1,0 +1,21 @@
+suite: Legacy Values Upgrade Compatibility
+templates:
+  - templates/deployment.yaml
+  - templates/load-balancer.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders when reused release values omit telemetryOtelConfig blocks
+    set:
+      telemetryOtelConfig: null
+      loadBalancer:
+        enabled: true
+        telemetryOtelConfig: null
+        otelConfig:
+          s3path: s3://example/config
+          encryptionKey: test-key
+      kedaScaler:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -347,17 +347,25 @@ keda:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:
+          stabilizationWindowSeconds: 300
+          selectPolicy: Min
           policies:
-            - periodSeconds: 300
-              type: Pods
-              value: 1
-          stabilizationWindowSeconds: 0
-        scaleUp:
-          policies:
-            - periodSeconds: 600
-              type: Pods
+            - type: Percent
               value: 10
+              periodSeconds: 60
+            - type: Pods
+              value: 5
+              periodSeconds: 60
+        scaleUp:
           stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+            - type: Pods
+              value: 20
+              periodSeconds: 60
   scaling:
     prometheus:
       enabled: false
@@ -370,6 +378,7 @@ keda:
     external:
       enabled: false
       metricType: Value
+      loadBalancerMetricType: AverageValue
       metadata:
         scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
         # Query by 99p latency of the 90p slowest pod
@@ -380,12 +389,11 @@ keda:
         targetValue: "5000"
       loadBalancerMetadata:
         scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
-        # Query by queue utilization - scale up if any queue is 70% full
-        query: >-
-          max((otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"} / otelcol_exporter_queue_capacity{exporter=~"loadbalancing/collector-loadbalancer.*"}) * 100) > 20
-          or max((otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"} / otelcol_exporter_queue_capacity{exporter=~"loadbalancing/collector-loadbalancer.*"}) * 100) < 5
-          or vector(10)
-        targetValue: "10"
+        # Total queued LB batches. With loadBalancerMetricType AverageValue,
+        # targetValue is queued batches per desired collector pod.
+        # Tune as: per-pod LB batch drain rate * acceptable queue wait seconds.
+        query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+        targetValue: "300"
     cpu:
       enabled: true
       targetUtilization: 80

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -338,6 +338,10 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  # Optional annotations for the KEDA ScaledObject.
+  # For HPA -> KEDA migrations, set:
+  #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  annotations: {}
   # Advanced HPA configuration for KEDA (optional)
   # This block allows you to specify advanced HorizontalPodAutoscaler behavior,
   # such as custom scaleUp/scaleDown policies and stabilization windows.
@@ -345,6 +349,9 @@ keda:
   # Example:
   advanced:
     horizontalPodAutoscalerConfig:
+      # Set this to an existing HPA name when using
+      # scaledobject.keda.sh/transfer-hpa-ownership.
+      name: ""
       behavior:
         scaleDown:
           stabilizationWindowSeconds: 300

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -339,7 +339,7 @@ keda:
   pollingInterval: 30
   cooldownPeriod: 0
   # Optional annotations for the KEDA ScaledObject.
-  # For HPA -> KEDA migrations, set:
+  # For non-Helm-owned HPA -> KEDA ownership transfers, set:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   annotations: {}
   # Advanced HPA configuration for KEDA (optional)
@@ -349,7 +349,7 @@ keda:
   # Example:
   advanced:
     horizontalPodAutoscalerConfig:
-      # Set this to an existing HPA name when using
+      # Set this to an existing non-Helm-owned HPA name when using
       # scaledobject.keda.sh/transfer-hpa-ownership.
       name: ""
       behavior:


### PR DESCRIPTION
sawmills-collector: Fix LB queue KEDA scaling

Fixes the LB queue KEDA trigger so LB-tiered collectors scale on queued work instead of capacity-relative utilization dead zones.

## Summary

Fix SAW-7254 by making the main collector KEDA trigger use LB queue depth when `loadBalancer.enabled=true`, while preserving the non-LB external latency trigger behavior.

Linear: https://linear.app/sawmills/issue/SAW-7254/fix-keda-lb-queue-trigger-and-scale-up-velocity-in-collector-chart

## Changes Made

* [ ] Feature addition
* [x] Bug fix
* [x] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [x] Performance improvement

- Adds `keda.scaling.external.loadBalancerMetricType: AverageValue` so LB queue scaling can use per-pod HPA math without changing non-LB `metricType: Value`.
- Replaces the LB queue utilization/dead-zone query with total queued LB batches and `targetValue: "300"`, calibrated from anonymized last-week batch drain data for the affected LB-tiered deployment.
- Updates KEDA HPA behavior to scale up faster and scale down conservatively.
- Adds KEDA HPA migration support: ScaledObject annotations, explicit KEDA-managed HPA name rendering, and suppression of the standard main HPA when KEDA is enabled.
- Hardens reused release values where older installs omit `telemetryOtelConfig` blocks.
- Adds Helm unittest coverage for LB, non-LB, HPA suppression, HPA ownership transfer rendering, and legacy reused-values rendering.

## Version Impact

**Add one of these labels to this PR:**

* `version:patch` - Bug fixes, small improvements (2.1.0 -> 2.1.1)
* `version:minor` - New features, backwards compatible (2.1.0 -> 2.2.0)
* `version:major` - Breaking changes (2.1.0 -> 3.0.0)

Selected: `version:patch`

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [x] Dry run installation (`helm install --dry-run=server`)
* [x] Server-side upgrade dry-run (`helm upgrade --dry-run=server`)
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
helm template sawmills-collector helm-charts/sawmills-collector \
  --set keda.enabled=true \
  --set keda.scaling.external.enabled=true \
  --set loadBalancer.enabled=true \
  --show-only templates/keda-hpa.yaml

helm template sawmills-collector helm-charts/sawmills-collector \
  --set keda.enabled=true \
  --set keda.scaling.external.enabled=true \
  --set loadBalancer.enabled=false \
  --show-only templates/keda-hpa.yaml

helm lint helm-charts/sawmills-collector
helm unittest helm-charts/sawmills-collector -f 'tests/keda_hpa_test.yaml' -f 'tests/hpa_test.yaml' -f 'tests/legacy_values_upgrade_test.yaml'
cd helm-charts/sawmills-collector && ./tests/run-tests.sh
git diff --check

# Staging sawmills server-side dry-run with live release values and KEDA admission validation
kubie exec staging sawmills -- helm upgrade sawmills-collector helm-charts/sawmills-collector \
  --namespace sawmills \
  --dry-run=server \
  --debug \
  --reuse-values \
  --set keda.enabled=true \
  --set keda.scaling.external.enabled=true \
  --set-json 'keda.annotations={"scaledobject.keda.sh/transfer-hpa-ownership":"true"}' \
  --set keda.advanced.horizontalPodAutoscalerConfig.name=sawmills-collector

# Affected operator-managed tenant ScaledObject server-side dry-run via remote-operator
kubectl apply --dry-run=server -n sawmills -f <rendered-keda-scaledobject.yaml>

# Fresh install server-side dry-run with KEDA enabled
kubie exec staging sawmills -- helm install sawmills-collector-keda-smoke helm-charts/sawmills-collector \
  --namespace sawmills \
  --dry-run=server \
  --debug \
  --set fullnameOverride=sawmills-collector-keda-smoke \
  --set loadBalancer.enabled=true \
  --set keda.enabled=true \
  --set keda.scaling.external.enabled=true
```

**Test environments:**

* [x] Local development
* [x] Staging environment
* [x] Customer test environment

**Results:**

* Expected: LB KEDA renders `AverageValue`, queue sum query, and `targetValue: "300"`; non-LB external KEDA stays `Value` with the existing latency query; the chart does not render both the standard main HPA and the main KEDA ScaledObject at the same time.
* Actual: Rendered output matches expected; full chart unittest suite passed, 16 suites / 127 tests; staging server-side dry-run, affected tenant ScaledObject dry-run, and fresh install dry-run passed.

## Breaking Changes

* [x] No breaking changes
* [ ] Contains breaking changes (describe below)

**Breaking Change Details:**

* **What breaks:** Nothing expected.
* **Migration path:** Existing overrides still win; operator-managed tenants need override cleanup/remediation to pick up these defaults. For Helm-managed HPAs created by this chart, migrate in two releases: first set `autoscaling.enabled=false` with `keda.enabled=false` so Helm prunes the standard HPA, then enable KEDA. For non-Helm-owned HPA handoff, use `keda.annotations.scaledobject.keda.sh/transfer-hpa-ownership: "true"` and set `keda.advanced.horizontalPodAutoscalerConfig.name` to the existing HPA name.
* **Version compatibility:** Chart version bumped from `2.6.12` to `2.6.13`.

## Impact Assessment

* **Who is affected:** LB-tiered collector tenants that use chart KEDA defaults for the main collector deployment.
* **What systems are affected:** `sawmills-collector` KEDA `ScaledObject` for the main collector. LB pod autoscaling is not changed.
* **Rollback plan:** Revert this chart change or override `keda.scaling.external.loadBalancerMetricType`, `loadBalancerMetadata`, and `keda.advanced` values to the previous behavior.

## Documentation Updated

* [x] Chart README.md updated
* [x] Configuration examples added/updated
* [ ] CHANGELOG.md updated
* [x] Inline comments added for complex logic
* [ ] Not applicable (no documentation changes needed)

## Additional Notes

Remote-operator inspection of the affected LB-tiered deployment showed current live/operator-managed values still override KEDA with the old dead-zone query and slow HPA behavior. Follow-up rollout/remediation should remove or update those overrides so current operator-managed tenants inherit this fixed default.

***

## Checklist

* [x] I have read the [contribution guidelines](README.md#contributing)
* [x] I have tested my changes thoroughly
* [x] I have updated documentation as needed
* [x] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* [x] I have tagged @sawmills/engineers for review
* [x] I have provided clear commit messages

***

@sawmills/engineers Please review this contribution.
