### PR TITLE
refactor(sawmills-collector): simplify runtime config wiring

### DIFF
--- a/.github/workflows/check-codeowners.yml
+++ b/.github/workflows/check-codeowners.yml
@@ -12,8 +12,11 @@ jobs:
           fetch-depth: 0
       - name: install yq
         run: |
-          sudo curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+          YQ_VERSION=v4.53.2
+          YQ_SHA256=d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum --check -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           yq --version
       - name: generate CODEOWNERS
         run: |

--- a/.github/workflows/check-codeowners.yml
+++ b/.github/workflows/check-codeowners.yml
@@ -12,7 +12,9 @@ jobs:
           fetch-depth: 0
       - name: install yq
         run: |
-          sudo snap install yq
+          sudo curl -fsSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
       - name: generate CODEOWNERS
         run: |
           ./scripts/check-codeowners.sh > .github/CODEOWNERS

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -29,10 +29,10 @@ lint:
     - shfmt@3.6.0
     - golangci-lint2@2.6.1
     - taplo@0.10.0
-    - bandit@1.8.6
-    - black@25.11.0
-    - isort@7.0.0
-    - ruff@0.14.4
+    - bandit@1.9.4
+    - black@26.3.1
+    - isort@8.0.1
+    - ruff@0.15.12
     - buf-breaking@1.59.0
     - gitleaks@8.29.0
     - goimports@0.9.1
@@ -45,16 +45,16 @@ lint:
     - actionlint@1.7.8
     - buf-format@1.59.0
     - buf-lint@1.59.0
-    - checkov@3.2.492
+    - checkov@3.2.526
     - gofumpt@0.7.0
     - golines@0.13.0
     - osv-scanner@2.2.4
-    - yamllint@1.37.1
+    - yamllint@1.38.0
     - git-diff-check
-    - markdownlint@0.45.0
-    - prettier@3.6.2
+    - markdownlint@0.48.0
+    - prettier@3.8.3
     - trufflehog@3.90.13
-    - semgrep@1.142.1
+    - semgrep@1.161.0
   ignore:
     - linters: [prettier]
       paths:

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -94,12 +94,14 @@ prometheusremotewrite:
 collector_gateway:
   endpoint: https://ingress.sawmills.ai
 
-# Runtime folder prefix used by generated remote collector configs
+# Runtime values used by generated remote collector configs
 collectorConfig:
   folderName: SAWMILLS_ORG
+  s3Bucket: sawmills-plat-ue1-prod-quotas
 
-# Quota storage bucket plus legacy folder alias for generated values
+# Legacy aliases for generated values that have not migrated yet
 quotamgmtprocessor:
+  # Legacy alias for collectorConfig.s3Bucket
   s3_bucket: sawmills-plat-ue1-prod-quotas
   # Legacy alias for collectorConfig.folderName
   folder_name: SAWMILLS_ORG
@@ -613,9 +615,7 @@ collector_gateway:
 
 collectorConfig:
   folderName: MY_ORG
-
-quotamgmtprocessor:
-  s3_bucket: my-bucket
+  s3Bucket: my-bucket
 ```
 
 ### Production Configuration

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -94,9 +94,14 @@ prometheusremotewrite:
 collector_gateway:
   endpoint: https://ingress.sawmills.ai
 
-# Quota Management Processor
+# Runtime folder prefix used by generated remote collector configs
+collectorConfig:
+  folderName: SAWMILLS_ORG
+
+# Quota storage bucket plus legacy folder alias for generated values
 quotamgmtprocessor:
   s3_bucket: sawmills-plat-ue1-prod-quotas
+  # Legacy alias for collectorConfig.folderName
   folder_name: SAWMILLS_ORG
 ```
 
@@ -584,9 +589,11 @@ prometheusremotewrite:
 collector_gateway:
   endpoint: https://ingress.sawmills.ai
 
+collectorConfig:
+  folderName: MY_ORG
+
 quotamgmtprocessor:
   s3_bucket: my-bucket
