### PR TITLE
fix(sawmills-collector): omit lb replicas under autoscaling

### DIFF
--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -10,6 +10,8 @@
 {{- $haproxyReadinessType := (dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower }}
 {{- $haproxyReadinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy }}
 {{- $haproxyReadinessPort := dig "probes" "readiness" "port" 13135 .Values.haproxy }}
+{{- $lbAutoscalingEnabled := and .Values.loadBalancer.autoscaling (eq .Values.loadBalancer.autoscaling.enabled true) }}
+{{- $lbKedaEnabled := and .Values.loadBalancer.keda (eq .Values.loadBalancer.keda.enabled true) }}
 {{- if eq $haproxyReadinessType "tcp" }}
 {{- $haproxyReadinessPort = (.Values.haproxy.healthcheck.port | default 13135) }}
 {{- end }}
@@ -25,7 +27,9 @@ metadata:
   labels:
     {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
 spec:
+  {{- if not (or $lbAutoscalingEnabled $lbKedaEnabled) }}
   replicas: {{ .Values.loadBalancer.replicas }}
+  {{- end }}
   {{- $lbStrategy := default (dict) .Values.loadBalancer.strategy }}
   {{- $lbStrategyType := default "RollingUpdate" $lbStrategy.type }}
   {{- if .Values.loadBalancer.storage.enabled }}

--- a/helm-charts/sawmills-collector/tests/load_balancer_replicas_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_replicas_test.yaml
@@ -1,0 +1,60 @@
+suite: Load Balancer Replica Ownership Tests
+templates:
+  - templates/load-balancer.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: renders replicas when load balancer scaling is not controller-managed
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: false
+        keda:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+
+  - it: omits replicas when load balancer HPA owns scaling
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: true
+        keda:
+          enabled: false
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: omits replicas when load balancer KEDA owns scaling
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: false
+        keda:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: omits replicas from StatefulSet when autoscaling owns scaling
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        storage:
+          enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.replicas


### PR DESCRIPTION
sawmills-collector: Omit LB replicas under autoscaling

The load balancer workload no longer renders `spec.replicas` when HPA or KEDA owns scaling.

Description
- Detect `loadBalancer.autoscaling.enabled` and `loadBalancer.keda.enabled` in `load-balancer.yaml`.
- Omit `spec.replicas` for controller-managed LB scaling to avoid Helm 4 server-side apply conflicts.
- Add helm unit coverage for unmanaged replicas, HPA, KEDA, and StatefulSet cases.

Test Plan
- `helm unittest helm-charts/sawmills-collector -f 'tests/load_balancer_replicas_test.yaml' -f 'tests/load_balancer_hpa_test.yaml' -f 'tests/load_balancer_keda_hpa_test.yaml'`
- `helm lint helm-charts/sawmills-collector`
- `./tests/run-tests.sh`
- `trunk check --fix helm-charts/sawmills-collector/templates/load-balancer.yaml helm-charts/sawmills-collector/tests/load_balancer_replicas_test.yaml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Helm 4 server-side apply conflicts by omitting `spec.replicas` for the `sawmills-collector` load balancer when autoscaling (HPA or KEDA) manages scaling. Applies to both Deployment and StatefulSet variants.

- **Bug Fixes**
  - Detect `loadBalancer.autoscaling.enabled` and `loadBalancer.keda.enabled` in `templates/load-balancer.yaml`.
  - Skip rendering `spec.replicas` when HPA or KEDA owns scaling.
  - Add unit tests for unmanaged replicas, HPA, KEDA, and StatefulSet cases.

<sup>Written for commit 77d6e7b29cd3e9aa406a1d3dab886f905ff73d75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

