### PR TITLE
fix(sawmills-collector): extend backend drain budget

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -508,7 +508,7 @@ rollout:
     maxUnavailable: null   # defaults to 1 for ≤ 10 replicas, scales proportionally beyond that
     maxSurge: null         # defaults to 2 for ≤ 10 replicas, scales proportionally beyond that
   minReadySeconds: 15
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   main:
     probes:
       liveness:
@@ -529,7 +529,7 @@ rollout:
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
-      duration: 15s
+      duration: 120s
       shutdownReserve: 10s
     preStopSleepSeconds: 15
 ```
@@ -540,7 +540,7 @@ When `loadBalancer.enabled: true`, the chart can protect backend collector rollo
 
 ```yaml
 rollout:
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   main:
     drain:
       enabled: true
@@ -549,7 +549,7 @@ rollout:
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
       serviceExtensions: [health_check, cgroupruntime]
-      duration: 15s
+      duration: 120s
       shutdownReserve: 10s
 ```
 

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -47,6 +47,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[2]
           pattern: "wget.*13137.*/drain.*sleep"
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 150
       - isNotSubset:
           path: spec.template.spec.containers[1].lifecycle
           content:
@@ -65,7 +68,7 @@ tests:
           count: 1
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n'
+          pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 120s\n'
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
@@ -191,9 +194,9 @@ tests:
     set:
       loadBalancer.enabled: true
       rollout.main.drain.enabled: true
-      rollout.main.drain.duration: 50s
+      rollout.main.drain.duration: 140s
       rollout.main.drain.shutdownReserve: 10s
-      rollout.terminationGracePeriodSeconds: 60
+      rollout.terminationGracePeriodSeconds: 150
     asserts:
       - failedTemplate:
-          errorMessage: 'rollout.main.drain.duration (50s) plus rollout.main.drain.shutdownReserve (10s) must be less than rollout.terminationGracePeriodSeconds (60s)'
+          errorMessage: 'rollout.main.drain.duration (140s) plus rollout.main.drain.shutdownReserve (10s) must be less than rollout.terminationGracePeriodSeconds (150s)'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -19,7 +19,7 @@ collectorId: sawmills-collector-id
 # Rollout configuration
 rollout:
   # Global rollout settings
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 150
   minReadySeconds: 15
 
   # Deployment strategy configuration
@@ -108,7 +108,7 @@ rollout:
       # Keep drain.duration + shutdownReserve below
       # rollout.terminationGracePeriodSeconds so the collector still has time
       # to handle SIGTERM after the drain hook returns.
-      duration: 15s
+      duration: 120s
       # Reserve explicit post-drain shutdown time inside the pod termination
       # grace period for collector shutdown and kubelet bookkeeping.
       shutdownReserve: 10s


### PR DESCRIPTION
SAW-7335: Extend backend drain budget

Conservative drain budget for collector LB shutdowns.

- raise the backend drain window to 120s
- keep pod termination grace at 150s so drain completes before kubelet force-kills
- update backend drain tests and README examples to match the new default budget

This PR supersedes the conflicted PR #163, which inherited unrelated history and no longer had a mergeable base against current main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the collector LB backend drain window to 120s and set the pod termination grace period to 150s so draining completes before forced kill. Updates defaults, tests, and README; implements SAW-7335’s drain-budget tuning (raise drain_duration and keep terminationGracePeriodSeconds aligned).

- **Migration**
  - If you override `rollout.main.drain.duration`, `rollout.main.drain.shutdownReserve`, or `rollout.terminationGracePeriodSeconds`, ensure duration + shutdownReserve < grace period (defaults now 120s + 10s < 150s).

<sup>Written for commit 62cc95750d44f278cbc9618b3b91667d9620dc2e. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