-  folder_name: MY_ORG
 ```
 
 ### Production Configuration

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -145,11 +145,29 @@ is kept as a backward-compatible alias because collectors-service still emits it
 {{- end -}}
 
 {{/*
+Resolve the runtime S3 bucket injected as S3_BUCKET.
+collectorConfig.s3Bucket is the clear public value; quotamgmtprocessor.s3_bucket
+is kept as a backward-compatible alias because collectors-service still emits it.
+*/}}
+{{- define "sawmills-collector.s3Bucket" -}}
+{{- $collectorConfig := default dict .Values.collectorConfig -}}
+{{- $s3Bucket := "" -}}
+{{- if and (kindIs "map" $collectorConfig) (hasKey $collectorConfig "s3Bucket") -}}
+{{- $s3Bucket = (default "" (get $collectorConfig "s3Bucket") | toString) -}}
+{{- end -}}
+{{- if $s3Bucket -}}
+{{- $s3Bucket -}}
+{{- else -}}
+{{- $qmp := default dict .Values.quotamgmtprocessor -}}
+{{- default "" $qmp.s3_bucket -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common runtime environment used by collector containers that load remote
 pipeline configs referencing ${env:FOLDER_NAME} and ${env:S3_BUCKET}.
 */}}
 {{- define "sawmills-collector.runtimeConfigEnv" -}}
-{{- $qmp := default dict .Values.quotamgmtprocessor -}}
 - name: MY_POD_NAME
   valueFrom:
     fieldRef:
@@ -161,7 +179,7 @@ pipeline configs referencing ${env:FOLDER_NAME} and ${env:S3_BUCKET}.
 - name: FOLDER_NAME
   value: {{ include "sawmills-collector.folderName" . | quote }}
 - name: S3_BUCKET
-  value: {{ default "" $qmp.s3_bucket | quote }}
+  value: {{ include "sawmills-collector.s3Bucket" . | quote }}
 - name: COLLECTOR_NAME
   value: {{ .Values.collectorName | quote }}
 {{- end -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -97,6 +97,47 @@ key: api-key
 {{- end -}}
 
 {{/*
+Resolve the runtime folder name injected as FOLDER_NAME.
+collectorConfig.folderName is the clear public value; quotamgmtprocessor.folder_name
+is kept as a backward-compatible alias because collectors-service still emits it.
+*/}}
+{{- define "sawmills-collector.folderName" -}}
+{{- $collectorConfig := default dict .Values.collectorConfig -}}
+{{- $folderName := "" -}}
+{{- if and (kindIs "map" $collectorConfig) (hasKey $collectorConfig "folderName") -}}
+{{- $folderName = (default "" (get $collectorConfig "folderName") | toString) -}}
+{{- end -}}
+{{- if $folderName -}}
+{{- $folderName -}}
+{{- else -}}
+{{- $qmp := default dict .Values.quotamgmtprocessor -}}
+{{- default "" $qmp.folder_name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common runtime environment used by collector containers that load remote
+pipeline configs referencing ${env:FOLDER_NAME} and ${env:S3_BUCKET}.
+*/}}
+{{- define "sawmills-collector.runtimeConfigEnv" -}}
+{{- $qmp := default dict .Values.quotamgmtprocessor -}}
+- name: MY_POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: MY_POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: FOLDER_NAME
+  value: {{ include "sawmills-collector.folderName" . | quote }}
+- name: S3_BUCKET
+  value: {{ default "" $qmp.s3_bucket | quote }}
+- name: COLLECTOR_NAME
+  value: {{ .Values.collectorName | quote }}
+{{- end -}}
+
+{{/*
 Generate external labels transform processor configuration
 */}}
 {{- define "sawmills-collector.externalLabelsProcessor" -}}
@@ -476,7 +517,8 @@ Validate load balancer queue compression settings for direct otelCollectorConfig
 Fail fast for known invalid combinations.
 */}}
 {{- define "sawmills-collector.validateLoadBalancerQueueCompression" -}}
-{{- if and .Values.loadBalancer.enabled (not .Values.loadBalancer.otelConfig.s3path) -}}
+{{- $lbOtelConfig := default dict .Values.loadBalancer.otelConfig -}}
+{{- if and .Values.loadBalancer.enabled (not (default "" $lbOtelConfig.s3path)) -}}
 {{- $cfg := default dict .Values.loadBalancer.otelCollectorConfig -}}
 {{- $exporters := default dict (get $cfg "exporters") -}}
 {{- range $name, $exporter := $exporters -}}

--- a/helm-charts/sawmills-collector/templates/configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- $otelConfig := default dict .Values.otelConfig }}
+{{- if not (default "" $otelConfig.s3path) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +12,4 @@ data:
     {{- if .Values.otelCollectorConfig }}
       {{- toYaml .Values.otelCollectorConfig | nindent 6 }}
     {{- end }}
+{{- end }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -1,6 +1,9 @@
 {{- $mainDrain := .Values.rollout.main.drain | default dict }}
 {{- $mainStartupProbe := .Values.rollout.main.probes.startup | default dict }}
 {{- $mainCollectorDrainEnabled := and .Values.loadBalancer.enabled ($mainDrain.enabled | default false) }}
+{{- $mainOtelConfig := default dict .Values.otelConfig }}
+{{- $mainOtelS3Path := default "" $mainOtelConfig.s3path }}
+{{- $mainOtelEncryptionKey := default "" $mainOtelConfig.encryptionKey }}
 {{- $telemetryOtelConfig := default (dict) .Values.telemetryOtelConfig }}
 {{- $telemetryOtelS3Path := default "" $telemetryOtelConfig.s3path }}
 {{- $telemetryOtelEncryptionKey := default "" $telemetryOtelConfig.encryptionKey }}
@@ -229,9 +232,11 @@ spec:
               {{- toYaml .Values.telemetry.resources.limits | nindent 14 }}
             {{- end }}
           volumeMounts:
+            {{- if not $telemetryOtelS3Path }}
             - name: sawmills-telemetry-config
               mountPath: /etc/otel/config.yaml
               subPath: telemetry-config.yaml
+            {{- end }}
             {{- if .Values.kedaScaler.enabled }}
             - name: sawmills-telemetry-keda-config
               mountPath: /etc/otel/keda.yaml
@@ -253,10 +258,10 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.otelConfig.s3path $mainCollectorDrainEnabled }}
+          {{- if or $mainOtelS3Path $mainCollectorDrainEnabled }}
           args:
-            {{- if .Values.otelConfig.s3path }}
-            - "--config={{ .Values.otelConfig.s3path }}{{- if .Values.otelConfig.encryptionKey }}@{{ .Values.otelConfig.encryptionKey }}{{- end }}"
+            {{- if $mainOtelS3Path }}
+            - "--config={{ $mainOtelS3Path }}{{- if $mainOtelEncryptionKey }}@{{ $mainOtelEncryptionKey }}{{- end }}"
             {{- else }}
             - "--config=file:/etc/otel/config.yaml"
             {{- end }}
@@ -265,23 +270,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: FOLDER_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sawmills-collector.fullname" . }}-secret
-                  key: folder-name
-            - name: S3_BUCKET
-              value: {{ .Values.quotamgmtprocessor.s3_bucket }}
-            - name: COLLECTOR_NAME
-              value: {{ .Values.collectorName }}
+            {{- include "sawmills-collector.runtimeConfigEnv" . | nindent 12 }}
             - name: AUTH_KEY
               valueFrom:
                 secretKeyRef:
@@ -353,7 +342,7 @@ spec:
               {{- toYaml .Values.resources.limits | nindent 14 }}
             {{- end }}
           volumeMounts:
-          {{- if not .Values.otelConfig.s3path }}
+          {{- if not $mainOtelS3Path }}
             - name: sawmills-collector-config
               mountPath: /etc/otel/config.yaml
               subPath: config.yaml
@@ -383,7 +372,7 @@ spec:
             secretName: {{ include "sawmills-collector.haproxyTlsSecretName" . }}
         {{- end }}
         {{- end }}
-        {{- if not .Values.otelConfig.s3path }}
+        {{- if not $mainOtelS3Path }}
         - name: sawmills-collector-config
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-config
@@ -399,12 +388,14 @@ spec:
               - key: config.yaml
                 path: config.yaml
         {{- end }}
+        {{- if not $telemetryOtelS3Path }}
         - name: sawmills-telemetry-config
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-telemetry-config
             items:
               - key: telemetry-config.yaml
                 path: telemetry-config.yaml
+        {{- end }}
         {{- if .Values.kedaScaler.enabled }}
         - name: sawmills-telemetry-keda-config
           configMap:

--- a/helm-charts/sawmills-collector/templates/load-balancer-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-configmap.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.loadBalancer.enabled (not .Values.loadBalancer.otelConfig.s3path) }}
+{{- $lbOtelConfig := default dict .Values.loadBalancer.otelConfig }}
+{{- if and .Values.loadBalancer.enabled (not (default "" $lbOtelConfig.s3path)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/sawmills-collector/templates/load-balancer-telemetry-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-telemetry-configmap.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.loadBalancer.enabled }}
+{{- $lbTelemetryOtelConfig := default dict .Values.loadBalancer.telemetryOtelConfig }}
+{{- if and .Values.loadBalancer.enabled (not (default "" $lbTelemetryOtelConfig.s3path)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +11,5 @@ data:
   telemetry-config.yaml: |
     {{- if .Values.telemetryConfig }}
       {{- include "sawmills-collector.loadBalancerTelemetryConfig" . | nindent 6 }}
-    {{- end }} 
+    {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.loadBalancer.enabled }}
 {{- include "sawmills-collector.validateLoadBalancerQueueCompression" . }}
+{{- $lbOtelConfig := default dict .Values.loadBalancer.otelConfig }}
+{{- $lbOtelS3Path := default "" $lbOtelConfig.s3path }}
+{{- $lbOtelEncryptionKey := default "" $lbOtelConfig.encryptionKey }}
 {{- $lbTelemetryOtelConfig := default (dict) .Values.loadBalancer.telemetryOtelConfig }}
 {{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
 {{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
@@ -120,28 +123,12 @@ spec:
                 - ALL
           image: {{ .Values.image.repository }}:{{ default "dev" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.loadBalancer.otelConfig.s3path }}
+          {{- if $lbOtelS3Path }}
           args:
-            - "--config={{ .Values.loadBalancer.otelConfig.s3path }}{{- if .Values.loadBalancer.otelConfig.encryptionKey }}@{{ .Values.loadBalancer.otelConfig.encryptionKey }}{{- end }}"
+            - "--config={{ $lbOtelS3Path }}{{- if $lbOtelEncryptionKey }}@{{ $lbOtelEncryptionKey }}{{- end }}"
           {{- end }}
           env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: FOLDER_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "sawmills-collector.fullname" . }}-secret
-                  key: folder-name
-            - name: S3_BUCKET
-              value: {{ .Values.quotamgmtprocessor.s3_bucket }}
-            - name: COLLECTOR_NAME
-              value: {{ .Values.collectorName }}
+            {{- include "sawmills-collector.runtimeConfigEnv" . | nindent 12 }}
             {{- if and (not .Values.loadBalancer.resources.disableLimits) .Values.loadBalancer.resources.limits .Values.loadBalancer.resources.limits.memory }}
             {{- $memLimit := .Values.loadBalancer.resources.limits.memory | toString }}
             - name: GOMEMLIMIT
@@ -219,7 +206,7 @@ spec:
               {{- toYaml .Values.loadBalancer.resources.limits | nindent 14 }}
             {{- end }}
           volumeMounts:
-          {{- if not .Values.loadBalancer.otelConfig.s3path }}
+          {{- if not $lbOtelS3Path }}
             - name: sawmills-collector-config-load-balancer
               mountPath: /etc/otel/config.yaml
               subPath: config.yaml
@@ -333,9 +320,11 @@ spec:
               {{- toYaml .Values.telemetry.resources.limits | nindent 14 }}
             {{- end }}
           volumeMounts:
+            {{- if not $lbTelemetryOtelS3Path }}
             - name: sawmills-load-balancer-telemetry-config
               mountPath: /etc/otel/config.yaml
               subPath: telemetry-config.yaml
+            {{- end }}
             {{- if .Values.kedaScaler.enabled }}
             - name: sawmills-telemetry-keda-config
               mountPath: /etc/otel/keda.yaml
@@ -354,7 +343,7 @@ spec:
           secret:
             secretName: {{ include "sawmills-collector.haproxyTlsSecretName" . }}
         {{- end }}
-        {{- if not .Values.loadBalancer.otelConfig.s3path }}
+        {{- if not $lbOtelS3Path }}
         - name: sawmills-collector-config-load-balancer
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-load-balancer-config
@@ -362,12 +351,14 @@ spec:
               - key: config.yaml
                 path: config.yaml
         {{- end }}
+        {{- if not $lbTelemetryOtelS3Path }}
         - name: sawmills-load-balancer-telemetry-config
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-load-balancer-telemetry-config
             items:
               - key: telemetry-config.yaml
                 path: telemetry-config.yaml
+        {{- end }}
         {{- if .Values.kedaScaler.enabled }}
         - name: sawmills-telemetry-keda-config
           configMap:

--- a/helm-charts/sawmills-collector/templates/secret.yaml
+++ b/helm-charts/sawmills-collector/templates/secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "sawmills-collector.fullname" . }}-secret
-type: Opaque
-data:
-  folder-name: {{ .Values.quotamgmtprocessor.folder_name | b64enc }}

--- a/helm-charts/sawmills-collector/templates/telemetry-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/telemetry-configmap.yaml
@@ -1,3 +1,5 @@
+{{- $telemetryOtelConfig := default dict .Values.telemetryOtelConfig }}
+{{- if not (default "" $telemetryOtelConfig.s3path) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,4 +11,5 @@ data:
   telemetry-config.yaml: |
     {{- if .Values.telemetryConfig }}
       {{- include "sawmills-collector.telemetryConfig" . | nindent 6 }}
-    {{- end }} 
+    {{- end }}
+{{- end }}

--- a/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
+++ b/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
@@ -1,0 +1,122 @@
+suite: runtime config simplification
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+  - templates/load-balancer.yaml
+  - templates/load-balancer-telemetry-configmap.yaml
+  - templates/telemetry-configmap.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders FOLDER_NAME directly from legacy quotamgmtprocessor folder name
+    template: templates/deployment.yaml
+    set:
+      quotamgmtprocessor.folder_name: legacy-folder
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: FOLDER_NAME
+            value: legacy-folder
+
+  - it: prefers collectorConfig folderName over legacy quotamgmtprocessor folder name
+    template: templates/deployment.yaml
+    set:
+      collectorConfig.folderName: clear-folder
+      quotamgmtprocessor.folder_name: legacy-folder
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: FOLDER_NAME
+            value: clear-folder
+
+  - it: falls back to legacy folder name when collectorConfig folderName is empty
+    template: templates/deployment.yaml
+    set:
+      collectorConfig.folderName: ""
+      quotamgmtprocessor.folder_name: legacy-folder
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: FOLDER_NAME
+            value: legacy-folder
+
+  - it: renders load balancer FOLDER_NAME directly from the same helper
+    template: templates/load-balancer.yaml
+    set:
+      collectorConfig.folderName: lb-folder
+      loadBalancer.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: FOLDER_NAME
+            value: lb-folder
+
+  - it: does not render main direct configmap when main collector uses S3 config
+    template: templates/configmap.yaml
+    set:
+      otelConfig.s3path: s3://example/main-config
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders main direct configmap when main collector does not use S3 config
+    template: templates/configmap.yaml
+    set:
+      otelConfig.s3path: ""
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: does not render telemetry direct configmap when telemetry collector uses S3 config
+    template: templates/telemetry-configmap.yaml
+    set:
+      telemetryOtelConfig.s3path: s3://example/telemetry-config
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders telemetry direct configmap when telemetry collector does not use S3 config
+    template: templates/telemetry-configmap.yaml
+    set:
+      telemetryOtelConfig.s3path: ""
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: does not mount telemetry direct config when telemetry collector uses S3 config
+    template: templates/deployment.yaml
+    set:
+      telemetryOtelConfig.s3path: s3://example/telemetry-config
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].volumeMounts
+          content:
+            name: sawmills-telemetry-config
+            mountPath: /etc/otel/config.yaml
+            subPath: telemetry-config.yaml
+
+  - it: does not render load balancer telemetry direct configmap when LB telemetry uses S3 config
+    template: templates/load-balancer-telemetry-configmap.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.telemetryOtelConfig.s3path: s3://example/lb-telemetry-config
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not mount load balancer telemetry direct config when LB telemetry uses S3 config
+    template: templates/load-balancer.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.telemetryOtelConfig.s3path: s3://example/lb-telemetry-config
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].volumeMounts
+          content:
+            name: sawmills-load-balancer-telemetry-config
+            mountPath: /etc/otel/config.yaml
+            subPath: telemetry-config.yaml

--- a/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
+++ b/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
@@ -19,6 +19,17 @@ tests:
             name: FOLDER_NAME
             value: legacy-folder
 
+  - it: renders S3_BUCKET directly from legacy quotamgmtprocessor bucket
+    template: templates/deployment.yaml
+    set:
+      quotamgmtprocessor.s3_bucket: legacy-bucket
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: S3_BUCKET
+            value: legacy-bucket
+
   - it: prefers collectorConfig folderName over legacy quotamgmtprocessor folder name
     template: templates/deployment.yaml
     set:
@@ -30,6 +41,18 @@ tests:
           content:
             name: FOLDER_NAME
             value: clear-folder
+
+  - it: prefers collectorConfig s3Bucket over legacy quotamgmtprocessor bucket
+    template: templates/deployment.yaml
+    set:
+      collectorConfig.s3Bucket: clear-bucket
+      quotamgmtprocessor.s3_bucket: legacy-bucket
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: S3_BUCKET
+            value: clear-bucket
 
   - it: falls back to legacy folder name when collectorConfig folderName is empty
     template: templates/deployment.yaml
@@ -43,6 +66,18 @@ tests:
             name: FOLDER_NAME
             value: legacy-folder
 
+  - it: falls back to legacy bucket when collectorConfig s3Bucket is empty
+    template: templates/deployment.yaml
+    set:
+      collectorConfig.s3Bucket: ""
+      quotamgmtprocessor.s3_bucket: legacy-bucket
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: S3_BUCKET
+            value: legacy-bucket
+
   - it: renders load balancer FOLDER_NAME directly from the same helper
     template: templates/load-balancer.yaml
     set:
@@ -54,6 +89,18 @@ tests:
           content:
             name: FOLDER_NAME
             value: lb-folder
+
+  - it: renders load balancer S3_BUCKET directly from the same helper
+    template: templates/load-balancer.yaml
+    set:
+      collectorConfig.s3Bucket: lb-bucket
+      loadBalancer.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: S3_BUCKET
+            value: lb-bucket
 
   - it: does not render main direct configmap when main collector uses S3 config
     template: templates/configmap.yaml

--- a/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
+++ b/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
@@ -120,6 +120,20 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: does not mount main direct config when main collector uses S3 config
+    template: templates/deployment.yaml
+    set:
+      otelConfig.s3path: s3://example/main-config
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: sawmills-collector-config
+            mountPath: /etc/otel/config.yaml
+            subPath: config.yaml
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="sawmills-collector-config")]
+
   - it: renders main direct configmap when main collector does not use S3 config
     template: templates/configmap.yaml
     set:

--- a/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
+++ b/helm-charts/sawmills-collector/tests/runtime_config_simplification_test.yaml
@@ -22,6 +22,7 @@ tests:
   - it: renders S3_BUCKET directly from legacy quotamgmtprocessor bucket
     template: templates/deployment.yaml
     set:
+      collectorConfig.s3Bucket: ""
       quotamgmtprocessor.s3_bucket: legacy-bucket
     asserts:
       - contains:
@@ -29,6 +30,15 @@ tests:
           content:
             name: S3_BUCKET
             value: legacy-bucket
+
+  - it: defaults S3_BUCKET to the Sawmills quota bucket
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: S3_BUCKET
+            value: sawmills-plat-ue1-prod-quotas
 
   - it: prefers collectorConfig folderName over legacy quotamgmtprocessor folder name
     template: templates/deployment.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -162,8 +162,15 @@ podDisruptionBudget:
 
 
 # Configuration for the Sawmills collector
+collectorConfig:
+  # Runtime folder prefix injected as FOLDER_NAME for remote collector configs.
+  # Defaults to quotamgmtprocessor.folder_name for backward compatibility.
+  folderName: ""
+
 quotamgmtprocessor:
   s3_bucket: sawmills-plat-ue1-prod-quotas
+  # Deprecated: use collectorConfig.folderName. Kept for collectors-service and
+  # remote-operator compatibility while generated values are migrated.
   folder_name: SAWMILLS_ORG
 
 # Configure the shared API secret used by the collector for authentication

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -167,8 +167,8 @@ collectorConfig:
   # Defaults to quotamgmtprocessor.folder_name for backward compatibility.
   folderName: ""
   # Runtime S3 bucket injected as S3_BUCKET for remote collector configs.
-  # Defaults to quotamgmtprocessor.s3_bucket for backward compatibility.
-  s3Bucket: ""
+  # Empty values fall back to quotamgmtprocessor.s3_bucket for backward compatibility.
+  s3Bucket: sawmills-plat-ue1-prod-quotas
 
 quotamgmtprocessor:
   # Deprecated: use collectorConfig.s3Bucket. Kept for collectors-service and

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -167,8 +167,8 @@ collectorConfig:
   # Defaults to quotamgmtprocessor.folder_name for backward compatibility.
   folderName: ""
   # Runtime S3 bucket injected as S3_BUCKET for remote collector configs.
-  # Empty values fall back to quotamgmtprocessor.s3_bucket for backward compatibility.
-  s3Bucket: sawmills-plat-ue1-prod-quotas
+  # Defaults to quotamgmtprocessor.s3_bucket for backward compatibility.
+  s3Bucket: ""
 
 quotamgmtprocessor:
   # Deprecated: use collectorConfig.s3Bucket. Kept for collectors-service and

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -166,8 +166,13 @@ collectorConfig:
   # Runtime folder prefix injected as FOLDER_NAME for remote collector configs.
   # Defaults to quotamgmtprocessor.folder_name for backward compatibility.
   folderName: ""
+  # Runtime S3 bucket injected as S3_BUCKET for remote collector configs.
+  # Defaults to quotamgmtprocessor.s3_bucket for backward compatibility.
+  s3Bucket: ""
 
 quotamgmtprocessor:
+  # Deprecated: use collectorConfig.s3Bucket. Kept for collectors-service and
+  # remote-operator compatibility while generated values are migrated.
   s3_bucket: sawmills-plat-ue1-prod-quotas
   # Deprecated: use collectorConfig.folderName. Kept for collectors-service and
   # remote-operator compatibility while generated values are migrated.


### PR DESCRIPTION
## Summary

Simplify sawmills-collector runtime config wiring while keeping generated legacy values backward compatible.

## Changes Made

* [ ] Feature addition
* [ ] Bug fix
* [x] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

- Add `collectorConfig.folderName` as the clearer FOLDER_NAME source, with `quotamgmtprocessor.folder_name` retained as fallback.
- Remove the chart-created folder-name Secret and inject runtime config env vars directly from values.
- Skip direct-config ConfigMaps and mounts when the main or telemetry collector loads config from S3.

## Version Impact

**Add one of these labelss to this PR:**

* `version:patch` - Bug fixes, small improvements (2.1.0 -> 2.1.1)
* `version:minor` - New features, backwards compatible (2.1.0 -> 2.2.0)
* `version:major` - Breaking changes (2.1.0 -> 3.0.0)

> This PR should use `version:patch`.

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation (`helm install --dry-run`)
* [ ] Deployed to test environment
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
helm unittest helm-charts/sawmills-collector -f 'tests/runtime_config_simplification_test.yaml'
cd helm-charts/sawmills-collector && ./tests/run-tests.sh
helm lint helm-charts/sawmills-collector
helm template test helm-charts/sawmills-collector --set haproxy.enabled=true
helm template test helm-charts/sawmills-collector --set haproxy.enabled=true --set haproxy.tls.secretName=test
helm template test helm-charts/sawmills-collector --set keda.enabled=true
helm template test helm-charts/sawmills-collector --set mode=daemonSet
helm template test helm-charts/sawmills-collector --set loadBalancer.enabled=true
helm template test helm-charts/sawmills-collector --set telemetryOtelConfig=null --set loadBalancer.telemetryOtelConfig=null --set loadBalancer.otelConfig=null --set loadBalancer.enabled=true
helm template sawmills-collector helm-charts/sawmills-collector --namespace sawmills-cb -f /Users/amirjakoby/Code/helm-charts/sawmills-cb-values.yaml
trunk check
git diff --check
```

