### PR TITLE
chore(remote-operator): bump chart image to 0.255.0

### DIFF
--- a/helm-charts/sawmills-remote-operator-manual/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/Chart.yaml
@@ -21,4 +21,4 @@ version: "0.1.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.247.0"
+appVersion: "0.255.0"

--- a/helm-charts/sawmills-remote-operator-manual/values.yaml
+++ b/helm-charts/sawmills-remote-operator-manual/values.yaml
@@ -38,7 +38,7 @@ collectorName: ""
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
-  tag: 0.247.0 # Sawmills Remote Operator image tag
+  tag: 0.255.0 # Sawmills Remote Operator image tag
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 

--- a/helm-charts/sawmills-remote-operator/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: "2.0.21"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.247.0"
+appVersion: "0.255.0"

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -34,7 +34,7 @@ collectorName: ""
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
-  tag: 0.247.0 # Sawmills Remote Operator image tag
+  tag: 0.255.0 # Sawmills Remote Operator image tag
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 


### PR DESCRIPTION
## Summary

Bump the maintained customer-facing Sawmills Remote Operator Helm charts to image `0.255.0`, which includes Sawmills/remote-operator#336 demoting noisy ClusterIP lookup logs to debug.

## Changes Made

* [ ] Feature addition
* [ ] Bug fix
* [ ] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

## Version Impact

Patch release. Added `version:patch` label.

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation (`helm install --dry-run`)
* [ ] Deployed to test environment
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

Commands used:

```bash
helm template test-release helm-charts/sawmills-remote-operator | rg -n 'image:|app.kubernetes.io/version|helm.sh/chart'
helm template test-release helm-charts/sawmills-remote-operator-manual --set apiKey=dummy --set collectorName=test | rg -n 'image:|app.kubernetes.io/version|helm.sh/chart'
helm lint helm-charts/sawmills-remote-operator
helm lint helm-charts/sawmills-remote-operator-manual --set apiKey=dummy --set collectorName=test
./tests/run-tests.sh # in helm-charts/sawmills-remote-operator
./tests/run-tests.sh # in helm-charts/sawmills-remote-operator-manual
trunk check --fix
```

Test environments:

* [x] Local development
* [ ] Staging environment
* [ ] Customer test environment

Results:

* Expected: both charts render `public.ecr.aws/s7a5m1b4/sawmills-remote-operator:0.255.0`.
* Actual: both charts render image/version `0.255.0`; lint, unit tests, and trunk passed.

## Breaking Changes

* [x] No breaking changes
* [ ] Contains breaking changes (describe below)

## Impact Assessment

* Who is affected: customer/operator installs using these Helm chart defaults.
* What systems are affected: Sawmills Remote Operator and manual Remote Operator chart deployments.
* Rollback plan: pin or roll back the chart image tag to `0.247.0`.

## Documentation Updated

* [ ] Chart README.md updated
* [ ] Configuration examples added/updated
* [ ] CHANGELOG.md updated
* [ ] Inline comments added for complex logic
* [x] Not applicable (no documentation changes needed)

## Additional Notes

The corresponding remote-operator release `v0.255.0` is already built and published.

## Checklist

* [x] I have read the contribution guidelines
* [x] I have tested my changes thoroughly
* [x] I have updated documentation as needed
* [x] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* [x] I have tagged @sawmills/engineers for review
* [x] I have provided clear commit messages

@sawmills/engineers Please review this contribution.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Remote Operator Helm charts to image 0.255.0. This release demotes noisy ClusterIP lookup logs to debug and applies to both `sawmills-remote-operator` and `sawmills-remote-operator-manual`.

<sup>Written for commit 49d7c58305150d839365bb1fc32c899bfde0aa5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sawmills Remote Operator to version 0.255.0 across deployment configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->