### PR TITLE
fix(sawmills-collector): decouple sibling fallback from external fallback

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -152,7 +152,7 @@ backend forwarding_health_backend
   {{ $proto = "proto h2" }}
 {{ end }}
 {{- $siblingEnabled := false }}
-{{- if and (eq (include "sawmills-collector.siblingFallbackEnabled" $) "true") $to.fallback_endpoint (ne $mode "tcp") }}
+{{- if and (eq (include "sawmills-collector.siblingFallbackEnabled" $) "true") (ne $mode "tcp") }}
   {{- $siblingEnabled = true }}
 {{- end }}
 frontend logs_http_frontend_{{ $config.from }}
@@ -211,7 +211,6 @@ backend logs_http_{{ $config.from }}
   {{ if .timeout.server }}timeout server {{ .timeout.server }}{{- end }}
   {{- end }}
   {{- end }}
-  {{- if $to.fallback_endpoint }}
   {{- $server := $fc.server | default dict -}}
   {{- $interval := default 2000 $server.interval -}}
   {{- $rise := default 10 $server.rise -}}
@@ -219,10 +218,12 @@ backend logs_http_{{ $config.from }}
   {{- $errorLimit := $.Values.haproxy.error_limit }}
   {{- $slowstart := "" }}
   {{- $externalFallbackEnabled := eq (include "sawmills-collector.externalFallbackEnabled" $) "true" }}
+  {{- $failoverEnabled := or $siblingEnabled $to.fallback_endpoint }}
   {{- if and ($refusalFastFail.enabled | default false) (ne $mode "tcp") }}
   {{- $errorLimit = ($refusalFastFail.error_limit | default 20) }}
   {{- $slowstart = ($refusalFastFail.slowstart | default "") }}
   {{- end }}
+  {{- if $failoverEnabled }}
   {{- if $siblingEnabled }}
   # Tag request as sibling-forwarded before sending to sibling tier
   http-request set-header X-Sibling-Hop 1
@@ -235,14 +236,12 @@ backend logs_http_{{ $config.from }}
   # Check port 13136 is served by the forwarding_health extension in
   # sawmills-collector (PR #811); chart + collector changes must ship together.
   server-template sibling {{ $sf.max_servers | default 10 }} {{ include "sawmills-collector.lbHeadlessSvcFQDN" $ }}:{{ $config.from }} {{ $proto }} check port {{ $sf.check.port | default 13136 }} inter {{ $sf.check.interval | default 3000 }} rise {{ $sf.check.rise | default 2 }} fall {{ $sf.check.fall | default 2 }} backup resolvers k8s init-addr none
-  {{- if $externalFallbackEnabled }}
+  {{- end }}
+  {{- if and $externalFallbackEnabled $to.fallback_endpoint }}
+  {{- if $siblingEnabled }}
   # External fallback: last resort (listed after siblings, so HAProxy tries siblings first)
-  server fallback {{ $to.fallback_endpoint }} {{ $proto }} backup {{ if (or (not (hasKey $to "fallback_ssl")) $to.fallback_ssl) }}ssl verify none{{ end }}
   {{- end }}
-  {{- else }}
-  {{- if $externalFallbackEnabled }}
   server fallback {{ $to.fallback_endpoint }} {{ $proto }} backup {{ if (or (not (hasKey $to "fallback_ssl")) $to.fallback_ssl) }}ssl verify none{{ end }}
