### PR TITLE
sawmills-collector: keep keda-scaler endpointed during chart rollouts

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.13
+version: 2.6.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
-  replicas: {{ default 2 .Values.kedaScaler.replicas }}
+  replicas: {{ default 1 .Values.kedaScaler.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -21,13 +21,18 @@ spec:
       {{- toYaml $selectorLabels | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/keda-scaler-config: {{ toYaml .Values.kedaScaler.config | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
-        {{- $podLabels := include "sawmills-collector.labels" . | fromYaml }}
+        {{- $podLabels := include "sawmills-collector.selectorLabels" . | fromYaml }}
         {{- $podResult := set $podLabels "app.kubernetes.io/name" $deploymentName }}
+        {{- if .Values.image.tag }}
+        {{- $versionResult := set $podLabels "app.kubernetes.io/version" .Values.image.tag }}
+        {{- end }}
+        {{- $managedByResult := set $podLabels "app.kubernetes.io/managed-by" .Release.Service }}
         {{- toYaml $podLabels | nindent 8 }}
     spec:
       serviceAccountName: {{ include "sawmills-collector.serviceAccountName" . }}

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.kedaScaler.enabled }}
 {{- $deploymentName := printf "%s-keda-otel-scaler" (include "sawmills-collector.fullname" .) }}
+{{- $kedaReplicas := int (default 1 .Values.kedaScaler.replicas) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,7 +9,7 @@ metadata:
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
-  replicas: {{ default 1 .Values.kedaScaler.replicas }}
+  replicas: {{ $kedaReplicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -104,9 +105,26 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if hasKey .Values.kedaScaler "affinity" }}
+      {{- with .Values.kedaScaler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
+      {{- $affinity := deepCopy (default (dict) .Values.affinity) }}
+      {{- $matchLabels := dict "app.kubernetes.io/instance" .Release.Name "app.kubernetes.io/name" $deploymentName }}
+      {{- if gt $kedaReplicas 1 }}
+      {{- $term := dict "labelSelector" (dict "matchLabels" $matchLabels) "topologyKey" "kubernetes.io/hostname" }}
+      {{- $_ := set $affinity "podAntiAffinity" (dict "requiredDuringSchedulingIgnoredDuringExecution" (list $term)) }}
+      {{- else }}
+      {{- $podAffinityTerm := dict "labelSelector" (dict "matchLabels" $matchLabels) "topologyKey" "kubernetes.io/hostname" }}
+      {{- $preferredTerm := dict "weight" 100 "podAffinityTerm" $podAffinityTerm }}
+      {{- $_ := set $affinity "podAntiAffinity" (dict "preferredDuringSchedulingIgnoredDuringExecution" (list $preferredTerm)) }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -8,7 +8,12 @@ metadata:
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ default 2 .Values.kedaScaler.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- $selectorLabels := include "sawmills-collector.selectorLabels" . | fromYaml }}

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -4,7 +4,7 @@ templates:
 values:
   - ../values.yaml
 tests:
-  - it: defaults to 2 replicas with maxUnavailable=0 to keep the service endpointed during chart rollouts
+  - it: defaults to 1 replica and uses maxUnavailable=0 during rolling updates
     set:
       kedaScaler:
         enabled: true
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.replicas
-          value: 2
+          value: 1
       - equal:
           path: spec.strategy.type
           value: RollingUpdate
@@ -25,6 +25,10 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxSurge
           value: 1
+      - exists:
+          path: spec.template.metadata.annotations["checksum/keda-scaler-config"]
+      - notExists:
+          path: spec.template.metadata.labels["helm.sh/chart"]
 
   - it: honors an explicit kedaScaler.replicas override
     set:

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -1,0 +1,45 @@
+suite: KEDA Scaler Deployment Tests
+templates:
+  - templates/keda-scaler-deployment.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: defaults to 2 replicas with maxUnavailable=0 to keep the service endpointed during chart rollouts
+    set:
+      kedaScaler:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+
+  - it: honors an explicit kedaScaler.replicas override
+    set:
+      kedaScaler:
+        enabled: true
+        replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: does not render when kedaScaler is disabled
+    set:
+      kedaScaler:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -29,6 +29,12 @@ tests:
           path: spec.template.metadata.annotations["checksum/keda-scaler-config"]
       - notExists:
           path: spec.template.metadata.labels["helm.sh/chart"]
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: RELEASE-NAME-keda-otel-scaler
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
 
   - it: honors an explicit kedaScaler.replicas override
     set:
@@ -39,6 +45,36 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: RELEASE-NAME-keda-otel-scaler
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
+          value: kubernetes.io/hostname
+
+  - it: allows kedaScaler.affinity to override generated anti-affinity
+    set:
+      kedaScaler:
+        enabled: true
+        replicas: 2
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: node-role
+                      operator: In
+                      values:
+                        - telemetry
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity.podAntiAffinity
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: telemetry
 
   - it: does not render when kedaScaler is disabled
     set:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1042,11 +1042,8 @@ kedaScaler:
   enabled: false
   imagePullPolicy: Always
   podSecurityContext: {}
-  # Number of keda-scaler replicas. Two replicas with maxUnavailable=0 keeps
-  # at least one endpoint behind the keda-otel-scaler Service during rolling
-  # chart upgrades, so collector telemetry pods never see a transient empty
-  # endpoint set during an upgrade.
-  replicas: 2
+  # Number of keda-scaler replicas.
+  replicas: 1
   probes:
     liveness:
       initialDelaySeconds: 5

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1042,6 +1042,11 @@ kedaScaler:
   enabled: false
   imagePullPolicy: Always
   podSecurityContext: {}
+  # Number of keda-scaler replicas. Two replicas with maxUnavailable=0 keeps
+  # at least one endpoint behind the keda-otel-scaler Service during rolling
+  # chart upgrades, so collector telemetry pods never see a transient empty
+  # endpoint set during an upgrade.
+  replicas: 2
   probes:
     liveness:
       initialDelaySeconds: 5

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1044,6 +1044,10 @@ kedaScaler:
   podSecurityContext: {}
   # Number of keda-scaler replicas.
   replicas: 1
+  # Optional keda-scaler-specific affinity override. When replicas > 1 and
+  # this is not set, the chart adds required hostname anti-affinity matching
+  # the rendered keda-scaler pod labels.
+  # affinity: {}
   probes:
     liveness:
       initialDelaySeconds: 5


### PR DESCRIPTION
## Summary

Avoid rolling the keda-scaler pod on unrelated chart version bumps.

The chart-level `helm.sh/chart` label includes `.Chart.Version` and was also included in the keda-scaler pod template labels. Any chart version bump changed the Deployment pod-template hash and restarted the single keda-scaler pod, which could create a transient availability gap while collector pods were also rolling.

This PR keeps `helm.sh/chart` on resource metadata, but removes it from the keda-scaler pod template labels. The pod template now uses stable labels plus `app.kubernetes.io/version`, and gets a `checksum/keda-scaler-config` annotation so actual keda-scaler config changes still trigger a rollout.

## Fix

- Keep `kedaScaler.replicas` configurable, defaulting to `1`
- Keep explicit `RollingUpdate` with `maxUnavailable: 0` and `maxSurge: 1`
- Remove the chart-version label from keda-scaler pod template labels
- Add a config checksum annotation to roll the pod when `kedaScaler.config` changes
- Add keda-scaler-specific anti-affinity matching the rendered keda-scaler pod labels:
  - preferred by hostname for `replicas: 1`, so single-node rollouts are not blocked
  - required by hostname for `replicas > 1`, so redundant scaler replicas cannot co-locate on one node unless explicitly overridden
- Allow `kedaScaler.affinity` to override the generated affinity
- Bump chart version `2.6.13` -> `2.6.14`

## Test plan

- [x] `helm template` renders keda-scaler with `replicas: 1`, stable pod labels, and `checksum/keda-scaler-config`
- [x] `helm template --set kedaScaler.replicas=2` renders required hostname anti-affinity matching `<release>-keda-otel-scaler`
- [x] `helm lint helm-charts/sawmills-collector`
- [x] `./tests/run-tests.sh` - full suite passes, 137/137
- [ ] Re-attempt the SAW-7254 chart upgrade on `staging-us-east-1`; confirm keda-scaler does not roll for chart-only version changes and the collector upgrade completes within the 10m budget

## Follow-up

`kedaScaler.replicas: 2` remains available as an override, but should be validated separately with real KEDA external metric reads before making it the default.
