### PR TITLE
sawmills-collector: Gate LB readiness on forwarding health

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -244,7 +244,7 @@ haproxy:
     readiness:
       type: http # http|tcp
       port: 13135
-      path: /healthcheck
+      path: /ready
   resources:
     requests:
       memory: 128Mi

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -261,6 +261,16 @@ haproxy:
     uri: "/"
     refresh: "10s"
     auth: "admin:admin"
+  healthcheck:
+    enabled: true
+    port: 13135
+    forwarding_health:
+      enabled: false
+      port: 13136
+      path: /forwarding-health
+      interval: 3000
+      rise: 2
+      fall: 2
 ```
 
 The HAProxy container defaults to numeric UID/GID `99` with `runAsNonRoot` so clusters enforcing non-root pod security can verify the official HAProxy image user. Override `haproxy.securityContext` when using a custom HAProxy image that requires a different numeric user or additional container hardening fields.

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -3,6 +3,7 @@
 {{- $healthcheck := .Values.haproxy.healthcheck | default dict -}}
 {{- $forwardingHealth := $healthcheck.forwarding_health | default dict -}}
 {{- $forwardingHealthEnabled := $forwardingHealth.enabled | default false -}}
+{{- $readinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy -}}
 
 global
 {{- with .Values.haproxy.global }}
@@ -114,18 +115,20 @@ frontend healthcheck
   # endpoint before pod actually terminates, preventing fallback during scale-down
   acl is_stopping stopping
   http-request deny deny_status 503 if is_stopping
+  acl readiness_check path {{ $readinessPath }}
   {{- range $name, $config := .Values.haproxy.mapping }}
   {{- if $config.to.fallback_endpoint }}
   # Only return healthy if HAProxy's internal rise checks have marked otel server as UP
   acl backend_{{ $name }}_up srv_is_up(logs_http_{{ $config.from }}/otel)
-  http-request deny deny_status 503 unless backend_{{ $name }}_up
+  http-request deny deny_status 503 if readiness_check !backend_{{ $name }}_up
   {{- end }}
   {{- end }}
   {{- if $forwardingHealthEnabled }}
   # Direct traffic readiness also requires the local collector to have usable forwarding backends.
   acl forwarding_health_up srv_is_up(forwarding_health_backend/forwarding_health)
-  http-request deny deny_status 503 unless forwarding_health_up
+  http-request deny deny_status 503 if readiness_check !forwarding_health_up
   {{- end }}
+  http-request return status 200 if readiness_check
   default_backend healthcheck_backend
 
 backend healthcheck_backend

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -1,5 +1,8 @@
 {{- define "sawmills-collector.haproxy.config" -}}
 {{- $refusalFastFail := .Values.haproxy.refusal_fast_fail | default dict -}}
+{{- $healthcheck := .Values.haproxy.healthcheck | default dict -}}
+{{- $forwardingHealth := $healthcheck.forwarding_health | default dict -}}
+{{- $forwardingHealthEnabled := $forwardingHealth.enabled | default false -}}
 
 global
 {{- with .Values.haproxy.global }}
@@ -118,11 +121,23 @@ frontend healthcheck
   http-request deny deny_status 503 unless backend_{{ $name }}_up
   {{- end }}
   {{- end }}
+  {{- if $forwardingHealthEnabled }}
+  # Direct traffic readiness also requires the local collector to have usable forwarding backends.
+  acl forwarding_health_up srv_is_up(forwarding_health_backend/forwarding_health)
+  http-request deny deny_status 503 unless forwarding_health_up
+  {{- end }}
   default_backend healthcheck_backend
 
 backend healthcheck_backend
   mode http
   server otel "$MY_POD_IP":13133
+
+{{- if $forwardingHealthEnabled }}
+backend forwarding_health_backend
+  mode http
+  option httpchk GET {{ $forwardingHealth.path | default "/forwarding-health" }}
+  server forwarding_health "$MY_POD_IP":{{ $forwardingHealth.port | default 13136 }} check inter {{ $forwardingHealth.interval | default 3000 }} rise {{ $forwardingHealth.rise | default 2 }} fall {{ $forwardingHealth.fall | default 2 }}
+{{- end }}
 {{- end }}
 
 {{- range $name, $config := .Values.haproxy.mapping }}
@@ -184,7 +199,7 @@ backend logs_http_{{ $config.from }}
   {{- end }}
   {{- if not $config.backend_options }}
   {{- if not (eq $mode "grpc") }}
-  option httpchk
+  option httpchk GET /healthcheck
   {{- end }}
   {{- end }}
   {{- with $fc }}
@@ -246,7 +261,7 @@ backend logs_http_{{ $config.from }}_direct
   {{- end }}
   {{- if not $config.backend_options }}
   {{- if not (eq $mode "grpc") }}
-  option httpchk
+  option httpchk GET /healthcheck
   {{- end }}
   {{- end }}
   {{- with $fc }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -519,7 +519,7 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- $livenessPath := dig "probes" "liveness" "path" "/healthcheck" $root.Values.haproxy -}}
 {{- $readinessType := (dig "probes" "readiness" "type" "http" $root.Values.haproxy) | toString | lower -}}
 {{- $readinessPort := dig "probes" "readiness" "port" 13135 $root.Values.haproxy -}}
-{{- $readinessPath := dig "probes" "readiness" "path" "/healthcheck" $root.Values.haproxy -}}
+{{- $readinessPath := dig "probes" "readiness" "path" "/ready" $root.Values.haproxy -}}
 {{- $defaultSecurityContext := dict "runAsNonRoot" true "runAsUser" 99 "runAsGroup" 99 -}}
 {{- $securityContext := mergeOverwrite (deepCopy $defaultSecurityContext) (default dict $root.Values.haproxy.securityContext) -}}
 {{- if not (or (eq $livenessType "http") (eq $livenessType "tcp")) -}}

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -3,7 +3,7 @@ templates:
   - deployment.yaml
   - load-balancer.yaml
 tests:
-  - it: should default to http healthcheck probes for haproxy in deployment mode
+  - it: should default to separate http liveness and readiness probes for haproxy in deployment mode
     template: deployment.yaml
     values:
       - ../values.yaml
@@ -24,7 +24,7 @@ tests:
           value: 13135
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /healthcheck
+          value: /ready
       - isNotSubset:
           path: spec.template.spec.containers[0].lifecycle
           content:
@@ -154,7 +154,7 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.httpGet
 
-  - it: should default to http healthcheck probes for haproxy in load balancer mode
+  - it: should default to separate http liveness and readiness probes for haproxy in load balancer mode
     template: load-balancer.yaml
     values:
       - ../values.yaml
@@ -176,7 +176,7 @@ tests:
           value: 13135
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /healthcheck
+          value: /ready
       - isNotSubset:
           path: spec.template.spec.containers[0].lifecycle
           content:
@@ -185,6 +185,31 @@ tests:
           path: spec.template.spec.containers[1].lifecycle
           content:
             "$patch": replace
+
+  - it: should keep haproxy liveness on healthcheck when forwarding health gates readiness
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.healthcheck.forwarding_health.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
 
   - it: should pin haproxy to numeric non-root user in load balancer mode
     template: load-balancer.yaml

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -260,7 +260,13 @@ tests:
           pattern: "acl forwarding_health_up srv_is_up\\(forwarding_health_backend/forwarding_health\\)"
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "http-request deny deny_status 503 unless forwarding_health_up"
+          pattern: "acl readiness_check path /ready"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "http-request deny deny_status 503 if readiness_check !forwarding_health_up"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "http-request return status 200 if readiness_check"
       - matchRegex:
           path: data["haproxy.cfg"]
           pattern: "backend forwarding_health_backend\\r?\\n  mode http\\r?\\n  option httpchk GET /forwarding-health\\r?\\n  server forwarding_health \"\\$MY_POD_IP\":13136 check"

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -194,6 +194,24 @@ tests:
           path: data["haproxy.cfg"]
           pattern: "server-template sibling 10 RELEASE-NAME-headless\\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
 
+  - it: should use /healthcheck for local and sibling backend checks
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /healthcheck"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318_direct\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /healthcheck"
+
   - it: should use custom max_servers for server-template
     template: haproxy-configmap.yaml
     set:
@@ -224,6 +242,46 @@ tests:
       - matchRegex:
           path: data["haproxy.cfg"]
           pattern: "server fallback vendor.example.com.*backup.*ssl verify none"
+
+  - it: should gate direct LB readiness on forwarding health when enabled
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.healthcheck.forwarding_health.enabled: true
+      haproxy.sibling_fallback.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "acl forwarding_health_up srv_is_up\\(forwarding_health_backend/forwarding_health\\)"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "http-request deny deny_status 503 unless forwarding_health_up"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend forwarding_health_backend\\r?\\n  mode http\\r?\\n  option httpchk GET /forwarding-health\\r?\\n  server forwarding_health \"\\$MY_POD_IP\":13136 check"
+
+  - it: should not gate direct LB readiness on forwarding health by default
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "forwarding_health_backend"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "forwarding_health_up"
 
   - it: should keep sibling fallback but disable external fallback when configured
     template: haproxy-configmap.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -764,6 +764,16 @@ haproxy:
   healthcheck:
     enabled: true
     port: 13135
+    # Optional readiness gate for LB pods. When enabled, the HAProxy readiness
+    # frontend only returns healthy when the local collector's forwarding_health
+    # extension reports usable downstream collector backends.
+    forwarding_health:
+      enabled: false
+      port: 13136
+      path: /forwarding-health
+      interval: 3000
+      rise: 2
+      fall: 2
 
   # Sibling fallback configuration
   # When enabled, HAProxy routes to sibling LB pods (round-robin) before falling back

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -632,7 +632,7 @@ haproxy:
     readiness:
       type: http
       port: 13135
-      path: /healthcheck
+      path: /ready
   # Number of consecutive layer 7 errors before marking backend DOWN and routing to fallback.
   # Higher values reduce fallback sensitivity to transient errors.
   # With Fix #1 (503 instead of 500), HAProxy retries on 503. error-limit counts only


### PR DESCRIPTION
Adds an opt-in HAProxy readiness gate so LB pods only accept direct traffic once the local collector has usable forwarding backends.

Description:
- Add `haproxy.healthcheck.forwarding_health` values for opt-in readiness gating.
- Render a HAProxy forwarding_health backend and deny readiness when it is down.
- Make sibling/local HTTP checks use `GET /healthcheck`, so port `13136` checks use forwarding_health semantics.

Linear: SAW-7283

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in readiness gate so LB pods only report ready when the local collector has usable forwarding backends, and moves readiness to a dedicated `/ready` path to reduce direct-traffic refusals during rapid scale-ups (SAW-7283).

- **New Features**
  - New `haproxy.healthcheck.forwarding_health` values (enable, `port`, `path`, `interval`, `rise`, `fall`).
  - HAProxy readiness on `:13135` now uses `/ready` and, when enabled, requires `forwarding_health` to be UP; returns 503 until healthy.
  - Adds `forwarding_health_backend` on `:13136`; local/sibling HTTP checks now `GET /healthcheck`; liveness stays on `/healthcheck`.
  - README, defaults, and tests updated for `/ready` and forwarding-health gating.

<sup>Written for commit 3f902da215d7753131cd23046cfe7fb56c350b97. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