-  {{- end }}
   {{- end }}
   {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
@@ -287,7 +286,7 @@ backend logs_http_{{ $config.from }}_direct
   {{- $directSlowstart = ($refusalFastFail.slowstart | default "") }}
   {{- end }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port 13133 inter {{ $interval }} rise {{ $rise }} fall {{ $fall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $directErrorLimit }} on-error mark-down{{ if ne $directSlowstart "" }} slowstart {{ $directSlowstart }}{{ end }}
-  {{- if $externalFallbackEnabled }}
+  {{- if and $externalFallbackEnabled $to.fallback_endpoint }}
   server fallback {{ $to.fallback_endpoint }} {{ $proto }} backup {{ if (or (not (hasKey $to "fallback_ssl")) $to.fallback_ssl) }}ssl verify none{{ end }}
   {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -455,16 +455,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "acl is_sibling_hop hdr\\(X-Sibling-Hop\\) -m found"
+          pattern: acl is_sibling_hop hdr\(X-Sibling-Hop\) -m found
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server-template sibling 10 RELEASE-NAME-headless\\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
+          pattern: server-template sibling 10 RELEASE-NAME-headless\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "backend logs_http_4318_direct"
+          pattern: backend logs_http_4318_direct
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server fallback"
+          pattern: server fallback
 
   - it: should keep sibling fallback when external fallback is disabled and no fallback_endpoint
     template: haproxy-configmap.yaml
@@ -479,16 +479,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "acl is_sibling_hop hdr\\(X-Sibling-Hop\\) -m found"
+          pattern: acl is_sibling_hop hdr\(X-Sibling-Hop\) -m found
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server-template sibling 10 RELEASE-NAME-headless\\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
+          pattern: server-template sibling 10 RELEASE-NAME-headless\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "backend logs_http_4318_direct"
+          pattern: backend logs_http_4318_direct
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server fallback"
+          pattern: server fallback
 
   - it: should not render fallback servers when sibling fallback is disabled and no fallback_endpoint
     template: haproxy-configmap.yaml
@@ -503,13 +503,13 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "X-Sibling-Hop"
+          pattern: X-Sibling-Hop
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server-template sibling"
+          pattern: server-template sibling
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server fallback"
+          pattern: server fallback
 
   - it: should render neither fallback when both fallback modes are disabled and no fallback_endpoint
     template: haproxy-configmap.yaml
@@ -524,13 +524,13 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "X-Sibling-Hop"
+          pattern: X-Sibling-Hop
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server-template sibling"
+          pattern: server-template sibling
       - notMatchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server fallback"
+          pattern: server fallback
 
   # ============================================================
   # 9. Headless service - HAProxy ports exposed when enabled

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -440,12 +440,61 @@ tests:
           pattern: "backend logs_http_4317_direct"
 
   # ============================================================
-  # 8. No fallback endpoint - sibling fallback NOT applied
+  # 8. No fallback endpoint - sibling/external fallback matrix
   # ============================================================
-  - it: should NOT apply sibling fallback when no fallback_endpoint
+  - it: should keep sibling fallback when external fallback is enabled and no fallback_endpoint
     template: haproxy-configmap.yaml
     set:
       haproxy.sibling_fallback.enabled: true
+      haproxy.external_fallback.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "acl is_sibling_hop hdr\\(X-Sibling-Hop\\) -m found"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server-template sibling 10 RELEASE-NAME-headless\\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318_direct"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server fallback"
+
+  - it: should keep sibling fallback when external fallback is disabled and no fallback_endpoint
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.external_fallback.enabled: false
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "acl is_sibling_hop hdr\\(X-Sibling-Hop\\) -m found"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server-template sibling 10 RELEASE-NAME-headless\\..*:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318_direct"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server fallback"
+
+  - it: should not render fallback servers when sibling fallback is disabled and no fallback_endpoint
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: false
+      haproxy.external_fallback.enabled: true
       haproxy.mapping:
         http_4318:
           from: 4318
@@ -458,6 +507,30 @@ tests:
       - notMatchRegex:
           path: data["haproxy.cfg"]
           pattern: "server-template sibling"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server fallback"
+
+  - it: should render neither fallback when both fallback modes are disabled and no fallback_endpoint
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: false
+      haproxy.external_fallback.enabled: false
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+    asserts:
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "X-Sibling-Hop"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server-template sibling"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server fallback"
 
   # ============================================================
   # 9. Headless service - HAProxy ports exposed when enabled
@@ -515,7 +588,7 @@ tests:
   # ============================================================
   # 10. Mixed ports - sibling applied only where appropriate
   # ============================================================
-  - it: should apply sibling fallback only to HTTP ports with fallback_endpoint
+  - it: should apply sibling fallback to HTTP ports regardless of fallback_endpoint
     template: haproxy-configmap.yaml
     set:
       haproxy.sibling_fallback.enabled: true
@@ -544,8 +617,8 @@ tests:
       - notMatchRegex:
           path: data["haproxy.cfg"]
           pattern: "logs_http_514_direct"
-      # HTTP without fallback - should NOT have sibling tier
-      - notMatchRegex:
+      # HTTP without fallback - should still have sibling tier
+      - matchRegex:
           path: data["haproxy.cfg"]
           pattern: "logs_http_8080_direct"
 


### PR DESCRIPTION
sawmills-collector: Decouple sibling fallback from external fallback

Sibling fallback can now render without an external fallback endpoint, matching the Via deployment shape from SAW-7324.

Description
- Compute sibling fallback from `sibling_fallback.enabled` plus non-TCP mode instead of requiring `fallback_endpoint`.
- Keep `server fallback` guarded by both `external_fallback.enabled` and a configured `fallback_endpoint`.
- Add helm-unittest coverage for the no-endpoint sibling/external fallback matrix and mixed-port behavior.

Linear: SAW-7324

Verification
- `helm unittest helm-charts/sawmills-collector -f tests/sibling_fallback_test.yaml`
- `helm lint helm-charts/sawmills-collector`
- `helm template test-release helm-charts/sawmills-collector`
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh`
- CI render variants from `.github/workflows/helm-test.yml`
- `trunk check helm-charts/sawmills-collector/templates/_haproxy.tpl helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples sibling fallback from external fallback in the `sawmills-collector` HAProxy template so the sibling tier renders without a `fallback_endpoint`. Aligns with SAW-7324 and fixes missing sibling backends in Via deployments.

- **Bug Fixes**
  - Compute `$siblingEnabled` from `sibling_fallback.enabled` and non-TCP mode, independent of `to.fallback_endpoint`.
  - Render `server fallback` only when `external_fallback.enabled` is true and `to.fallback_endpoint` is set; gate the failover block on either sibling or endpoint.
  - Expand helm-unittest coverage for the no-endpoint sibling/external matrix and mixed-port behavior; tidy regex patterns.

<sup>Written for commit 118efbad59a7f9ad057debdbd5493f119e64b525. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

