### PR TITLE
feat(sawmills-collector): add resource base name

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -84,7 +84,7 @@ collectorId: sawmills-collector-id
 
 # Optional stable Kubernetes resource base name.
 # Useful when this chart is embedded under an umbrella or monochart release.
-# Must be a DNS label no longer than 46 characters.
+# Must be a DNS label no longer than 32 characters.
 resourceBaseName: ""
 
 # Prometheus Remote Write endpoint
@@ -105,9 +105,9 @@ collectorConfig:
   s3Bucket: sawmills-plat-ue1-prod-quotas
 ```
 
-Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`. The value is capped at 46 characters so the longest generated Service name, `<base>-backend-headless`, stays within Kubernetes DNS label limits.
+Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`. The value is capped at 32 characters so the longest generated name, `<base>-load-balancer-telemetry-config`, stays within Kubernetes DNS label limits.
 
-Changing `resourceBaseName` on an existing release changes immutable workload selectors. Use it for fresh installs, or plan a delete-and-recreate migration when adopting it on an already-installed release.
+Changing `resourceBaseName` on an existing release changes rendered resource names. Use it for fresh installs, or plan a rename migration when adopting it on an already-installed release.
 
 When overriding `affinity` or `loadBalancer.affinity` with `resourceBaseName` set, use the selector label values rendered by the chart: `<resourceBaseName>` for the collector and `<resourceBaseName>-lb` for the load balancer. The default affinity blocks are rewritten automatically; arbitrary custom selector values are not.
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -107,6 +107,10 @@ collectorConfig:
 
 Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`. The value is capped at 46 characters so the longest generated Service name, `<base>-backend-headless`, stays within Kubernetes DNS label limits.
 
+Changing `resourceBaseName` on an existing release changes immutable workload selectors. Use it for fresh installs, or plan a delete-and-recreate migration when adopting it on an already-installed release.
+
+When overriding `affinity` or `loadBalancer.affinity` with `resourceBaseName` set, use the selector label values rendered by the chart: `<resourceBaseName>` for the collector and `<resourceBaseName>-lb` for the load balancer. The default affinity blocks are rewritten automatically; arbitrary custom selector values are not.
+
 ### Pin Images By Digest
 
 Set `image.digest` to render the collector image as `repository@digest` instead of `repository:tag`:

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -82,6 +82,10 @@ mode: daemonSet
 collectorName: sawmills-collector
 collectorId: sawmills-collector-id
 
+# Optional stable Kubernetes resource base name.
+# Useful when this chart is embedded under an umbrella or monochart release.
+resourceBaseName: ""
+
 # Prometheus Remote Write endpoint
 prometheusremotewrite:
   endpoint: https://ingress.sawmills.ai
@@ -99,6 +103,8 @@ collectorConfig:
   folderName: SAWMILLS_ORG
   s3Bucket: sawmills-plat-ue1-prod-quotas
 ```
+
+Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`.
 
 ### Pin Images By Digest
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -84,6 +84,7 @@ collectorId: sawmills-collector-id
 
 # Optional stable Kubernetes resource base name.
 # Useful when this chart is embedded under an umbrella or monochart release.
+# Must be a DNS label no longer than 46 characters.
 resourceBaseName: ""
 
 # Prometheus Remote Write endpoint
