### PR TITLE
fix(sawmills-collector): tolerate legacy reuse values

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -1,4 +1,5 @@
 {{- define "sawmills-collector.haproxy.config" -}}
+{{- $refusalFastFail := .Values.haproxy.refusal_fast_fail | default dict -}}
 
 global
 {{- with .Values.haproxy.global }}
@@ -175,7 +176,7 @@ frontend logs_http_frontend_{{ $config.from }}
 
 backend logs_http_{{ $config.from }}
   mode {{ if eq $mode "grpc" }}http{{ else }}{{ $mode }}{{ end }}
-  {{- if and $.Values.haproxy.refusal_fast_fail.enabled $siblingEnabled (ne $mode "tcp") }}
+  {{- if and ($refusalFastFail.enabled | default false) $siblingEnabled (ne $mode "tcp") }}
   retry-on 503
   {{- end }}
   {{- range $option := $config.backend_options }}
@@ -200,9 +201,9 @@ backend logs_http_{{ $config.from }}
   {{- $errorLimit := $.Values.haproxy.error_limit }}
   {{- $slowstart := "" }}
   {{- $externalFallbackEnabled := eq (include "sawmills-collector.externalFallbackEnabled" $) "true" }}
-  {{- if and $.Values.haproxy.refusal_fast_fail.enabled (ne $mode "tcp") }}
-  {{- $errorLimit = ($.Values.haproxy.refusal_fast_fail.error_limit | default 20) }}
-  {{- $slowstart = ($.Values.haproxy.refusal_fast_fail.slowstart | default "") }}
+  {{- if and ($refusalFastFail.enabled | default false) (ne $mode "tcp") }}
+  {{- $errorLimit = ($refusalFastFail.error_limit | default 20) }}
+  {{- $slowstart = ($refusalFastFail.slowstart | default "") }}
   {{- end }}
   {{- if $siblingEnabled }}
   # Tag request as sibling-forwarded before sending to sibling tier
@@ -263,9 +264,9 @@ backend logs_http_{{ $config.from }}_direct
   {{- $directErrorLimit := $.Values.haproxy.error_limit }}
   {{- $directSlowstart := "" }}
   {{- $externalFallbackEnabled := eq (include "sawmills-collector.externalFallbackEnabled" $) "true" }}
