### PR TITLE
fix(sawmills-collector): route LB readiness through HAProxy ready

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -117,11 +117,9 @@ frontend healthcheck
   http-request deny deny_status 503 if is_stopping
   acl readiness_check path {{ $readinessPath }}
   {{- range $name, $config := .Values.haproxy.mapping }}
-  {{- if $config.to.fallback_endpoint }}
   # Only return healthy if HAProxy's internal rise checks have marked otel server as UP
   acl backend_{{ $name }}_up srv_is_up(logs_http_{{ $config.from }}/otel)
   http-request deny deny_status 503 if readiness_check !backend_{{ $name }}_up
-  {{- end }}
   {{- end }}
   {{- if $forwardingHealthEnabled }}
   # Direct traffic readiness also requires the local collector to have usable forwarding backends.

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -4,6 +4,12 @@
 {{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
 {{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
 {{- $lbStartupProbe := .Values.rollout.loadBalancer.probes.startup | default dict }}
+{{- $haproxyReadinessType := (dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower }}
+{{- $haproxyReadinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy }}
+{{- $haproxyReadinessPort := dig "probes" "readiness" "port" 13135 .Values.haproxy }}
+{{- if eq $haproxyReadinessType "tcp" }}
+{{- $haproxyReadinessPort = (.Values.haproxy.healthcheck.port | default 13135) }}
+{{- end }}
 apiVersion: apps/v1
 {{- if .Values.loadBalancer.storage.enabled }}
 kind: StatefulSet
@@ -177,10 +183,11 @@ spec:
             failureThreshold: {{ .Values.rollout.loadBalancer.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /healthcheck
               {{- if .Values.haproxy.enabled }}
-              port: 13135  # Route through HAProxy to ensure backend is UP before receiving traffic
+              path: {{ $haproxyReadinessPath }}
+              port: {{ $haproxyReadinessPort }}  # Route through HAProxy to ensure backend is UP before receiving traffic
               {{- else }}
+              path: /healthcheck
               port: 13133
               {{- end }}
             initialDelaySeconds: {{ .Values.rollout.loadBalancer.probes.readiness.initialDelaySeconds }}

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -153,6 +153,15 @@ tests:
           value: 10000
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /ready
 
   - it: should default to separate http liveness and readiness probes for haproxy in load balancer mode
     template: load-balancer.yaml
@@ -176,6 +185,21 @@ tests:
           value: 13135
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
           value: /ready
       - isNotSubset:
           path: spec.template.spec.containers[0].lifecycle
@@ -210,6 +234,44 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /ready
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /ready
+
+  - it: should route load balancer main collector readiness through custom haproxy readiness path
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.probes.readiness.path: /lb-ready
+      haproxy.probes.readiness.port: 13135
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /lb-ready
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /lb-ready
 
   - it: should pin haproxy to numeric non-root user in load balancer mode
     template: load-balancer.yaml

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -163,6 +163,42 @@ tests:
           path: spec.template.spec.containers[1].readinessProbe.httpGet.path
           value: /ready
 
+  - it: should route load balancer main collector readiness through custom haproxy healthcheck port with tcp haproxy probes
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.healthcheck.port: 13136
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: TCP
+      haproxy.probes.liveness.type: tcp
+      haproxy.probes.liveness.port: 10000
+      haproxy.probes.readiness.type: tcp
+      haproxy.probes.readiness.port: 10000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 10000
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 10000
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13136
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /ready
+
   - it: should default to separate http liveness and readiness probes for haproxy in load balancer mode
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -137,7 +137,7 @@ tests:
       haproxy.enabled: true
       haproxy.mapping.logs_http_10000.from: 10000
       haproxy.mapping.logs_http_10000.to.port: 10518
-      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+      haproxy.mapping.logs_http_10000.to.protocol: TCP
       haproxy.probes.liveness.type: tcp
       haproxy.probes.liveness.port: 10000
       haproxy.probes.readiness.type: tcp

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -462,6 +462,18 @@ tests:
       - matchRegex:
           path: data["haproxy.cfg"]
           pattern: backend logs_http_4318_direct
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: acl readiness_check path /ready
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: acl backend_http_4318_up srv_is_up\(logs_http_4318/otel\)
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: http-request deny deny_status 503 if readiness_check !backend_http_4318_up
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: default_backend healthcheck_backend
       - notMatchRegex:
           path: data["haproxy.cfg"]
           pattern: server fallback


### PR DESCRIPTION
## Summary

Routes the collector LB main container readiness probe through HAProxy `/ready` instead of `/healthcheck`, so drain/backend readiness affects Kubernetes endpoint eligibility without turning liveness into readiness.

## Changes Made

* [ ] Feature addition
* [x] Bug fix
* [ ] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

## Version Impact

**Add one of these labelss to this PR:**

* `version:patch` - Bug fixes, small improvements (2.1.0 -> 2.1.1)
* `version:minor` - New features, backwards compatible (2.1.0 -> 2.2.0)
* `version:major` - Breaking changes (2.1.0 -> 3.0.0)

Selected: `version:patch`

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation (`helm install --dry-run`)
* [ ] Deployed to test environment
* [ ] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
helm unittest helm-charts/sawmills-collector -f tests/haproxy_probe_config_test.yaml
helm unittest helm-charts/sawmills-collector -f tests/sibling_fallback_test.yaml
helm lint helm-charts/sawmills-collector
helm template saw7323 helm-charts/sawmills-collector --set loadBalancer.enabled=true --set haproxy.enabled=true --set haproxy.mapping.http_4318.from=4318 --set haproxy.mapping.http_4318.to.port=4318 --set haproxy.mapping.http_4318.to.protocol=TCP
cd helm-charts/sawmills-collector && ./tests/run-tests.sh
helm template test-release . --values values.yaml
helm template test-release . --values values.yaml --set haproxy.enabled=true
helm template test-release . --values values.yaml --set haproxy.enabled=true --set haproxy.probes.readiness.type=tcp --set haproxy.probes.readiness.port=10000 --set haproxy.mapping.logs_http_10000.from=10000 --set haproxy.mapping.logs_http_10000.to.port=10518 --set haproxy.mapping.logs_http_10000.to.protocol=TCP
helm template test-release . --values values.yaml --set keda.enabled=true
helm template test-release . --values values.yaml --set mode=daemonSet
helm template test-release . --values values.yaml --set loadBalancer.enabled=true
helm template test-release . --values values.yaml --set loadBalancer.enabled=true --set loadBalancer.autoscaling.enabled=true
trunk check helm-charts/sawmills-collector/templates/_haproxy.tpl helm-charts/sawmills-collector/templates/load-balancer.yaml helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
```

**Test environments:**

* [x] Local development
* [ ] Staging environment
* [ ] Customer test environment

**Results:**

* Expected: LB HAProxy liveness stays `/healthcheck`, LB readiness uses `/ready`, and `/ready` gates local backend health even without `fallback_endpoint`.
* Actual: Helm unit tests, lint, template renders, and trunk check pass. Render proof shows `main-collector` readiness on `/ready:13135` with HAProxy enabled and local backend `srv_is_up` readiness ACLs.

## Breaking Changes

* [x] No breaking changes
* [ ] Contains breaking changes (describe below)

**Breaking Change Details:**

* **What breaks:** N/A
* **Migration path:** N/A
* **Version compatibility:** Patch release

## Impact Assessment

* **Who is affected:** Collector LB deployments with HAProxy enabled.
* **What systems are affected:** `sawmills-collector` Helm chart LB pod readiness and HAProxy health frontend config.
* **Rollback plan:** Roll back to the previous collector chart version.

## Documentation Updated

* [ ] Chart README.md updated
* [ ] Configuration examples added/updated
* [ ] CHANGELOG.md updated
* [ ] Inline comments added for complex logic
* [x] Not applicable (no documentation changes needed)

## Additional Notes

Linear: SAW-7323

This intentionally keeps `/healthcheck` as liveness and uses `/ready` for endpoint eligibility. The chart still preserves TCP HAProxy probe mode by routing the LB main-container readiness check to the HAProxy health frontend port.

***

## Checklist

* [x] I have read the [contribution guidelines](README.md#contributing)
* [x] I have tested my changes thoroughly
* [x] I have updated documentation as needed
* [x] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* [ ] I have tagged @sawmills/engineers for review
* [x] I have provided clear commit messages

***

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the load balancer main-collector readiness probe through HAProxy `/ready` (configurable) instead of `/healthcheck`, so drain and backend status control endpoint eligibility without touching liveness. Supports SAW-7323 by ensuring `/drain` flips `/ready` to 503 while `/healthcheck` stays 200.

- **Bug Fixes**
  - Main collector readiness now uses `haproxy.probes.readiness.path` and `port` (defaults `/ready` on `13135`) when `haproxy.enabled`; liveness remains `/healthcheck` on `13133`.
  - TCP readiness mode routes the LB readiness probe to HAProxy `healthcheck.port` (default `13135` or overridden), not the TCP data port.
  - HAProxy readiness ACLs apply to all mappings; `/ready` returns 503 if the local backend isn’t UP.
  - Helm tests expanded to cover LB readiness routing (custom readiness path and TCP mode with custom `healthcheck.port`) and fixed to satisfy YAML lint.

<sup>Written for commit eb0cf45eab2828b713df212cc8378076618087d5. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced readiness probe configuration with customizable HAProxy endpoint path and port settings.
  * Improved readiness gating behavior for load balancer backends.

* **Tests**
  * Expanded test coverage for HAProxy probe configuration across sidecar containers.
  * Added validation for sibling fallback scenarios with readiness gating assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->