@@ -104,7 +105,7 @@ collectorConfig:
   s3Bucket: sawmills-plat-ue1-prod-quotas
 ```
 
-Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`.
+Set `resourceBaseName` when the Helm release name is owned by a parent chart but the collector needs stable resource names. For example, `resourceBaseName: coinbase-logs` renders the regular collector as `coinbase-logs`, the load balancer as `coinbase-logs-lb`, the backend service as `coinbase-logs-backend`, and the load-balancer headless service as `coinbase-logs-headless`. The value is capped at 46 characters so the longest generated Service name, `<base>-backend-headless`, stays within Kubernetes DNS label limits.
 
 ### Pin Images By Digest
 

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -6,12 +6,20 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Resolve the runtime resource base name.
+Defaults to the Helm release name for backward compatibility.
+*/}}
+{{- define "sawmills-collector.resourceBaseName" -}}
+{{- default .Release.Name .Values.resourceBaseName | toString | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "sawmills-collector.fullname" -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- include "sawmills-collector.resourceBaseName" . }}
 {{- end }}
 
 {{/*
@@ -65,9 +73,25 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
+{{- define "sawmills-collector.selectorName" -}}
+{{- if .Values.resourceBaseName -}}
+{{- include "sawmills-collector.resourceBaseName" . }}
+{{- else -}}
+{{- include "sawmills-collector.name" . }}
+{{- end }}
+{{- end }}
+
+{{- define "sawmills-collector.selectorInstance" -}}
+{{- if .Values.resourceBaseName -}}
+{{- include "sawmills-collector.resourceBaseName" . }}
+{{- else -}}
+{{- .Release.Name }}
+{{- end }}
+{{- end }}
+
 {{- define "sawmills-collector.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "sawmills-collector.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "sawmills-collector.selectorName" . }}
+app.kubernetes.io/instance: {{ include "sawmills-collector.selectorInstance" . }}
 {{- end }}
 
 {{/*
@@ -85,9 +109,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
+{{- define "sawmills-collector.loadBalancerSelectorName" -}}
+{{- if .Values.resourceBaseName -}}
+{{- printf "%s-lb" (include "sawmills-collector.resourceBaseName" .) | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- printf "%s-lb" (include "sawmills-collector.name" .) }}
+{{- end }}
+{{- end }}
+
 {{- define "sawmills-collector.loadBalancerSelectorLabels" -}}
-app.kubernetes.io/name: {{ include "sawmills-collector.name" . }}-lb
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "sawmills-collector.loadBalancerSelectorName" . }}
+app.kubernetes.io/instance: {{ include "sawmills-collector.selectorInstance" . }}
 {{- end }}
 
 {{/*

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -15,8 +15,8 @@ Defaults to the Helm release name for backward compatibility.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Returns the runtime resource base name: .Values.resourceBaseName when set,
+otherwise .Release.Name for backward compatibility.
 */}}
 {{- define "sawmills-collector.fullname" -}}
 {{- include "sawmills-collector.resourceBaseName" . }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -82,11 +82,7 @@ Selector labels
 {{- end }}
 
 {{- define "sawmills-collector.selectorInstance" -}}
-{{- if .Values.resourceBaseName -}}
-{{- include "sawmills-collector.resourceBaseName" . }}
-{{- else -}}
 {{- .Release.Name }}
-{{- end }}
 {{- end }}
 
 {{- define "sawmills-collector.selectorLabels" -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -126,7 +126,9 @@ When resourceBaseName is set, only the chart's built-in legacy selector name is 
 {{- $root := index . "root" -}}
 {{- $affinity := toYaml (index . "affinity") -}}
 {{- if $root.Values.resourceBaseName -}}
-{{- $affinity = replace (index . "legacyName") (index . "selectorName") $affinity -}}
+{{- $legacyListItem := printf "- %s" (index . "legacyName") -}}
+{{- $selectorListItem := printf "- %s" (index . "selectorName") -}}
+{{- $affinity = replace $legacyListItem $selectorListItem $affinity -}}
 {{- end -}}
 {{- $affinity -}}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -119,6 +119,27 @@ app.kubernetes.io/instance: {{ include "sawmills-collector.selectorInstance" . }
 {{- end }}
 
 {{/*
+Render affinity values while preserving backward-compatible defaults.
+When resourceBaseName is set, only the chart's built-in legacy selector name is rewritten.
+*/}}
+{{- define "sawmills-collector.renderAffinity" -}}
+{{- $root := index . "root" -}}
+{{- $affinity := toYaml (index . "affinity") -}}
+{{- if $root.Values.resourceBaseName -}}
+{{- $affinity = replace (index . "legacyName") (index . "selectorName") $affinity -}}
+{{- end -}}
+{{- $affinity -}}
+{{- end }}
+
+{{- define "sawmills-collector.renderCollectorAffinity" -}}
+{{- include "sawmills-collector.renderAffinity" (dict "root" . "affinity" .Values.affinity "legacyName" "sawmills-collector-chart" "selectorName" (include "sawmills-collector.selectorName" .)) -}}
+{{- end }}
+
+{{- define "sawmills-collector.renderLoadBalancerAffinity" -}}
+{{- include "sawmills-collector.renderAffinity" (dict "root" . "affinity" .Values.loadBalancer.affinity "legacyName" "sawmills-collector-chart-lb" "selectorName" (include "sawmills-collector.loadBalancerSelectorName" .)) -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "sawmills-collector.serviceAccountName" -}}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -117,7 +117,11 @@ spec:
       {{- end }}
       {{- if not (empty .Values.affinity) }}
       affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- $affinity := toYaml .Values.affinity }}
+        {{- if .Values.resourceBaseName }}
+        {{- $affinity = replace "sawmills-collector-chart" (include "sawmills-collector.selectorName" .) $affinity }}
+        {{- end }}
+        {{- $affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -117,11 +117,7 @@ spec:
       {{- end }}
       {{- if not (empty .Values.affinity) }}
       affinity:
-        {{- $affinity := toYaml .Values.affinity }}
-        {{- if .Values.resourceBaseName }}
-        {{- $affinity = replace "sawmills-collector-chart" (include "sawmills-collector.selectorName" .) $affinity }}
-        {{- end }}
-        {{- $affinity | nindent 8 }}
+        {{- include "sawmills-collector.renderCollectorAffinity" . | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -94,9 +94,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if not (empty .Values.affinity) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- include "sawmills-collector.renderCollectorAffinity" . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -79,7 +79,11 @@ spec:
       {{- end }}
       {{- if not (empty .Values.loadBalancer.affinity) }}
       affinity:
-        {{- toYaml .Values.loadBalancer.affinity | nindent 8 }}
+        {{- $affinity := toYaml .Values.loadBalancer.affinity }}
+        {{- if .Values.resourceBaseName }}
+        {{- $affinity = replace "sawmills-collector-chart-lb" (include "sawmills-collector.loadBalancerSelectorName" .) $affinity }}
+        {{- end }}
+        {{- $affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.loadBalancer.priorityClassName }}
       priorityClassName: {{ .Values.loadBalancer.priorityClassName }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -79,11 +79,7 @@ spec:
       {{- end }}
       {{- if not (empty .Values.loadBalancer.affinity) }}
       affinity:
-        {{- $affinity := toYaml .Values.loadBalancer.affinity }}
-        {{- if .Values.resourceBaseName }}
-        {{- $affinity = replace "sawmills-collector-chart-lb" (include "sawmills-collector.loadBalancerSelectorName" .) $affinity }}
-        {{- end }}
-        {{- $affinity | nindent 8 }}
+        {{- include "sawmills-collector.renderLoadBalancerAffinity" . | nindent 8 }}
       {{- end }}
       {{- if .Values.loadBalancer.priorityClassName }}
       priorityClassName: {{ .Values.loadBalancer.priorityClassName }}

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -247,6 +247,9 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/instance"]
           value: customer-umbrella
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
+          content: coinbase-logs
 
   - it: uses resourceBaseName for KEDA scaler service selectors
     template: templates/keda-scaler-service.yaml

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -1,0 +1,254 @@
+suite: resource base name contract
+templates:
+  - templates/deployment.yaml
+  - templates/load-balancer.yaml
+  - templates/service.yaml
+  - templates/service-headless.yaml
+  - templates/load-balancer-service.yaml
+  - templates/load-balancer-service-headless.yaml
+  - templates/haproxy-configmap.yaml
+  - templates/keda-hpa.yaml
+  - templates/load-balancer-keda-hpa.yaml
+  - templates/keda-scaler-deployment.yaml
+  - templates/keda-scaler-service.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: preserves default release-based collector workload name and legacy selector labels
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: sawmills-collector-chart
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: sawmills-collector-chart
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: uses resourceBaseName for collector workload name and selector labels
+    template: templates/deployment.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: coinbase-logs
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: coinbase-logs
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: coinbase-logs
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: coinbase-logs
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
+          content: coinbase-logs
+
+  - it: uses resourceBaseName for backend service names when load balancer is enabled
+    template: templates/service.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-backend
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: coinbase-logs
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: coinbase-logs
+
+  - it: uses resourceBaseName for backend headless service when load balancer is enabled
+    template: templates/service-headless.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-backend-headless
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: coinbase-logs
+
+  - it: uses resourceBaseName for load balancer workload and selector labels
+    template: templates/load-balancer.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-lb
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: coinbase-logs-lb
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: coinbase-logs
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: coinbase-logs-lb
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: coinbase-logs
+      - contains:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
+          content: coinbase-logs-lb
+
+  - it: uses resourceBaseName for load balancer public service
+    template: templates/load-balancer-service.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: coinbase-logs-lb
+
+  - it: uses resourceBaseName for load balancer headless service
+    template: templates/load-balancer-service-headless.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+      loadBalancer.service.headless.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-headless
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: coinbase-logs-lb
+
+  - it: uses resourceBaseName in HAProxy sibling fallback headless DNS
+    template: templates/haproxy-configmap.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      haproxy.enabled: true
+      haproxy.sibling_fallback.enabled: true
+      loadBalancer.enabled: true
+      loadBalancer.service.headless.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server-template sibling 10 coinbase-logs-headless\\.customer-ns\\.svc\\.cluster\\.local:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
+
+  - it: uses resourceBaseName for KEDA scaler resources and scaler address
+    template: templates/keda-hpa.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-keda-hpa
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: coinbase-logs
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: coinbase-logs-keda-otel-scaler.customer-ns.svc.cluster.local:4418
+
+  - it: uses resourceBaseName for load balancer KEDA target
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      loadBalancer.enabled: true
+      loadBalancer.keda.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-lb-keda-hpa
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: coinbase-logs-lb
+
+  - it: uses resourceBaseName for KEDA scaler deployment and service selectors
+    template: templates/keda-scaler-deployment.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      kedaScaler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-keda-otel-scaler
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: coinbase-logs-keda-otel-scaler
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: coinbase-logs
+
+  - it: uses resourceBaseName for KEDA scaler service selectors
+    template: templates/keda-scaler-service.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      kedaScaler.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: coinbase-logs-keda-otel-scaler
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: coinbase-logs-keda-otel-scaler
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: coinbase-logs

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -7,6 +7,7 @@ templates:
   - templates/load-balancer-service.yaml
   - templates/load-balancer-service-headless.yaml
   - templates/haproxy-configmap.yaml
+  - templates/load-balancer-telemetry-configmap.yaml
   - templates/keda-hpa.yaml
   - templates/load-balancer-keda-hpa.yaml
   - templates/keda-scaler-deployment.yaml
@@ -49,13 +50,13 @@ tests:
           value: coinbase-logs
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: coinbase-logs
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
       - contains:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
           content: coinbase-logs
@@ -77,7 +78,7 @@ tests:
           value: coinbase-logs
       - equal:
           path: spec.selector["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
 
   - it: uses resourceBaseName for backend headless service when load balancer is enabled
     template: templates/service-headless.yaml
@@ -112,13 +113,13 @@ tests:
           value: coinbase-logs-lb
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: coinbase-logs-lb
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
       - contains:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
           content: coinbase-logs-lb
@@ -178,6 +179,19 @@ tests:
           path: data["haproxy.cfg"]
           pattern: "server-template sibling 10 coinbase-logs-headless\\.customer-ns\\.svc\\.cluster\\.local:4318.*check port 13136.*backup.*resolvers k8s.*init-addr none"
 
+  - it: allows max-length resourceBaseName for load balancer telemetry config
+    template: templates/load-balancer-telemetry-configmap.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-load-balancer-telemetry-config
+
   - it: uses resourceBaseName for KEDA scaler resources and scaler address
     template: templates/keda-hpa.yaml
     release:
@@ -232,7 +246,7 @@ tests:
           value: coinbase-logs-keda-otel-scaler
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella
 
   - it: uses resourceBaseName for KEDA scaler service selectors
     template: templates/keda-scaler-service.yaml
@@ -251,4 +265,4 @@ tests:
           value: coinbase-logs-keda-otel-scaler
       - equal:
           path: spec.selector["app.kubernetes.io/instance"]
-          value: coinbase-logs
+          value: customer-umbrella

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -61,6 +61,34 @@ tests:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values
           content: coinbase-logs
 
+  - it: rewrites only exact legacy affinity selector values
+    template: templates/deployment.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - sawmills-collector-chart
+                        - note-sawmills-collector-chart
+                topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
+          value: coinbase-logs
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[1]
+          value: note-sawmills-collector-chart
+
   - it: uses resourceBaseName for backend service names when load balancer is enabled
     template: templates/service.yaml
     release:

--- a/helm-charts/sawmills-collector/values.schema.json
+++ b/helm-charts/sawmills-collector/values.schema.json
@@ -4,9 +4,9 @@
   "properties": {
     "resourceBaseName": {
       "type": "string",
-      "maxLength": 46,
+      "maxLength": 32,
       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$|^$",
-      "description": "Optional stable Kubernetes resource base name. Limited to 46 characters so generated names such as <base>-backend-headless remain valid DNS labels."
+      "description": "Optional stable Kubernetes resource base name. Limited to 32 characters so generated names such as <base>-load-balancer-telemetry-config remain valid DNS labels."
     },
     "proxy": {
       "type": "object",

--- a/helm-charts/sawmills-collector/values.schema.json
+++ b/helm-charts/sawmills-collector/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "resourceBaseName": {
+      "type": "string",
+      "maxLength": 46,
+      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$|^$",
+      "description": "Optional stable Kubernetes resource base name. Limited to 46 characters so generated names such as <base>-backend-headless remain valid DNS labels."
+    },
     "proxy": {
       "type": "object",
       "properties": {

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -16,6 +16,11 @@ mode: deployment
 collectorName: sawmills-collector
 collectorId: sawmills-collector-id
 
+# Optional runtime resource base name. Leave empty to keep using the Helm release name.
+# Set this when embedding the chart in an umbrella/monochart release where the
+# collector resources need their own stable Kubernetes base name.
+resourceBaseName: ""
+
 # Rollout configuration
 rollout:
   # Global rollout settings

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -19,6 +19,8 @@ collectorId: sawmills-collector-id
 # Optional runtime resource base name. Leave empty to keep using the Helm release name.
 # Set this when embedding the chart in an umbrella/monochart release where the
 # collector resources need their own stable Kubernetes base name.
+# Must be a Kubernetes DNS label no longer than 46 characters so generated
+# suffixed Services such as <base>-backend-headless remain valid.
 resourceBaseName: ""
 
 # Rollout configuration

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -19,10 +19,10 @@ collectorId: sawmills-collector-id
 # Optional runtime resource base name. Leave empty to keep using the Helm release name.
 # Set this when embedding the chart in an umbrella/monochart release where the
 # collector resources need their own stable Kubernetes base name.
-# Must be a Kubernetes DNS label no longer than 46 characters so generated
-# suffixed Services such as <base>-backend-headless remain valid.
-# Changing this on an existing release changes immutable workload selectors.
-# Adopt it with a fresh install or a delete-and-recreate migration.
+# Must be a Kubernetes DNS label no longer than 32 characters so generated
+# suffixed names such as <base>-load-balancer-telemetry-config remain valid.
+# Changing this on an existing release changes rendered resource names.
+# Adopt it with a fresh install or a planned rename migration.
 resourceBaseName: ""
 
 # Rollout configuration

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -21,6 +21,8 @@ collectorId: sawmills-collector-id
 # collector resources need their own stable Kubernetes base name.
 # Must be a Kubernetes DNS label no longer than 46 characters so generated
 # suffixed Services such as <base>-backend-headless remain valid.
+# Changing this on an existing release changes immutable workload selectors.
+# Adopt it with a fresh install or a delete-and-recreate migration.
 resourceBaseName: ""
 
 # Rollout configuration
@@ -263,6 +265,9 @@ podLabels: {}
 
 # Node affinity settings for the Sawmills collector pods
 # Default configuration spreads pods across nodes to ensure high availability
+# If resourceBaseName is set and you override this block, use the selector label
+# value rendered by sawmills-collector.selectorName. The default value below is
+# automatically rewritten to resourceBaseName; unrelated custom values are not.
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
@@ -1203,6 +1208,10 @@ loadBalancer:
   nodeSelector: {}
   tolerations: []
   # Default configuration spreads LB pods across nodes to ensure high availability
+  # If resourceBaseName is set and you override this block, use the selector
+  # label value rendered by sawmills-collector.loadBalancerSelectorName.
+  # The default value below is automatically rewritten to <resourceBaseName>-lb;
+  # unrelated custom values are not.
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- Add `resourceBaseName` to the sawmills-collector chart so umbrella/monochart users can decouple Kubernetes resource names from Helm release/chart names.
- Keep default names/selectors unchanged when unset.
- Route LB HAProxy sibling traffic through the resource-base headless service.
- Document the value and add Helm unittest coverage.

## Verification
- `helm unittest . -f tests/resource_base_name_test.yaml --color`
- `./tests/run-tests.sh`
- `helm lint helm-charts/sawmills-collector`
- `trunk check --fix`
- `git diff --check`

Refs SAW-7315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resourceBaseName` to the `sawmills-collector` Helm chart to make resource names stable and decoupled from the Helm release; keeps legacy selector labels when unset and validates a DNS label ≤32 chars. This supports SAW‑7315 by making umbrella/monochart installs predictable.

- New Features
  - New value `resourceBaseName` (defaults to the Helm release); applied to Deployment/Service names and load balancer names (`-lb`, `-backend`, `-headless`, `-backend-headless`).
  - Selector labels use the base for `app.kubernetes.io/name` and keep `app.kubernetes.io/instance` set to the Helm release for stability.
  - Propagates to KEDA (HPA/scaler names, `scalerAddress`, and scaler Deployment/Service selectors), HAProxy sibling fallback DNS, and affinity defaults for collector, LB, and scaler; only exact legacy selector values are auto-rewritten when the base is set. README updated; Helm unittests added; schema enforces DNS format and the 32‑char cap.

- Migration
  - Optional; adopting on an existing release changes rendered names—plan a fresh install or delete‑and‑recreate due to immutable selectors.
  - For umbrella/monochart installs, set `resourceBaseName: <stable-name>` (≤32 chars) to render resources like `<name>`, `<name>-lb`, `<name>-backend`, `<name>-headless`, and `<name>-backend-headless`. When overriding `affinity`, use the selector values rendered by the chart.

<sup>Written for commit 103e29db4adc3a4d40bd50f582f1f018b48fc421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional resourceBaseName value to produce stable, predictable Kubernetes resource names (max 32 chars).

* **Improvements**
  * Naming and selectors updated so workloads, services and load‑balancer targets consistently derive names from the new base when set; affinity rendering adapts to preserve correct selectors.
  * Guidance added for changing resourceBaseName on existing releases (rename/migration considerations).

* **Documentation**
  * README and values docs updated with examples and DNS/length guidance.

* **Tests**
  * Added test suite validating naming, labels/selectors and related wiring when resourceBaseName is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->