-  {{- if and $.Values.haproxy.refusal_fast_fail.enabled (ne $mode "tcp") }}
-  {{- $directErrorLimit = ($.Values.haproxy.refusal_fast_fail.error_limit | default 20) }}
-  {{- $directSlowstart = ($.Values.haproxy.refusal_fast_fail.slowstart | default "") }}
+  {{- if and ($refusalFastFail.enabled | default false) (ne $mode "tcp") }}
+  {{- $directErrorLimit = ($refusalFastFail.error_limit | default 20) }}
+  {{- $directSlowstart = ($refusalFastFail.slowstart | default "") }}
   {{- end }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port 13133 inter {{ $interval }} rise {{ $rise }} fall {{ $fall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $directErrorLimit }} on-error mark-down{{ if ne $directSlowstart "" }} slowstart {{ $directSlowstart }}{{ end }}
   {{- if $externalFallbackEnabled }}

--- a/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
@@ -1,9 +1,10 @@
-{{- if and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+{{- $mainDrain := .Values.rollout.main.drain | default dict }}
+{{- if and .Values.loadBalancer.enabled ($mainDrain.enabled | default false) }}
 {{- $serviceExtensions := list }}
 {{- if and (kindIs "map" .Values.otelCollectorConfig) (hasKey .Values.otelCollectorConfig "service") (kindIs "map" .Values.otelCollectorConfig.service) (hasKey .Values.otelCollectorConfig.service "extensions") }}
 {{- $serviceExtensions = deepCopy .Values.otelCollectorConfig.service.extensions }}
 {{- else }}
-{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") .Values.rollout.main.drain.serviceExtensions) }}
+{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") $mainDrain.serviceExtensions) }}
 {{- end }}
 {{- $filteredServiceExtensions := list }}
 {{- range $serviceExtensions }}
@@ -25,11 +26,11 @@ data:
   config.yaml: |
     extensions:
       backend_drain:
-        endpoint: ${env:MY_POD_IP}:{{ .Values.rollout.main.drain.port }}
-        readiness_path: {{ .Values.rollout.main.drain.readinessPath }}
-        drain_path: {{ .Values.rollout.main.drain.drainPath }}
-        health_check_endpoint: {{ .Values.rollout.main.drain.healthCheckEndpoint }}
-        drain_duration: {{ .Values.rollout.main.drain.duration }}
+        endpoint: ${env:MY_POD_IP}:{{ default 13137 $mainDrain.port }}
+        readiness_path: {{ default "/ready" $mainDrain.readinessPath }}
+        drain_path: {{ default "/drain" $mainDrain.drainPath }}
+        health_check_endpoint: {{ default "http://${env:MY_POD_IP}:13133/healthcheck" $mainDrain.healthCheckEndpoint }}
+        drain_duration: {{ default "15s" $mainDrain.duration }}
     service:
       extensions:
 {{- toYaml $filteredServiceExtensions | nindent 8 }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,13 +1,17 @@
-{{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+{{- $mainDrain := .Values.rollout.main.drain | default dict }}
+{{- $mainStartupProbe := .Values.rollout.main.probes.startup | default dict }}
+{{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled ($mainDrain.enabled | default false) }}
 {{- $telemetryOtelConfig := default (dict) .Values.telemetryOtelConfig }}
 {{- $telemetryOtelS3Path := default "" $telemetryOtelConfig.s3path }}
 {{- $telemetryOtelEncryptionKey := default "" $telemetryOtelConfig.encryptionKey }}
 {{- if $mainCollectorDrainEnabled }}
-{{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.duration | atoi }}
-{{- $shutdownReserveMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.shutdownReserve | atoi }}
+{{- $drainDuration := default "15s" $mainDrain.duration }}
+{{- $shutdownReserve := default "10s" $mainDrain.shutdownReserve }}
+{{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" $drainDuration | atoi }}
+{{- $shutdownReserveMs := include "sawmills-collector.durationToMilliseconds" $shutdownReserve | atoi }}
 {{- $terminationGracePeriodMs := mul (int .Values.rollout.terminationGracePeriodSeconds) 1000 }}
 {{- if ge (add $drainDurationMs $shutdownReserveMs) $terminationGracePeriodMs }}
-{{- fail (printf "rollout.main.drain.duration (%s) plus rollout.main.drain.shutdownReserve (%s) must be less than rollout.terminationGracePeriodSeconds (%ds)" .Values.rollout.main.drain.duration .Values.rollout.main.drain.shutdownReserve (int .Values.rollout.terminationGracePeriodSeconds)) }}
+{{- fail (printf "rollout.main.drain.duration (%s) plus rollout.main.drain.shutdownReserve (%s) must be less than rollout.terminationGracePeriodSeconds (%ds)" $drainDuration $shutdownReserve (int .Values.rollout.terminationGracePeriodSeconds)) }}
 {{- end }}
 {{- end }}
 {{- if eq .Values.mode "daemonSet" }}
@@ -314,14 +318,14 @@ spec:
               {{- end }}
             initialDelaySeconds: {{ .Values.rollout.main.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.rollout.main.probes.readiness.periodSeconds }}
-          {{- if .Values.rollout.main.probes.startup.enabled }}
+          {{- if ($mainStartupProbe.enabled | default false) }}
           startupProbe:
             httpGet:
               path: /healthcheck
               port: 13133
-            initialDelaySeconds: {{ default 0 .Values.rollout.main.probes.startup.initialDelaySeconds }}
-            periodSeconds: {{ .Values.rollout.main.probes.startup.periodSeconds }}
-            failureThreshold: {{ .Values.rollout.main.probes.startup.failureThreshold }}
+            initialDelaySeconds: {{ default 0 $mainStartupProbe.initialDelaySeconds }}
+            periodSeconds: {{ default 5 $mainStartupProbe.periodSeconds }}
+            failureThreshold: {{ default 12 $mainStartupProbe.failureThreshold }}
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -3,6 +3,7 @@
 {{- $lbTelemetryOtelConfig := default (dict) .Values.loadBalancer.telemetryOtelConfig }}
 {{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
 {{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
+{{- $lbStartupProbe := .Values.rollout.loadBalancer.probes.startup | default dict }}
 apiVersion: apps/v1
 {{- if .Values.loadBalancer.storage.enabled }}
 kind: StatefulSet
@@ -184,14 +185,14 @@ spec:
               {{- end }}
             initialDelaySeconds: {{ .Values.rollout.loadBalancer.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.rollout.loadBalancer.probes.readiness.periodSeconds }}
-          {{- if .Values.rollout.loadBalancer.probes.startup.enabled }}
+          {{- if ($lbStartupProbe.enabled | default false) }}
           startupProbe:
             httpGet:
               path: /healthcheck
               port: 13133
-            initialDelaySeconds: {{ default 0 .Values.rollout.loadBalancer.probes.startup.initialDelaySeconds }}
-            periodSeconds: {{ .Values.rollout.loadBalancer.probes.startup.periodSeconds }}
-            failureThreshold: {{ .Values.rollout.loadBalancer.probes.startup.failureThreshold }}
+            initialDelaySeconds: {{ default 0 $lbStartupProbe.initialDelaySeconds }}
+            periodSeconds: {{ default 5 $lbStartupProbe.periodSeconds }}
+            failureThreshold: {{ default 12 $lbStartupProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:

--- a/helm-charts/sawmills-collector/templates/poddisruptionbudget.yaml
+++ b/helm-charts/sawmills-collector/templates/poddisruptionbudget.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.podDisruptionBudget.enabled (eq .Values.mode "deployment") }}
+{{- $pdb := .Values.podDisruptionBudget | default dict }}
+{{- if and ($pdb.enabled | default false) (eq .Values.mode "deployment") }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,7 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "sawmills-collector.selectorLabels" . | nindent 6 }}
-  {{- $pdb := .Values.podDisruptionBudget }}
   {{- if and $pdb (hasKey $pdb "minAvailable") (not (kindIs "invalid" $pdb.minAvailable)) }}
   minAvailable: {{ $pdb.minAvailable }}
   {{- else if and $pdb (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" $pdb.maxUnavailable)) }}
@@ -20,7 +20,8 @@ spec:
   {{- end }}
 {{- end }}
 ---
-{{- if and .Values.loadBalancer.enabled .Values.loadBalancer.podDisruptionBudget.enabled }}
+{{- $lbPdb := .Values.loadBalancer.podDisruptionBudget | default dict }}
+{{- if and .Values.loadBalancer.enabled ($lbPdb.enabled | default false) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -32,7 +33,6 @@ spec:
   selector:
     matchLabels:
       {{- include "sawmills-collector.loadBalancerSelectorLabels" . | nindent 6 }}
-  {{- $lbPdb := .Values.loadBalancer.podDisruptionBudget }}
   {{- if and $lbPdb (hasKey $lbPdb "minAvailable") (not (kindIs "invalid" $lbPdb.minAvailable)) }}
   minAvailable: {{ $lbPdb.minAvailable }}
   {{- else if and $lbPdb (hasKey $lbPdb "maxUnavailable") (not (kindIs "invalid" $lbPdb.maxUnavailable)) }}

--- a/helm-charts/sawmills-collector/tests/legacy_reuse_values_compatibility_test.yaml
+++ b/helm-charts/sawmills-collector/tests/legacy_reuse_values_compatibility_test.yaml
@@ -1,0 +1,76 @@
+suite: Legacy Reuse Values Compatibility
+templates:
+  - templates/backend-drain-configmap.yaml
+  - templates/deployment.yaml
+  - templates/load-balancer.yaml
+  - templates/poddisruptionbudget.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders when reused release values omit top-level podDisruptionBudget
+    template: templates/poddisruptionbudget.yaml
+    set:
+      mode: deployment
+      podDisruptionBudget: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when reused release values omit loadBalancer podDisruptionBudget
+    template: templates/poddisruptionbudget.yaml
+    set:
+      mode: deployment
+      podDisruptionBudget:
+        enabled: false
+      loadBalancer:
+        enabled: true
+        podDisruptionBudget: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders main collector when reused release values omit main startup probe and drain blocks
+    template: templates/deployment.yaml
+    set:
+      loadBalancer:
+        enabled: false
+      rollout:
+        main:
+          probes:
+            startup: null
+          drain: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: renders load balancer when reused release values omit load balancer startup probe and main drain blocks
+    template: templates/load-balancer.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        telemetryOtelConfig: null
+      rollout:
+        main:
+          drain: null
+        loadBalancer:
+          probes:
+            startup: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: skips backend drain config when reused release values omit main drain block
+    template: templates/backend-drain-configmap.yaml
+    set:
+      loadBalancer:
+        enabled: true
+      rollout:
+        main:
+          drain: null
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -567,6 +567,22 @@ tests:
           path: data["haproxy.cfg"]
           pattern: "retry-on 503"
 
+  - it: should render when reused release values omit refusal_fast_fail
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.refusal_fast_fail: null
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318"
+
   - it: should NOT include slowstart by default
     template: haproxy-configmap.yaml
     set:


### PR DESCRIPTION
sawmills-collector: Tolerate legacy reuse values

Fixes Helm rendering for older collector releases upgraded with `--reuse-values`, where newly added nested value blocks may be absent from the stored release values.

Description:
- Defaults optional PDB, HAProxy refusal fast-fail, startup probe, and backend drain blocks before dereferencing them.
- Adds regression coverage for legacy reuse-values shapes missing those blocks.

Validation:
- `helm lint helm-charts/sawmills-collector`
- `./tests/run-tests.sh` from `helm-charts/sawmills-collector`
- Server-side dry-runed the published chart with equivalent compatibility shims across representative legacy releases; all eligible releases passed, aside from one pre-existing Helm pending-upgrade lock.

Refs: SAW-7254

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Helm rendering for upgrades using --reuse-values by defaulting missing nested values from older `sawmills-collector` releases. Prevents template errors and keeps rollouts safe when PDB, HAProxy fast-fail, startup probes, or backend drain blocks are absent.

- **Bug Fixes**
  - Default missing blocks: PDB, `haproxy.refusal_fast_fail`, startup probes (main/LB), and main drain.
  - Provide safe defaults for drain config (port, paths, duration) and startup probe timings.
  - Guard feature checks with `enabled` flags via `default` to avoid nil dereferences.
  - Add regression tests for legacy reuse-values shapes across PDB, drain, startup probes, and HAProxy.
  - Addresses SAW-7254.

<sup>Written for commit 2be18f69b41e321ac6828a2feb7ea1fe51b32533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Helm chart templates to gracefully handle missing or null configuration values with sensible defaults.
  * Enhanced default value handling across multiple templates to prevent rendering failures when optional configuration blocks are omitted.

* **Tests**
  * Added test coverage for legacy configuration scenarios where optional values are missing or explicitly null.
  * Added test coverage for fallback behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->