### PR TITLE
refactor(sawmills-collector): stop setting deprecated values

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -98,13 +98,6 @@ collector_gateway:
 collectorConfig:
   folderName: SAWMILLS_ORG
   s3Bucket: sawmills-plat-ue1-prod-quotas
-
-# Legacy aliases for generated values that have not migrated yet
-quotamgmtprocessor:
-  # Legacy alias for collectorConfig.s3Bucket
-  s3_bucket: sawmills-plat-ue1-prod-quotas
-  # Legacy alias for collectorConfig.folderName
-  folder_name: SAWMILLS_ORG
 ```
 
 ### Pin Images By Digest

--- a/helm-charts/sawmills-collector/examples/additional-containers.yaml
+++ b/helm-charts/sawmills-collector/examples/additional-containers.yaml
@@ -84,12 +84,12 @@ additionalVolumes:
 
 # Rest of the standard sawmills-collector configuration
 collectorName: test-sawmills-collector
-quotamgmtprocessor:
-  s3_bucket: test-bucket
-  folder_name: TEST_ORG
+collectorConfig:
+  s3Bucket: test-bucket
+  folderName: TEST_ORG
+apiSecret:
+  name: test-sawmills-secret
+  key: api-key
 
 prometheusremotewrite:
   endpoint: https://test.sawmills.ai
-  api_key_secret:
-    name: test-sawmills-secret
-    key: api-key

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -128,7 +128,7 @@ key: api-key
 {{/*
 Resolve the runtime folder name injected as FOLDER_NAME.
 collectorConfig.folderName is the clear public value; quotamgmtprocessor.folder_name
-is kept as a backward-compatible alias because collectors-service still emits it.
+is kept as a backward-compatible alias for reused release values.
 */}}
 {{- define "sawmills-collector.folderName" -}}
 {{- $collectorConfig := default dict .Values.collectorConfig -}}
@@ -140,14 +140,14 @@ is kept as a backward-compatible alias because collectors-service still emits it
 {{- $folderName -}}
 {{- else -}}
 {{- $qmp := default dict .Values.quotamgmtprocessor -}}
-{{- default "" $qmp.folder_name -}}
+{{- default "SAWMILLS_ORG" $qmp.folder_name -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Resolve the runtime S3 bucket injected as S3_BUCKET.
 collectorConfig.s3Bucket is the clear public value; quotamgmtprocessor.s3_bucket
-is kept as a backward-compatible alias because collectors-service still emits it.
+is kept as a backward-compatible alias for reused release values.
 */}}
 {{- define "sawmills-collector.s3Bucket" -}}
 {{- $collectorConfig := default dict .Values.collectorConfig -}}
@@ -159,7 +159,7 @@ is kept as a backward-compatible alias because collectors-service still emits it
 {{- $s3Bucket -}}
 {{- else -}}
 {{- $qmp := default dict .Values.quotamgmtprocessor -}}
-{{- default "" $qmp.s3_bucket -}}
+{{- default "sawmills-plat-ue1-prod-quotas" $qmp.s3_bucket -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -71,14 +71,14 @@ spec:
     {{- end }}
     {{- if .Values.keda.scaling.cpu.enabled }}
     - type: cpu
+      metricType: Utilization
       metadata:
-        type: Utilization
         value: {{ .Values.keda.scaling.cpu.targetUtilization | quote }}
     {{- end }}
     {{- if .Values.keda.scaling.memory.enabled }}
     - type: memory
+      metricType: Utilization
       metadata:
-        type: Utilization
         value: {{ .Values.keda.scaling.memory.targetUtilization | quote }}
     {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -31,15 +31,14 @@ spec:
   triggers:
     {{- if .Values.loadBalancer.keda.scaling.cpu.enabled }}
     - type: cpu
+      metricType: Utilization
       metadata:
-        type: Utilization
         value: {{ .Values.loadBalancer.keda.scaling.cpu.targetUtilization | quote }}
     {{- end }}
     {{- if .Values.loadBalancer.keda.scaling.memory.enabled }}
     - type: memory
+      metricType: Utilization
       metadata:
-        type: Utilization
         value: {{ .Values.loadBalancer.keda.scaling.memory.targetUtilization | quote }}
     {{- end }}
 {{- end }}
-

--- a/helm-charts/sawmills-collector/tests/collector_values_migration_test.yaml
+++ b/helm-charts/sawmills-collector/tests/collector_values_migration_test.yaml
@@ -1,0 +1,82 @@
+suite: Collector Values Migration
+templates:
+  - templates/deployment.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: uses apiSecret for collector API key references
+    set:
+      apiSecret:
+        name: new-secret
+        key: new-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: AUTH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: new-secret
+                key: new-key
+
+  - it: keeps prometheusremotewrite api_key_secret as a legacy alias
+    set:
+      prometheusremotewrite:
+        api_key_secret:
+          name: legacy-secret
+          key: legacy-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: AUTH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: legacy-secret
+                key: legacy-key
+
+  - it: prefers apiSecret over legacy prometheusremotewrite api_key_secret
+    set:
+      apiSecret:
+        name: new-secret
+        key: new-key
+      prometheusremotewrite:
+        api_key_secret:
+          name: legacy-secret
+          key: legacy-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: AUTH_KEY
+            valueFrom:
+              secretKeyRef:
+                name: new-secret
+                key: new-key
+
+  - it: uses serviceAccount.name for pod service account
+    set:
+      serviceAccount:
+        name: new-service-account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: new-service-account
+
+  - it: keeps serviceAccountName as a legacy alias
+    set:
+      serviceAccountName: legacy-service-account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: legacy-service-account
+
+  - it: prefers serviceAccount.name over legacy serviceAccountName
+    set:
+      serviceAccount:
+        name: new-service-account
+      serviceAccountName: legacy-service-account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: new-service-account

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -133,3 +133,44 @@ tests:
       - equal:
           path: spec.triggers[0].metadata.targetValue
           value: "5000"
+
+  - it: renders CPU and memory triggers with KEDA metricType syntax
+    set:
+      keda:
+        enabled: true
+        scaling:
+          prometheus:
+            enabled: false
+          external:
+            enabled: false
+          cpu:
+            enabled: true
+            targetUtilization: 70
+          memory:
+            enabled: true
+            targetUtilization: 75
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.triggers[0].type
+          value: cpu
+      - equal:
+          path: spec.triggers[0].metricType
+          value: Utilization
+      - notExists:
+          path: spec.triggers[0].metadata.type
+      - equal:
+          path: spec.triggers[0].metadata.value
+          value: "70"
+      - equal:
+          path: spec.triggers[1].type
+          value: memory
+      - equal:
+          path: spec.triggers[1].metricType
+          value: Utilization
+      - notExists:
+          path: spec.triggers[1].metadata.type
+      - equal:
+          path: spec.triggers[1].metadata.value
+          value: "75"

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -1,0 +1,44 @@
+suite: Load Balancer KEDA HPA Tests
+templates:
+  - templates/load-balancer-keda-hpa.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders CPU and memory triggers with KEDA metricType syntax
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          scaling:
+            cpu:
+              enabled: true
+              targetUtilization: 65
+            memory:
+              enabled: true
+              targetUtilization: 70
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.triggers[0].type
+          value: cpu
+      - equal:
+          path: spec.triggers[0].metricType
+          value: Utilization
+      - notExists:
+          path: spec.triggers[0].metadata.type
+      - equal:
+          path: spec.triggers[0].metadata.value
+          value: "65"
+      - equal:
+          path: spec.triggers[1].type
+          value: memory
+      - equal:
+          path: spec.triggers[1].metricType
+          value: Utilization
+      - notExists:
+          path: spec.triggers[1].metadata.type
+      - equal:
+          path: spec.triggers[1].metadata.value
+          value: "70"

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -164,19 +164,9 @@ podDisruptionBudget:
 # Configuration for the Sawmills collector
 collectorConfig:
   # Runtime folder prefix injected as FOLDER_NAME for remote collector configs.
-  # Defaults to quotamgmtprocessor.folder_name for backward compatibility.
   folderName: ""
   # Runtime S3 bucket injected as S3_BUCKET for remote collector configs.
-  # Defaults to quotamgmtprocessor.s3_bucket for backward compatibility.
   s3Bucket: ""
-
-quotamgmtprocessor:
-  # Deprecated: use collectorConfig.s3Bucket. Kept for collectors-service and
-  # remote-operator compatibility while generated values are migrated.
-  s3_bucket: sawmills-plat-ue1-prod-quotas
-  # Deprecated: use collectorConfig.folderName. Kept for collectors-service and
-  # remote-operator compatibility while generated values are migrated.
-  folder_name: SAWMILLS_ORG
 
 # Configure the shared API secret used by the collector for authentication
 # apiSecret:
@@ -1044,8 +1034,6 @@ telemetryConfig:
                   temporality_preference: delta
                   compression: gzip
 
-# deprecated, use serviceAccount.name instead
-serviceAccountName: ""
 serviceAccount:
   # -- Whether to create a service account for the Sawmills Collector deployment.
   create: false


### PR DESCRIPTION
sawmills-collector: Stop setting deprecated collector values

Moves collector chart defaults, examples, and docs to the current value keys while preserving legacy alias compatibility for reused Helm releases.

Description:
- remove default/example/doc usage of `prometheusremotewrite.api_key_secret`, `serviceAccountName`, and top-level `quotamgmtprocessor`
- keep helper fallbacks for legacy `--reuse-values` upgrades and add migration coverage
- render KEDA CPU/memory triggers with trigger-level `metricType: Utilization`

Validation:
- `helm unittest helm-charts/sawmills-collector -f 'tests/collector_values_migration_test.yaml' -f 'tests/keda_hpa_test.yaml' -f 'tests/load_balancer_keda_hpa_test.yaml'`
- `./tests/run-tests.sh`
- `helm lint helm-charts/sawmills-collector --strict`
- `trunk check --fix`
- live staging validation: upgraded `sawmills-test-manual` to `sawmills-collector-chart-2.10.2-deprecated-values-validation`; collector and LB pods rolled out healthy with zero restarts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop setting deprecated Helm values in `sawmills-collector` and move docs/examples to current keys. Keeps legacy aliases for `--reuse-values` and fixes KEDA CPU/memory trigger syntax across collector and load balancer.

- **Refactors**
  - Use `apiSecret` instead of `prometheusremotewrite.api_key_secret`.
  - Prefer `serviceAccount.name` over `serviceAccountName`.
  - Replace top-level `quotamgmtprocessor` with `collectorConfig.s3Bucket` and `collectorConfig.folderName`.
  - Render KEDA CPU/memory triggers with trigger-level `metricType: Utilization` for both collector and load balancer HPAs.
  - Remove legacy defaults/examples; helpers now default `folderName` to `SAWMILLS_ORG` and `s3Bucket` to `sawmills-plat-ue1-prod-quotas` when unset.

- **Migration**
  - Existing releases with `--reuse-values` continue to work via legacy aliases.
  - For new installs, set `collectorConfig.s3Bucket`, `collectorConfig.folderName`, `apiSecret`, and `serviceAccount.name`.

<sup>Written for commit 6308c2ba52aa709097efcac12574a371f752e152. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated legacy quota processor configuration aliases. Users must migrate to the updated configuration structure.
  * Removed deprecated service account configuration parameter in favor of the updated structure.

* **Improvements**
  * KEDA autoscaling configuration updated with explicit utilization metrics for CPU and memory scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->