### PR TITLE
fix(sawmills-collector): expose KEDA scaler self metrics

### DIFF
--- a/helm-charts/sawmills-collector/tests/keda_scaler_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_config_test.yaml
@@ -1,0 +1,27 @@
+suite: keda scaler config
+templates:
+  - templates/keda-scaler-configmap.yaml
+tests:
+  - it: exposes self telemetry through prometheus pull reader instead of otlp push
+    template: templates/keda-scaler-configmap.yaml
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*-\s*pull:\s*$'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*prometheus:\s*$'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*host: \$\{env:MY_POD_IP\}\s*$'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*port: \$\{env:OTEL_PROMETHEUS_PORT\}\s*$'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*periodic:\s*$'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^\s*endpoint: \$\{env:MY_POD_IP\}:\$\{env:OTEL_PROMETHEUS_PORT\}\s*$'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1172,11 +1172,11 @@ kedaScaler:
             - stdout
         metrics:
           readers:
-            - periodic:
+            - pull:
                 exporter:
-                  otlp:
-                    protocol: grpc
-                    endpoint: ${env:MY_POD_IP}:${env:OTEL_PROMETHEUS_PORT}
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: ${env:OTEL_PROMETHEUS_PORT}
 
 loadBalancer:
   enabled: false


### PR DESCRIPTION
## Summary

sawmills-collector: Fix KEDA scaler self telemetry export.

The KEDA scaler now exposes its own service telemetry through the Prometheus pull reader on the existing `otel-prometheus` port instead of trying to push OTLP to itself on that same port.

## Changes Made

* [ ] Feature addition
* [x] Bug fix
* [ ] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

## Version Impact

**Add one of these labelss to this PR:**

* `version:patch` - Bug fixes, small improvements (2.1.0 → 2.1.1)
* `version:minor` - New features, backwards compatible (2.1.0 → 2.2.0)
* `version:major` - Breaking changes (2.1.0 → 3.0.0)

> ⚠️ **If no version label is added, this will default to a minor bump**

## Testing Performed

* [x] Helm template validation (`helm template --debug`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation (`helm install --dry-run`)
* [ ] Deployed to test environment
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
helm lint helm-charts/sawmills-collector
helm unittest helm-charts/sawmills-collector -f 'tests/keda_scaler_config_test.yaml'\ncd helm-charts/sawmills-collector && ./tests/run-tests.sh\nexport MY_POD_IP=127.0.0.1 OTEL_PROMETHEUS_PORT=19876 OTLP_RECEIVER_PORT=4518 MONITORING_PORT=19465 KEDA_EXTERNAL_SCALER_PORT=4418 HEALTHCHECK_PORT=13134 MY_POD_NAME=test-keda-scaler\nhelm template sawmills-collector helm-charts/sawmills-collector --set kedaScaler.enabled=true --show-only templates/keda-scaler-configmap.yaml | yq -r '.data."config.yaml"' | /Users/amirjakoby/Code/sawmills-collector/cmd/sawmills-otelcol/sawmills-collector validate --config=file:/dev/stdin\n```\n\n**Test environments:**\n\n* [x] Local development\n* [ ] Staging environment\n* [ ] Customer test environment\n\n**Results:**\n\n* Expected: KEDA scaler self telemetry renders as a Prometheus pull reader on `${env:MY_POD_IP}:${env:OTEL_PROMETHEUS_PORT}`, with no OTLP self-push endpoint to that port.\n* Actual: Rendered config uses `pull.exporter.prometheus` and validates with the local collector binary. Full chart unit suite passed: 179/179.\n\n## Breaking Changes\n\n* [x] No breaking changes\n* [ ] Contains breaking changes (describe below)\n\n**Breaking Change Details:**\n\n* **What breaks:** N/A\n* **Migration path:** N/A\n* **Version compatibility:** Backward-compatible chart config fix.\n\n## Impact Assessment\n\n* **Who is affected:** Collector deployments with `kedaScaler.enabled=true`.\n* **What systems are affected:** `sawmills-collector` KEDA scaler self-telemetry only. External scaler and metric ingestion paths are unchanged.\n* **Rollback plan:** Revert this PR to restore the previous OTLP self-telemetry reader.\n\n## Documentation Updated\n\n* [ ] Chart README.md updated\n* [ ] Configuration examples added/updated\n* [ ] CHANGELOG.md updated\n* [ ] Inline comments added for complex logic\n* [x] Not applicable (no documentation changes needed)\n\n## Additional Notes\n\nThis PR was not deployed to staging. The staging manual deployment used the currently published chart and still demonstrates the old `:19876` self-push failure mode.\n\n***\n\n## Checklist\n\n* [x] I have read the [contribution guidelines](README.md#contributing)\n* [x] I have tested my changes thoroughly\n* [x] I have updated documentation as needed\n* [ ] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)\n* [x] I have tagged @sawmills/engineers for review\n* [x] I have provided clear commit messages\n\n***\n\n@sawmills/engineers Please review this contribution.\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-telemetry in the `sawmills-collector` KEDA scaler by switching from OTLP self-push to a Prometheus pull reader on the existing `otel-prometheus` port. This makes the scaler’s own metrics available reliably and avoids port conflicts.

- **Bug Fixes**
  - Update `values.yaml` to use `pull.exporter.prometheus` with `host: ${env:MY_POD_IP}` and `port: ${env:OTEL_PROMETHEUS_PORT}`.
  - Remove the `periodic` OTLP push config targeting its own `otel-prometheus` port.
  - Add a Helm unit test to assert the Prometheus pull reader is rendered and no OTLP self-push endpoint exists.

<sup>Written for commit 3c2c42702ccf00ad22c505f954540ef74700847a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for KEDA scaler configuration to validate telemetry metrics export behavior and settings.

* **Chores**
  * Updated KEDA scaler telemetry configuration, including enhancements to metrics export settings and reader configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->