### PR TITLE
fix(sawmills-collector): extend backend drain budget

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.12
+version: 2.6.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -180,12 +180,16 @@ keda:
   pollingInterval: 30
   cooldownPeriod: 0
   annotations: {}
-  # For migrating an existing HPA to KEDA without admission conflicts:
+  # For non-Helm-owned HPA ownership transfer:
   # annotations:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   # advanced:
   #   horizontalPodAutoscalerConfig:
   #     name: <existing-hpa-name>
+  #
+  # For Helm-managed HPAs from this chart, use a two-step migration:
+  # 1. Upgrade with autoscaling.enabled=false and keda.enabled=false to prune the standard HPA.
+  # 2. Upgrade with keda.enabled=true after the standard HPA has been removed.
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -179,6 +179,13 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  annotations: {}
+  # For migrating an existing HPA to KEDA without admission conflicts:
+  # annotations:
+  #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  # advanced:
+  #   horizontalPodAutoscalerConfig:
+  #     name: sawmills-collector
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -498,7 +498,7 @@ rollout:
     maxUnavailable: null   # defaults to 1 for ≤ 10 replicas, scales proportionally beyond that
     maxSurge: null         # defaults to 2 for ≤ 10 replicas, scales proportionally beyond that
   minReadySeconds: 15
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   main:
     probes:
       liveness:
@@ -519,7 +519,7 @@ rollout:
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
-      duration: 15s
+      duration: 120s
       shutdownReserve: 10s
     preStopSleepSeconds: 15
 ```
@@ -530,7 +530,7 @@ When `loadBalancer.enabled: true`, the chart can protect backend collector rollo
 
 ```yaml
 rollout:
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   main:
     drain:
       enabled: true
@@ -539,7 +539,7 @@ rollout:
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
-      duration: 15s
+      duration: 120s
       shutdownReserve: 10s
 ```
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -185,7 +185,7 @@ keda:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   # advanced:
   #   horizontalPodAutoscalerConfig:
-  #     name: sawmills-collector
+  #     name: <existing-hpa-name>
   scaling:
     cpu:
       enabled: true

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -193,6 +193,22 @@ keda:
         serverAddress: http://prometheus:9090
         query: sum(rate(http_requests_total[2m]))
         threshold: "100.50"
+    external:
+      enabled: false
+      metricType: Value
+      loadBalancerMetricType: AverageValue
+      metadata:
+        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        query: >-
+          quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 > 6000
+          or quantile(0.9, (histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[10m])) by (le, method, instance)))) * 1000 < 3500
+          or vector(5000)
+        targetValue: "5000"
+      loadBalancerMetadata:
+        scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
+        # targetValue is queued LB batches per desired collector pod.
+        query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+        targetValue: "300"
 ```
 
 ### HAProxy Load Balancing

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,4 +1,7 @@
 {{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled .Values.rollout.main.drain.enabled }}
+{{- $telemetryOtelConfig := default (dict) .Values.telemetryOtelConfig }}
+{{- $telemetryOtelS3Path := default "" $telemetryOtelConfig.s3path }}
+{{- $telemetryOtelEncryptionKey := default "" $telemetryOtelConfig.encryptionKey }}
 {{- if $mainCollectorDrainEnabled }}
 {{- $drainDurationMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.duration | atoi }}
 {{- $shutdownReserveMs := include "sawmills-collector.durationToMilliseconds" .Values.rollout.main.drain.shutdownReserve | atoi }}