**Test environments:**

* [x] Local development
* [ ] Staging environment
* [x] Customer test environment

**Results:**

* Expected: S3-backed configs skip unused direct ConfigMaps/mounts while legacy folder values still populate FOLDER_NAME.
* Actual: Main and LB collectors render direct FOLDER_NAME/S3_BUCKET/COLLECTOR_NAME env vars; no chart-created folder-name Secret or direct-config ConfigMaps render for the sawmills-cb S3-backed values.

## Breaking Changes

* [x] No breaking changes
* [ ] Contains breaking changes (describe below)

**Breaking Change Details:**

* **What breaks:** Nothing expected. `quotamgmtprocessor.folder_name` remains supported.
* **Migration path:** Generated values can move to `collectorConfig.folderName` when ready.
* **Version compatibility:** Backward compatible with existing generated values.

## Impact Assessment

* **Who is affected:** sawmills-collector chart users.
* **What systems are affected:** Collector pod rendering only.
* **Rollback plan:** Revert this commit or pin the previous collector chart release.

## Documentation Updated

* [x] Chart README.md updated
* [x] Configuration examples added/updated
* [x] Inline comments added for complex logic
* [ ] CHANGELOG.md updated
* [ ] Not applicable (no documentation changes needed)

## Additional Notes

The livetail and hot-reload ConfigMaps intentionally remain because they are remote patch targets.

