### PR TITLE
helm-charts: Support image digest pinning

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -110,6 +110,15 @@ image:
   digest: sha256:...
 ```
 
+Set `haproxy.image.digest` the same way for the optional HAProxy sidecar:
+
+```yaml
+haproxy:
+  image:
+    repository: public.ecr.aws/docker/library/haproxy
+    digest: sha256:...
+```
+
 ### Proxy Configuration
 
 Customers that require all internet-bound traffic to pass through an HTTP/HTTPS proxy can set the `proxy` block. The chart wires these values into the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables consumed by the collector so TLS sessions still terminate at Sawmills services.
@@ -239,7 +248,10 @@ Enable HAProxy for advanced load balancing:
 ```yaml
 haproxy:
   enabled: true
-  image: public.ecr.aws/docker/library/haproxy:3.1
+  image:
+    repository: public.ecr.aws/docker/library/haproxy
+    tag: "3.1"
+    digest: ""
   securityContext:
     runAsNonRoot: true
     runAsUser: 99

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -100,6 +100,16 @@ quotamgmtprocessor:
   folder_name: SAWMILLS_ORG
 ```
 
+### Pin Images By Digest
+
+Set `image.digest` to render the collector image as `repository@digest` instead of `repository:tag`:
+
+```yaml
+image:
+  repository: public.ecr.aws/s7a5m1b4/sawmills-collector
+  digest: sha256:...
+```
+
 ### Proxy Configuration
 
 Customers that require all internet-bound traffic to pass through an HTTP/HTTPS proxy can set the `proxy` block. The chart wires these values into the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables consumed by the collector so TLS sessions still terminate at Sawmills services.

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -33,6 +33,24 @@ Build the collector image reference. If image.digest is set, pin by digest and i
 {{- end }}
 
 {{/*
+Build the HAProxy image reference. Supports the legacy haproxy.image string and
+the structured haproxy.image.repository/tag/digest format.
+*/}}
+{{- define "sawmills-collector.haproxyImage" -}}
+{{- $image := .Values.haproxy.image -}}
+{{- if kindIs "map" $image -}}
+{{- $repository := default "public.ecr.aws/docker/library/haproxy" $image.repository -}}
+{{- if $image.digest -}}
+{{- printf "%s@%s" $repository $image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repository (default "3.1.15" $image.tag) -}}
+{{- end -}}
+{{- else -}}
+{{- $image -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "sawmills-collector.labels" -}}
@@ -540,7 +558,7 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- fail (printf "haproxy.probes.readiness.type must be one of [http, tcp], got %q" $readinessType) -}}
 {{- end -}}
 - name: haproxy
-  image: {{ $root.Values.haproxy.image }}
+  image: {{ include "sawmills-collector.haproxyImage" $root }}
   securityContext:
     {{- toYaml $securityContext | nindent 4 }}
   {{- if $nativeSidecar }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -22,6 +22,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Build the collector image reference. If image.digest is set, pin by digest and ignore image.tag.
+*/}}
+{{- define "sawmills-collector.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (default "dev" .Values.image.tag) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "sawmills-collector.labels" -}}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
+          image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or $telemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:
@@ -251,7 +251,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
+          image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or .Values.otelConfig.s3path $mainCollectorDrainEnabled }}
           args:

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.kedaScaler.podSecurityContext | nindent 8 }}
       containers:
         - name: otel-scaler
-          image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
+          image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.kedaScaler.imagePullPolicy }}
           ports:
             - name: otlp-receiver

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -118,7 +118,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
+          image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.loadBalancer.otelConfig.s3path }}
           args:
@@ -242,7 +242,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
+          image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or $lbTelemetryOtelS3Path .Values.kedaScaler.enabled }}
           args:

--- a/helm-charts/sawmills-collector/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-collector/tests/image_digest_test.yaml
@@ -71,3 +71,40 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+
+  - it: should render digest instead of tag for haproxy sidecar
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.mapping.http_4318.from: 4318
+      haproxy.mapping.http_4318.to.port: 4318
+      haproxy.mapping.http_4318.to.protocol: TCP
+      haproxy.image.tag: 9.9.9
+      haproxy.image.digest: sha256:cafebabe
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/docker/library/haproxy@sha256:cafebabe
+
+  - it: should preserve legacy full haproxy image strings
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.mapping.http_4318.from: 4318
+      haproxy.mapping.http_4318.to.port: 4318
+      haproxy.mapping.http_4318.to.protocol: TCP
+      haproxy.image: public.ecr.aws/docker/library/haproxy:3.1.15
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/docker/library/haproxy:3.1.15

--- a/helm-charts/sawmills-collector/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-collector/tests/image_digest_test.yaml
@@ -1,0 +1,73 @@
+suite: image digest rendering
+templates:
+  - deployment.yaml
+  - load-balancer.yaml
+  - keda-scaler-deployment.yaml
+tests:
+  - it: should render digest instead of tag for deployment collectors
+    template: deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+
+  - it: should render digest instead of tag for load balancer deployment collectors
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.storage.enabled: false
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+
+  - it: should render digest instead of tag for load balancer statefulset collectors
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.storage.enabled: true
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef
+
+  - it: should render digest instead of tag for keda scaler
+    template: keda-scaler-deployment.yaml
+    values:
+      - ../values.yaml
+    set:
+      kedaScaler.enabled: true
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-collector@sha256:deadbeef

--- a/helm-charts/sawmills-collector/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-collector/tests/image_digest_test.yaml
@@ -10,7 +10,7 @@ tests:
       - ../values.yaml
     set:
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -27,7 +27,7 @@ tests:
       loadBalancer.enabled: true
       loadBalancer.storage.enabled: false
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: kind
@@ -47,7 +47,7 @@ tests:
       loadBalancer.enabled: true
       loadBalancer.storage.enabled: true
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: kind
@@ -66,7 +66,7 @@ tests:
     set:
       kedaScaler.enabled: true
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -618,7 +618,14 @@ otelCollectorConfig: {}
 # HAProxy configuration
 haproxy:
   enabled: false
-  image: public.ecr.aws/docker/library/haproxy:3.1.15
+  # HAProxy image used for the optional load-balancing sidecar.
+  # Legacy full image strings are still accepted, e.g.
+  # image: public.ecr.aws/docker/library/haproxy:3.1.15
+  image:
+    repository: public.ecr.aws/docker/library/haproxy
+    tag: 3.1.15
+    # Optional image digest. When set, the chart renders repository@digest and ignores tag.
+    digest: ""
   securityContext:
     runAsNonRoot: true
     runAsUser: 99

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -222,6 +222,8 @@ image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-collector
   pullPolicy: IfNotPresent
   tag: 1.770.0
+  # Optional image digest. When set, the chart renders repository@digest and ignores tag.
+  digest: ""
 
 # The node selector for the Sawmills collector
 nodeSelector: {}

--- a/helm-charts/sawmills-remote-operator-manual/README.md
+++ b/helm-charts/sawmills-remote-operator-manual/README.md
@@ -111,6 +111,11 @@ Example:
 managedChartsValues:
   sawmills-collector:
     replicaCount: 2
+    image:
+      digest: sha256:...
+    haproxy:
+      image:
+        digest: sha256:...
 
 managedChartsOverrides:
   sawmills-collector:

--- a/helm-charts/sawmills-remote-operator-manual/README.md
+++ b/helm-charts/sawmills-remote-operator-manual/README.md
@@ -34,6 +34,16 @@ It defaults the operator to `SELF_MANAGED=true`.
 `collectorName` is required.
 Any non-default `autoscaler.*` value will fail rendering.
 
+## Pin Images By Digest
+
+Set `image.digest` to render the operator image as `repository@digest` instead of `repository:tag`:
+
+```yaml
+image:
+  repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
+  digest: sha256:...
+```
+
 ## Outbound proxy support
 
 Customers that require all internet-bound traffic to pass through an HTTP/HTTPS proxy can set the `proxy` block. The chart wires these values into the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables consumed by the operator so TLS sessions still terminate at `controller.sawmills.ai`.

--- a/helm-charts/sawmills-remote-operator-manual/templates/_helpers.tpl
+++ b/helm-charts/sawmills-remote-operator-manual/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Build the remote-operator image reference. If image.digest is set, pin by digest and ignore image.tag.
+*/}}
+{{- define "sawmills-remote-operator.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "sawmills-remote-operator.labels" -}}

--- a/helm-charts/sawmills-remote-operator-manual/templates/deployment.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
       - name: remote-operator
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ include "sawmills-remote-operator.image" . }}
         command: [/remote-operator]
         args: [operator]
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
@@ -12,3 +12,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator@sha256:deadbeef
+
+  - it: should pass managed collector and haproxy image digests
+    set:
+      apiKey: test-key
+      collectorName: sawmills-collector
+      managedChartsValues.sawmills-collector.image.digest: sha256:collector
+      managedChartsValues.sawmills-collector.haproxy.image.digest: sha256:haproxy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="MANAGED_CHARTS_VALUES")].value
+          value: '{"sawmills-collector":{"haproxy":{"image":{"digest":"sha256:haproxy"}},"image":{"digest":"sha256:collector"}}}'

--- a/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
@@ -1,0 +1,14 @@
+suite: image digest rendering
+templates:
+  - deployment.yaml
+tests:
+  - it: should render digest instead of tag
+    set:
+      apiKey: test-key
+      collectorName: sawmills-collector
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator@sha256:deadbeef

--- a/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/tests/image_digest_test.yaml
@@ -7,7 +7,7 @@ tests:
       apiKey: test-key
       collectorName: sawmills-collector
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/helm-charts/sawmills-remote-operator-manual/values.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/values.yaml
@@ -171,6 +171,11 @@ tolerations: []
 #     replicaCount: 3
 #     image:
 #       tag: latest
+#       digest: sha256:...
+#     haproxy:
+#       image:
+#         tag: 3.1.15
+#         digest: sha256:...
 # Prefer managedChartsValues; managedCharts is kept as a backward-compatible alias.
 managedChartsValues: {}
 

--- a/helm-charts/sawmills-remote-operator-manual/values.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/values.yaml
@@ -39,6 +39,8 @@ image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
   tag: 0.247.0 # Sawmills Remote Operator image tag
+  # Optional image digest. When set, the chart renders repository@digest and ignores tag.
+  digest: ""
 
 # The address of the Sawmills operator
 operatorAddress: https://controller.sawmills.ai

--- a/helm-charts/sawmills-remote-operator/README.md
+++ b/helm-charts/sawmills-remote-operator/README.md
@@ -88,6 +88,11 @@ Example:
 managedChartsValues:
   sawmills-collector:
     replicaCount: 2
+    image:
+      digest: sha256:...
+    haproxy:
+      image:
+        digest: sha256:...
 
 managedChartsOverrides:
   sawmills-collector:

--- a/helm-charts/sawmills-remote-operator/README.md
+++ b/helm-charts/sawmills-remote-operator/README.md
@@ -2,6 +2,16 @@
 
 This chart deploys the Sawmills Remote Operator, which maintains a bidirectional gRPC session with `controller.sawmills.ai` and optionally forwards Prometheus remote-write metrics. Use the values below to configure outbound connectivity.
 
+## Pin Images By Digest
+
+Set `image.digest` to render the operator image as `repository@digest` instead of `repository:tag`:
+
+```yaml
+image:
+  repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
+  digest: sha256:...
+```
+
 ## Outbound proxy support
 
 Customers that require all internet-bound traffic to pass through an HTTP/HTTPS proxy can set the new `proxy` block. The chart wires these values into the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables consumed by the operator so TLS sessions still terminate at `controller.sawmills.ai`.

--- a/helm-charts/sawmills-remote-operator/templates/_helpers.tpl
+++ b/helm-charts/sawmills-remote-operator/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Build the remote-operator image reference. If image.digest is set, pin by digest and ignore image.tag.
+*/}}
+{{- define "sawmills-remote-operator.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "sawmills-remote-operator.labels" -}}

--- a/helm-charts/sawmills-remote-operator/templates/deployment.yaml
+++ b/helm-charts/sawmills-remote-operator/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: remote-operator
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ include "sawmills-remote-operator.image" . }}
         command: [/remote-operator]
         args: [operator]
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
@@ -12,3 +12,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator@sha256:deadbeef
+
+  - it: should pass managed collector and haproxy image digests
+    set:
+      apiKey: test-key
+      collectorName: sawmills-collector
+      managedChartsValues.sawmills-collector.image.digest: sha256:collector
+      managedChartsValues.sawmills-collector.haproxy.image.digest: sha256:haproxy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="MANAGED_CHARTS_VALUES")].value
+          value: '{"sawmills-collector":{"haproxy":{"image":{"digest":"sha256:haproxy"}},"image":{"digest":"sha256:collector"}}}'

--- a/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
@@ -1,0 +1,14 @@
+suite: image digest rendering
+templates:
+  - deployment.yaml
+tests:
+  - it: should render digest instead of tag
+    set:
+      apiKey: test-key
+      collectorName: sawmills-collector
+      image.tag: 9.9.9
+      image.digest: "sha256:deadbeef"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator@sha256:deadbeef

--- a/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
@@ -7,7 +7,7 @@ tests:
       apiKey: test-key
       collectorName: sawmills-collector
       image.tag: 9.9.9
-      image.digest: "sha256:deadbeef"
+      image.digest: sha256:deadbeef
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -157,6 +157,11 @@ tolerations: []
 #     replicaCount: 3
 #     image:
 #       tag: latest
+#       digest: sha256:...
+#     haproxy:
+#       image:
+#         tag: 3.1.15
+#         digest: sha256:...
 # Prefer managedChartsValues; managedCharts is kept as a backward-compatible alias.
 managedChartsValues: {}
 

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -35,6 +35,8 @@ image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
   tag: 0.247.0 # Sawmills Remote Operator image tag
+  # Optional image digest. When set, the chart renders repository@digest and ignores tag.
+  digest: ""
 
 # The address of the Sawmills operator
 operatorAddress: https://controller.sawmills.ai


### PR DESCRIPTION
Allows customer-managed installs to pin chart-owned images by digest instead of tag.

Description
- Adds `image.digest` to collector, remote-operator, and manual operator charts.
- Renders `repository@digest` when set while preserving tag fallback.
- Adds Helm unittest coverage for collector, load balancer, KEDA scaler, and operator images.

Verification
- `helm lint` for all three charts
- `./tests/run-tests.sh` for collector, remote-operator, and manual operator
- Digest render smoke checks for all touched render paths
- `trunk check`
- `git diff --check`

Refs: SAW-7364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `image.digest` configuration option to Helm charts, enabling image pinning by digest (`repository@digest`) instead of tag across sawmills-collector and sawmills-remote-operator charts.

* **Documentation**
  * Updated Helm chart READMEs with guidance on configuring image digest pinning.

* **Tests**
  * Added tests verifying image digest rendering functionality across all affected Helm charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->