### PR TITLE
sawmills-collector: Allow KEDA scaler network access

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -784,7 +784,9 @@ kedaScaler:
 When the namespace has default-deny ingress policy, enable
 `kedaScaler.networkPolicy.enabled`. The chart allows collector and load-balancer
 pods from the same release to send OTLP metrics to the scaler, and allows the
-KEDA operator pods to call the external scaler gRPC endpoint. Override
+KEDA operator pods from the `keda` namespace to call the external scaler gRPC
+endpoint. By default, the namespace selector uses Kubernetes' automatic
+`kubernetes.io/metadata.name: keda` namespace label. Override
 `kedaScaler.networkPolicy.kedaOperatorNamespaceSelector` or
 `kedaScaler.networkPolicy.kedaOperatorPodSelector` if your KEDA install uses
 different namespace or pod labels.

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -785,8 +785,9 @@ When the namespace has default-deny ingress policy, enable
 `kedaScaler.networkPolicy.enabled`. The chart allows collector and load-balancer
 pods from the same release to send OTLP metrics to the scaler, and allows the
 KEDA operator pods to call the external scaler gRPC endpoint. Override
+`kedaScaler.networkPolicy.kedaOperatorNamespaceSelector` or
 `kedaScaler.networkPolicy.kedaOperatorPodSelector` if your KEDA install uses
-different pod labels.
+different namespace or pod labels.
 
 ## Troubleshooting
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -784,7 +784,9 @@ kedaScaler:
 When the namespace has default-deny ingress policy, enable
 `kedaScaler.networkPolicy.enabled`. The chart allows collector and load-balancer
 pods from the same release to send OTLP metrics to the scaler, and allows the
-KEDA operator namespace to call the external scaler gRPC endpoint.
+KEDA operator pods to call the external scaler gRPC endpoint. Override
+`kedaScaler.networkPolicy.kedaOperatorPodSelector` if your KEDA install uses
+different pod labels.
 
 ## Troubleshooting
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -770,6 +770,8 @@ Enable the KEDA scaler component:
 ```yaml
 kedaScaler:
   enabled: true
+  networkPolicy:
+    enabled: true
   resources:
     limits:
       cpu: 500m
@@ -778,6 +780,11 @@ kedaScaler:
       cpu: 500m
       memory: 128Mi
 ```
+
+When the namespace has default-deny ingress policy, enable
+`kedaScaler.networkPolicy.enabled`. The chart allows collector and load-balancer
+pods from the same release to send OTLP metrics to the scaler, and allows the
+KEDA operator namespace to call the external scaler gRPC endpoint.
 
 ## Troubleshooting
 