***

## Checklist

* [x] I have read the contribution guidelines
* [x] I have tested my changes thoroughly
* [x] I have updated documentation as needed
* [x] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* [x] I have tagged @sawmills/engineers for review
* [x] I have provided clear commit messages

***

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the `sawmills-collector` Helm chart runtime config and makes S3-backed configs first-class. Adds `collectorConfig.folderName` and `collectorConfig.s3Bucket` (defaults to the Sawmills quota bucket), removes the folder-name Secret, injects env vars directly, and skips ConfigMaps/mounts when configs come from S3.

- **Refactors**
  - Introduces `sawmills-collector.folderName`/`sawmills-collector.s3Bucket` helpers; prefer `collectorConfig.*`, fall back to `quotamgmtprocessor.*`.
  - Adds shared runtime env block (`FOLDER_NAME`, `S3_BUCKET`, `COLLECTOR_NAME`, pod name/IP) for main and LB collectors; removes `secret.yaml`.
  - Uses nil-safe checks and `default` dicts; renders ConfigMaps/mounts only when S3 config is unset (main, telemetry, and load balancer); supports `encryptionKey` in args.
  - Updates README/values and expands helm-unittest to cover S3 suppression, env helpers, and legacy fallbacks.

- **Bug Fixes**
  - Preserve legacy `quotamgmtprocessor.s3_bucket` override when `collectorConfig.s3Bucket` is empty.
  - Keep a default runtime S3 bucket when unset (`collectorConfig.s3Bucket` defaults to `sawmills-plat-ue1-prod-quotas`).
  - CI: install `yq` via curl and verify checksum to avoid `snap` dependency; upgrade Trunk linters.

<sup>Written for commit ff6b99965f4fd656ce15771ab91069211fffae47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `collectorConfig.folderName` configuration option for runtime folder naming.
  * Introduced support for remote OpenTelemetry configuration via S3 paths.

* **Documentation**
  * Updated configuration examples and added migration guidance for legacy settings.
  * Backward compatibility maintained with fallback to previous configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->