@@ -147,10 +150,10 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.telemetryOtelConfig.s3path .Values.kedaScaler.enabled }}
+          {{- if or $telemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:
-            {{- if .Values.telemetryOtelConfig.s3path }}
-            - "--config={{ .Values.telemetryOtelConfig.s3path }}{{- if .Values.telemetryOtelConfig.encryptionKey }}@{{ .Values.telemetryOtelConfig.encryptionKey }}{{- end }}"
+            {{- if $telemetryOtelS3Path }}
+            - "--config={{ $telemetryOtelS3Path }}{{- if $telemetryOtelEncryptionKey }}@{{ $telemetryOtelEncryptionKey }}{{- end }}"
             {{- else }}
             - "--config=file:/etc/otel/config.yaml"
             {{- end }}

--- a/helm-charts/sawmills-collector/templates/hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.autoscaling (eq .Values.autoscaling.enabled true) }}
+{{- if and .Values.autoscaling (eq .Values.autoscaling.enabled true) (not (and .Values.keda (eq .Values.keda.enabled true))) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/revision: {{ .Release.Revision | quote }}
+    {{- with .Values.keda.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
@@ -22,9 +25,12 @@ spec:
   advanced:
     {{- with .horizontalPodAutoscalerConfig }}
     horizontalPodAutoscalerConfig:
+      {{- with .name }}
+      name: {{ . | quote }}
+      {{- end }}
       {{- with .behavior }}
       behavior:
-        {{ toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -39,7 +39,11 @@ spec:
     {{- end }}
     {{- if .Values.keda.scaling.external.enabled }}
     - type: external
+      {{- if .Values.loadBalancer.enabled }}
+      metricType: {{ .Values.keda.scaling.external.loadBalancerMetricType | default .Values.keda.scaling.external.metricType }}
+      {{- else }}
       metricType: {{ .Values.keda.scaling.external.metricType }}
+      {{- end }}
       metadata:
         {{- if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.loadBalancer.enabled }}
 {{- include "sawmills-collector.validateLoadBalancerQueueCompression" . }}
+{{- $lbTelemetryOtelConfig := default (dict) .Values.loadBalancer.telemetryOtelConfig }}
+{{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
+{{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
 apiVersion: apps/v1
 {{- if .Values.loadBalancer.storage.enabled }}
 kind: StatefulSet
@@ -233,10 +236,10 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.loadBalancer.telemetryOtelConfig.s3path .Values.kedaScaler.enabled }}
+          {{- if or $lbTelemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:
-            {{- if .Values.loadBalancer.telemetryOtelConfig.s3path }}
-            - "--config={{ .Values.loadBalancer.telemetryOtelConfig.s3path }}{{- if .Values.loadBalancer.telemetryOtelConfig.encryptionKey }}@{{ .Values.loadBalancer.telemetryOtelConfig.encryptionKey }}{{- end }}"
+            {{- if $lbTelemetryOtelS3Path }}
+            - "--config={{ $lbTelemetryOtelS3Path }}{{- if $lbTelemetryOtelEncryptionKey }}@{{ $lbTelemetryOtelEncryptionKey }}{{- end }}"
             {{- else }}
             - "--config=file:/etc/otel/config.yaml"
             {{- end }}

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -47,6 +47,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
           pattern: "wget.*13137.*/drain.*sleep"
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 150
       - isNotSubset:
           path: spec.template.spec.containers[1].lifecycle
           content:
@@ -65,7 +68,7 @@ tests:
           count: 1
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n'
+          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 120s\n'
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
@@ -191,9 +194,9 @@ tests:
     set:
       loadBalancer.enabled: true
       rollout.main.drain.enabled: true
-      rollout.main.drain.duration: 50s
+      rollout.main.drain.duration: 140s
       rollout.main.drain.shutdownReserve: 10s
-      rollout.terminationGracePeriodSeconds: 60
+      rollout.terminationGracePeriodSeconds: 150
     asserts:
       - failedTemplate:
-          errorMessage: 'rollout.main.drain.duration (50s) plus rollout.main.drain.shutdownReserve (10s) must be less than rollout.terminationGracePeriodSeconds (60s)'
+          errorMessage: 'rollout.main.drain.duration (140s) plus rollout.main.drain.shutdownReserve (10s) must be less than rollout.terminationGracePeriodSeconds (150s)'

--- a/helm-charts/sawmills-collector/tests/hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/hpa_test.yaml
@@ -1,0 +1,30 @@
+suite: Main HPA Tests
+templates:
+  - templates/hpa.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders the standard HPA when autoscaling is enabled and KEDA is disabled
+    set:
+      autoscaling:
+        enabled: true
+      keda:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME
+
+  - it: does not render the standard HPA when KEDA is enabled
+    set:
+      autoscaling:
+        enabled: true
+      keda:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -82,6 +82,33 @@ tests:
           path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].periodSeconds
           value: 60
 
+  - it: renders KEDA HPA ownership transfer settings
+    set:
+      loadBalancer:
+        enabled: true
+      keda:
+        enabled: true
+        annotations:
+          scaledobject.keda.sh/transfer-hpa-ownership: "true"
+        advanced:
+          horizontalPodAutoscalerConfig:
+            name: sawmills-collector
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["scaledobject.keda.sh/transfer-hpa-ownership"]
+          value: "true"
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.name
+          value: sawmills-collector
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+
   - it: keeps non-LB external latency scaler on Value
     set:
       loadBalancer:

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -1,0 +1,108 @@
+suite: KEDA HPA Tests
+templates:
+  - templates/keda-hpa.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders LB external queue scaler with AverageValue
+    set:
+      loadBalancer:
+        enabled: true
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.triggers[0].type
+          value: external
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "300"
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.selectPolicy
+          value: Max
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].value
+          value: 100
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[0].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].value
+          value: 20
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.policies[1].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.selectPolicy
+          value: Min
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].type
+          value: Percent
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].value
+          value: 10
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[0].periodSeconds
+          value: 60
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].type
+          value: Pods
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].value
+          value: 5
+      - equal:
+          path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].periodSeconds
+          value: 60
+
+  - it: keeps non-LB external latency scaler on Value
+    set:
+      loadBalancer:
+        enabled: false
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.triggers[0].type
+          value: external
+      - equal:
+          path: spec.triggers[0].metricType
+          value: Value
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: vector\(5000\)
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "5000"

--- a/helm-charts/sawmills-collector/tests/legacy_values_upgrade_test.yaml
+++ b/helm-charts/sawmills-collector/tests/legacy_values_upgrade_test.yaml
@@ -1,0 +1,21 @@
+suite: Legacy Values Upgrade Compatibility
+templates:
+  - templates/deployment.yaml
+  - templates/load-balancer.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders when reused release values omit telemetryOtelConfig blocks
+    set:
+      telemetryOtelConfig: null
+      loadBalancer:
+        enabled: true
+        telemetryOtelConfig: null
+        otelConfig:
+          s3path: s3://example/config
+          encryptionKey: test-key
+      kedaScaler:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -19,7 +19,7 @@ collectorId: sawmills-collector-id
 # Rollout configuration
 rollout:
   # Global rollout settings
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   minReadySeconds: 15
 
   # Deployment strategy configuration
@@ -108,7 +108,7 @@ rollout:
       # Keep drain.duration + shutdownReserve below
       # rollout.terminationGracePeriodSeconds so the collector still has time
       # to handle SIGTERM after the drain hook returns.
-      duration: 15s
+      duration: 120s
       # Reserve explicit post-drain shutdown time inside the pod termination
       # grace period for collector shutdown and kubelet bookkeeping.
       shutdownReserve: 10s

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -347,17 +347,25 @@ keda:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:
+          stabilizationWindowSeconds: 300
+          selectPolicy: Min
           policies:
-            - periodSeconds: 300
-              type: Pods
-              value: 1
-          stabilizationWindowSeconds: 0
-        scaleUp:
-          policies:
-            - periodSeconds: 600
-              type: Pods
+            - type: Percent
               value: 10
+              periodSeconds: 60
+            - type: Pods
+              value: 5
+              periodSeconds: 60
+        scaleUp:
           stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+            - type: Pods
+              value: 20
+              periodSeconds: 60
   scaling:
     prometheus:
       enabled: false
@@ -370,6 +378,7 @@ keda:
     external:
       enabled: false
       metricType: Value
+      loadBalancerMetricType: AverageValue
       metadata:
         scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
         # Query by 99p latency of the 90p slowest pod
@@ -380,12 +389,11 @@ keda:
         targetValue: "5000"
       loadBalancerMetadata:
         scalerAddress: sawmills-collector-keda-otel-scaler.sawmills.svc.cluster.local:4418
-        # Query by queue utilization - scale up if any queue is 70% full
-        query: >-
-          max((otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"} / otelcol_exporter_queue_capacity{exporter=~"loadbalancing/collector-loadbalancer.*"}) * 100) > 20
-          or max((otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"} / otelcol_exporter_queue_capacity{exporter=~"loadbalancing/collector-loadbalancer.*"}) * 100) < 5
-          or vector(10)
-        targetValue: "10"
+        # Total queued LB batches. With loadBalancerMetricType AverageValue,
+        # targetValue is queued batches per desired collector pod.
+        # Tune as: per-pod LB batch drain rate * acceptable queue wait seconds.
+        query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
+        targetValue: "300"
     cpu:
       enabled: true
       targetUtilization: 80

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -338,6 +338,10 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  # Optional annotations for the KEDA ScaledObject.
+  # For HPA -> KEDA migrations, set:
+  #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  annotations: {}
   # Advanced HPA configuration for KEDA (optional)
   # This block allows you to specify advanced HorizontalPodAutoscaler behavior,
   # such as custom scaleUp/scaleDown policies and stabilization windows.
@@ -345,6 +349,9 @@ keda:
   # Example:
   advanced:
     horizontalPodAutoscalerConfig:
+      # Set this to an existing HPA name when using
+      # scaledobject.keda.sh/transfer-hpa-ownership.
+      name: ""
       behavior:
         scaleDown:
           stabilizationWindowSeconds: 300

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -339,7 +339,7 @@ keda:
   pollingInterval: 30
   cooldownPeriod: 0
   # Optional annotations for the KEDA ScaledObject.
-  # For HPA -> KEDA migrations, set:
+  # For non-Helm-owned HPA -> KEDA ownership transfers, set:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
   annotations: {}
   # Advanced HPA configuration for KEDA (optional)
@@ -349,7 +349,7 @@ keda:
   # Example:
   advanced:
     horizontalPodAutoscalerConfig:
-      # Set this to an existing HPA name when using
+      # Set this to an existing non-Helm-owned HPA name when using
       # scaledobject.keda.sh/transfer-hpa-ownership.
       name: ""
       behavior:


### PR DESCRIPTION
SAW-7335: Extend backend drain budget

Conservative drain budget for collector LB shutdowns.

- raise the backend drain window to 120s
- keep pod termination grace at 150s so drain completes before kubelet force-kills
- update backend drain tests and README examples to match the new default budget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the collector LB drain window to 120s and sets pod termination grace to 150s for safer, clean rollouts; also refines KEDA autoscaling and migration. Aligns with SAW-7335’s drain-budget follow-up.

- **Bug Fixes**
  - Extend backend drain duration to 120s and set `terminationGracePeriodSeconds` to 150s; update defaults, tests, and README.
  - Prevent duplicate HPAs by not rendering the standard HPA when KEDA is enabled; make `telemetryOtelConfig` usage null-safe.

- **New Features**
  - Add LB queue-based KEDA external scaler using per-pod AverageValue targeting for total queued batches (targetValue "300").
  - Support HPA ownership transfer via `scaledobject.keda.sh/transfer-hpa-ownership` and `advanced.horizontalPodAutoscalerConfig.name`; tune HPA behaviors and document a safe migration path.

<sup>Written for commit df0584d74977def54075111a1b8bf35f7f0b3a59. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