--- a/helm-charts/sawmills-collector/templates/keda-scaler-network-policy.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-network-policy.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.kedaScaler.enabled .Values.kedaScaler.networkPolicy.enabled }}
+{{- $deploymentName := include "sawmills-collector.kedaScalerName" . }}
+{{- $networkPolicy := .Values.kedaScaler.networkPolicy }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $deploymentName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ $deploymentName }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- if $networkPolicy.allowSameReleasePodsToOtlp }}
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - port: {{ .Values.kedaScaler.service.otlpReceiverPort }}
+          protocol: TCP
+    {{- end }}
+    {{- if $networkPolicy.allowKedaOperator }}
+    - from:
+        - namespaceSelector:
+            {{- toYaml $networkPolicy.kedaOperatorNamespaceSelector | nindent 12 }}
+          {{- with $networkPolicy.kedaOperatorPodSelector }}
+          podSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      ports:
+        - port: {{ .Values.kedaScaler.service.kedaExternalScalerPort }}
+          protocol: TCP
+    {{- end }}
+    {{- with $networkPolicy.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
@@ -38,8 +38,11 @@ tests:
           path: spec.ingress[0].ports[0].port
           value: 4518
       - equal:
-          path: spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: keda
+          path: spec.ingress[1].from[0].namespaceSelector
+          value: {}
+      - equal:
+          path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: keda-operator
       - equal:
           path: spec.ingress[1].ports[0].port
           value: 4418

--- a/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
@@ -1,0 +1,81 @@
+suite: keda scaler network policy
+templates:
+  - templates/keda-scaler-network-policy.yaml
+tests:
+  - it: does not render by default
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ingress from same release pods to OTLP and KEDA operator to scaler gRPC
+    release:
+      name: sawmills-collector
+      namespace: sawmills
+    set:
+      kedaScaler.enabled: true
+      kedaScaler.networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: sawmills-collector-keda-otel-scaler
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/instance"]
+          value: sawmills-collector
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: sawmills-collector-keda-otel-scaler
+      - equal:
+          path: spec.policyTypes[0]
+          value: Ingress
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/instance"]
+          value: sawmills-collector
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 4518
+      - equal:
+          path: spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: keda
+      - equal:
+          path: spec.ingress[1].ports[0].port
+          value: 4418
+
+  - it: supports custom KEDA operator selector and extra ingress
+    release:
+      name: custom-release
+      namespace: custom-ns
+    set:
+      kedaScaler.enabled: true
+      kedaScaler.networkPolicy:
+        enabled: true
+        kedaOperatorNamespaceSelector:
+          matchLabels:
+            name: autoscaling
+        kedaOperatorPodSelector:
+          matchLabels:
+            app.kubernetes.io/name: keda-operator
+        extraIngress:
+          - from:
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: prometheus
+            ports:
+              - port: 19465
+                protocol: TCP
+    asserts:
+      - equal:
+          path: spec.ingress[1].from[0].namespaceSelector.matchLabels.name
+          value: autoscaling
+      - equal:
+          path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: keda-operator
+      - equal:
+          path: spec.ingress[2].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: prometheus
+      - equal:
+          path: spec.ingress[2].ports[0].port
+          value: 19465

--- a/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
@@ -38,8 +38,8 @@ tests:
           path: spec.ingress[0].ports[0].port
           value: 4518
       - equal:
-          path: spec.ingress[1].from[0].namespaceSelector
-          value: {}
+          path: spec.ingress[1].from[0].namespaceSelector.matchLabels.name
+          value: keda
       - equal:
           path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
           value: keda-operator

--- a/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml
@@ -38,7 +38,7 @@ tests:
           path: spec.ingress[0].ports[0].port
           value: 4518
       - equal:
-          path: spec.ingress[1].from[0].namespaceSelector.matchLabels.name
+          path: spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: keda
       - equal:
           path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1073,6 +1073,15 @@ kedaScaler:
   enabled: false
   imagePullPolicy: Always
   podSecurityContext: {}
+  networkPolicy:
+    enabled: false
+    allowSameReleasePodsToOtlp: true
+    allowKedaOperator: true
+    kedaOperatorNamespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: keda
+    kedaOperatorPodSelector: {}
+    extraIngress: []
   probes:
     liveness:
       initialDelaySeconds: 5

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1077,7 +1077,9 @@ kedaScaler:
     enabled: false
     allowSameReleasePodsToOtlp: true
     allowKedaOperator: true
-    kedaOperatorNamespaceSelector: {}
+    kedaOperatorNamespaceSelector:
+      matchLabels:
+        name: keda
     kedaOperatorPodSelector:
       matchLabels:
         app.kubernetes.io/name: keda-operator

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1079,7 +1079,7 @@ kedaScaler:
     allowKedaOperator: true
     kedaOperatorNamespaceSelector:
       matchLabels:
-        name: keda
+        kubernetes.io/metadata.name: keda
     kedaOperatorPodSelector:
       matchLabels:
         app.kubernetes.io/name: keda-operator

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1077,10 +1077,10 @@ kedaScaler:
     enabled: false
     allowSameReleasePodsToOtlp: true
     allowKedaOperator: true
-    kedaOperatorNamespaceSelector:
+    kedaOperatorNamespaceSelector: {}
+    kedaOperatorPodSelector:
       matchLabels:
-        kubernetes.io/metadata.name: keda
-    kedaOperatorPodSelector: {}
+        app.kubernetes.io/name: keda-operator
     extraIngress: []
   probes:
     liveness:


### PR DESCRIPTION
sawmills-collector: Allow KEDA scaler network access

Adds an opt-in NetworkPolicy for the KEDA scaler so default-deny namespaces can still receive collector telemetry and KEDA gRPC calls. This is needed for SAW-7438 before BigID can make the scaler Ready.

Description:
- Add `kedaScaler.networkPolicy` values and render a NetworkPolicy when enabled.
- Allow same-release collector/LB pods to reach OTLP `4518` and the KEDA namespace to reach gRPC `4418`.
- Add Helm unit coverage and README guidance.

Tests:
- `helm lint helm-charts/sawmills-collector`
- `helm unittest helm-charts/sawmills-collector -f tests/keda_scaler_network_policy_test.yaml --color`
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh`
- `trunk check --fix helm-charts/sawmills-collector/templates/keda-scaler-network-policy.yaml helm-charts/sawmills-collector/tests/keda_scaler_network_policy_test.yaml helm-charts/sawmills-collector/values.yaml helm-charts/sawmills-collector/README.md`

Refs: SAW-7438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in NetworkPolicy for the KEDA scaler in `sawmills-collector` so default-deny namespaces can reach it, unblocking SAW-7438 in BigID. Allows OTLP 4518 from same-release collector/LB pods and gRPC 4418 from KEDA operator pods, scoped to scaler pods.

- New Features
  - Added `kedaScaler.networkPolicy.*` values; renders a NetworkPolicy when enabled.
  - Default selectors use namespace label `kubernetes.io/metadata.name: keda` and pod label `app.kubernetes.io/name: keda-operator`; toggles for same-release OTLP and operator access; supports `extraIngress`.
  - Added Helm unit tests and README updates.

- Migration
  - In default-deny namespaces, set `kedaScaler.enabled: true` and `kedaScaler.networkPolicy.enabled: true`.

<sup>Written for commit c7346dd0e8119df18c0bc64ebaab812a0579a07b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

