### PR TITLE
fix(sawmills-collector): template keda scaler endpoint

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -209,14 +209,14 @@ keda:
       metricType: Value
       loadBalancerMetricType: AverageValue
       metadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         query: >-
           quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 > 6000
           or quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 < 3500
           or vector(5000)
         targetValue: "5000"
       loadBalancerMetadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         # targetValue is queued LB batches per desired collector pod.
         query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
         targetValue: "300"

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -436,6 +436,14 @@ Note: assumes default cluster domain (cluster.local).
 {{- end -}}
 
 {{/*
+Get the fully qualified KEDA external scaler service name.
+Returns "<fullname>-keda-otel-scaler.<namespace>.svc.cluster.local".
+*/}}
+{{- define "sawmills-collector.kedaScalerSvcFQDN" -}}
+{{- printf "%s-keda-otel-scaler.%s.svc.cluster.local" (include "sawmills-collector.fullname" .) .Release.Namespace -}}
+{{- end -}}
+
+{{/*
 Resolve whether to use native sidecar mode for HAProxy.
 Accepts .Values.haproxy.nativeSidecar: "false" | "true" | "auto"
 Returns "true" or "false" as a string.

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -436,11 +436,19 @@ Note: assumes default cluster domain (cluster.local).
 {{- end -}}
 
 {{/*
+Get the KEDA external scaler resource name.
+Returns "<fullname>-keda-otel-scaler", keeping the DNS label <= 63 chars.
+*/}}
+{{- define "sawmills-collector.kedaScalerName" -}}
+{{- printf "%s-keda-otel-scaler" (include "sawmills-collector.fullname" . | trunc 46 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Get the fully qualified KEDA external scaler service name.
-Returns "<fullname>-keda-otel-scaler.<namespace>.svc.cluster.local".
+Returns "<keda-scaler-name>.<namespace>.svc.cluster.local".
 */}}
 {{- define "sawmills-collector.kedaScalerSvcFQDN" -}}
-{{- printf "%s-keda-otel-scaler.%s.svc.cluster.local" (include "sawmills-collector.fullname" .) .Release.Namespace -}}
+{{- printf "%s.%s.svc.cluster.local" (include "sawmills-collector.kedaScalerName" .) .Release.Namespace -}}
 {{- end -}}
 
 {{/*

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -53,11 +53,19 @@ spec:
       metadata:
         {{- if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}
+        {{- if eq $key "scalerAddress" }}
+        {{ $key }}: {{ tpl (toString $value) $ | quote }}
+        {{- else }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
         {{- else}}
         {{- range $key, $value := .Values.keda.scaling.external.metadata }}
+        {{- if eq $key "scalerAddress" }}
+        {{ $key }}: {{ tpl (toString $value) $ | quote }}
+        {{- else }}
         {{ $key }}: {{ $value | quote }}
+        {{- end }}
         {{- end }}
         {{- end }}
     {{- end }}

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kedaScaler.enabled }}
-{{- $deploymentName := printf "%s-keda-otel-scaler" (include "sawmills-collector.fullname" .) }}
+{{- $deploymentName := include "sawmills-collector.kedaScalerName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-charts/sawmills-collector/templates/keda-scaler-service.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kedaScaler.enabled }}
-{{- $deploymentName := printf "%s-keda-otel-scaler" (include "sawmills-collector.fullname" .) }}
+{{- $deploymentName := include "sawmills-collector.kedaScalerName" . }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm-charts/sawmills-collector/templates/telemetry-keda-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/telemetry-keda-configmap.yaml
@@ -9,6 +9,14 @@ metadata:
 data:
   keda.yaml: |
     {{- with .Values.kedaScaler.telemetryConfig }}
-      {{- toYaml . | nindent 4 }}
+      {{- $config := deepCopy . }}
+      {{- with $config.exporters }}
+        {{- with (index . "otlp/keda") }}
+          {{- with .endpoint }}
+            {{- $_ := set (index $config.exporters "otlp/keda") "endpoint" (tpl (toString .) $) }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- toYaml $config | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -1,8 +1,10 @@
 suite: keda scaler address namespace templating
 templates:
   - templates/keda-hpa.yaml
+  - templates/keda-scaler-service.yaml
 tests:
   - it: resolves non-LB external scalerAddress from release namespace and configured port
+    template: templates/keda-hpa.yaml
     release:
       name: my-release
       namespace: any-ns
@@ -19,7 +21,34 @@ tests:
           path: spec.triggers[0].metadata.scalerAddress
           pattern: '\.sawmills\.svc\.cluster\.local'
 
+  - it: truncates long release names in scalerAddress to keep the service label valid
+    template: templates/keda-hpa.yaml
+    release:
+      name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      namespace: any-ns
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      kedaScaler.enabled: true
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-keda-otel-scaler.any-ns.svc.cluster.local:4418
+
+  - it: truncates long release names in the scaler service name
+    template: templates/keda-scaler-service.yaml
+    release:
+      name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      namespace: any-ns
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-keda-otel-scaler
+
   - it: resolves LB external scalerAddress without changing LB queue scaling contract
+    template: templates/keda-hpa.yaml
     release:
       name: sawmills-collector
       namespace: sawmills-o11y

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -1,0 +1,45 @@
+suite: keda scaler address namespace templating
+templates:
+  - templates/keda-hpa.yaml
+tests:
+  - it: resolves non-LB external scalerAddress from release namespace and configured port
+    release:
+      name: my-release
+      namespace: any-ns
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      loadBalancer.enabled: false
+      kedaScaler.service.kedaExternalScalerPort: 9444
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: my-release-keda-otel-scaler.any-ns.svc.cluster.local:9444
+      - notMatchRegex:
+          path: spec.triggers[0].metadata.scalerAddress
+          pattern: '\.sawmills\.svc\.cluster\.local'
+
+  - it: resolves LB external scalerAddress without changing LB queue scaling contract
+    release:
+      name: sawmills-collector
+      namespace: sawmills-o11y
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: sawmills-collector-keda-otel-scaler.sawmills-o11y.svc.cluster.local:4418
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "300"
+      - notMatchRegex:
+          path: spec.triggers[0].metadata.scalerAddress
+          pattern: '\.sawmills\.svc\.cluster\.local'

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -101,3 +101,29 @@ tests:
       - matchRegex:
           path: data["keda.yaml"]
           pattern: '(?m)^\s*metrics/keda:\s*$'
+
+  - it: resolves keda otlp exporter endpoint and preserves literal template-like config
+    template: telemetry-keda-configmap.yaml
+    release:
+      name: my-release
+      namespace: any-ns
+    set:
+      kedaScaler:
+        enabled: true
+        telemetryConfig:
+          processors:
+            transform/literal:
+              metric_statements:
+                - context: metric
+                  statements:
+                    - 'set(attributes["template"], "{{ must_stay_literal }}")'
+    asserts:
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local'
+      - notMatchRegex:
+          path: data["keda.yaml"]
+          pattern: '\.sawmills\.svc\.cluster\.local'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: '\{\{ must_stay_literal \}\}'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -387,7 +387,7 @@ keda:
       metricType: Value
       loadBalancerMetricType: AverageValue
       metadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         # Query by 99p latency of the 90p slowest pod
         query: >-
           quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 > 6000
@@ -395,7 +395,7 @@ keda:
           or vector(5000)
         targetValue: "5000"
       loadBalancerMetadata:
-        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         # Total queued LB batches. With loadBalancerMetricType AverageValue,
         # targetValue is queued batches per desired collector pod.
         # Tune as: per-pod LB batch drain rate * acceptable queue wait seconds.
@@ -1075,7 +1075,7 @@ kedaScaler:
             - name != "haproxy_server_http_responses_total" and name != "http.server.duration" and name != "otelcol_exporter_queue_size" and name != "otelcol_exporter_queue_capacity" and name != "http.server.request.duration"
     exporters:
       otlp/keda:
-        endpoint: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}
+        endpoint: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}'
         compression: "none"
         tls:
           insecure: true


### PR DESCRIPTION
## Summary

Fixes SAW-7112 by rendering the KEDA external scaler service endpoint from the Helm release name and namespace instead of the literal `sawmills` namespace.

## Changes Made

* [ ] Feature addition
* [x] Bug fix
* [x] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

## Version Impact

**Add one of these labelss to this PR:**

* `version:patch` - Bug fixes, small improvements (2.1.0 -> 2.1.1)
* `version:minor` - New features, backwards compatible (2.1.0 -> 2.2.0)
* `version:major` - Breaking changes (2.1.0 -> 3.0.0)

Selected: `version:patch`

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation (`helm install --dry-run`)
* [ ] Deployed to test environment
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
helm unittest helm-charts/sawmills-collector -f 'tests/keda_scaler_address_test.yaml' -f 'tests/telemetry_keda_overlay_test.yaml'
./tests/run-tests.sh
helm lint helm-charts/sawmills-collector --strict
helm template sawmills-collector helm-charts/sawmills-collector -n sawmills-o11y --set keda.enabled=true --set keda.scaling.external.enabled=true --set kedaScaler.enabled=true --set loadBalancer.enabled=true --set kedaScaler.service.kedaExternalScalerPort=9444
trunk check helm-charts/sawmills-collector/README.md helm-charts/sawmills-collector/templates/_helpers.tpl helm-charts/sawmills-collector/templates/keda-hpa.yaml helm-charts/sawmills-collector/templates/telemetry-keda-configmap.yaml helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml helm-charts/sawmills-collector/values.yaml
git diff --check
```

**Test environments:**

* [x] Local development
* [ ] Staging environment
* [ ] Customer test environment

**Results:**

* Expected: KEDA scaler endpoints render with the release namespace and preserve the SAW-7254 LB queue scaling contract.
* Actual: Regression tests fail on the old hardcoded namespace, then pass with rendered endpoints; full chart tests pass.

## Breaking Changes

* [x] No breaking changes
* [ ] Contains breaking changes (describe below)

**Breaking Change Details:**

* **What breaks:** None expected.
* **Migration path:** No migration required.
* **Version compatibility:** Existing releases in namespace `sawmills` render the same service DNS; non-`sawmills` namespaces now render correctly.

## Impact Assessment

* **Who is affected:** Collector deployments using KEDA external scaler endpoints, especially namespaces other than `sawmills`.
* **What systems are affected:** `sawmills-collector` Helm chart KEDA ScaledObject and telemetry KEDA ConfigMap rendering.
* **Rollback plan:** Revert this chart change; existing rendered resources are Helm-managed.

## Documentation Updated

* [x] Chart README.md updated
* [x] Configuration examples added/updated
* [ ] CHANGELOG.md updated
* [x] Inline comments added for complex logic
* [ ] Not applicable (no documentation changes needed)

## Additional Notes

The telemetry ConfigMap intentionally templates only the `otlp/keda.endpoint` value, not the full telemetry config tree, so literal `{{ ... }}` strings in OTel statements are preserved.

***

## Checklist

* [x] I have read the [contribution guidelines](README.md#contributing)
* [x] I have tested my changes thoroughly
* [x] I have updated documentation as needed
* [x] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* [x] I have tagged @sawmills/engineers for review
* [x] I have provided clear commit messages

***

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the KEDA external scaler endpoint from the Helm release name and namespace instead of a hardcoded `sawmills` namespace, and cap the scaler resource name to a valid DNS length. Restores external metrics outside `sawmills` while keeping existing `sawmills` installs unchanged (SAW-7112).

- **Bug Fixes**
  - Added helper `sawmills-collector.kedaScalerName` to build `<fullname>-keda-otel-scaler` with DNS-safe truncation; used by the scaler Deployment and Service.
  - Added helper `sawmills-collector.kedaScalerSvcFQDN` to build `<keda-scaler-name>.<namespace>.svc.cluster.local`.
  - Replaced hardcoded FQDNs in `values.yaml` and README with `{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}` and the configured port.
  - In `keda-hpa.yaml`, resolve `scalerAddress` via `tpl` for both LB and non-LB metadata.
  - In the telemetry KEDA ConfigMap, `tpl` only the OTLP exporter `endpoint`; preserve other literal template-like strings.
  - Added helm-unittest coverage for namespace-based resolution, name truncation, and to guard against `.sawmills.svc.cluster.local`; verifies the LB queue scaling contract remains the same.

<sup>Written for commit a2c123c315623e13628e0976956050a769521c64. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/159?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * KEDA external scaler service address and telemetry endpoints are now dynamically resolved using Helm template helpers, supporting flexible deployments across different namespaces.
  * Configuration values can now include Helm template expressions for runtime evaluation.

* **Documentation**
  * Updated KEDA autoscaling configuration examples and guidance.

* **Tests**
  * Added test coverage for KEDA scaler address templating and endpoint resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->