### PR TITLE
fix(sawmills-remote-operator): allow NetworkPolicy management

### DIFF
--- a/helm-charts/sawmills-remote-operator/templates/sawmills-role.yaml
+++ b/helm-charts/sawmills-remote-operator/templates/sawmills-role.yaml
@@ -49,7 +49,7 @@ rules:
     resources: [podmonitors, servicemonitors]
     verbs: [create, delete, get, list, patch, update, watch]
   - apiGroups: [networking.k8s.io]
-    resources: [ingresses]
+    resources: [ingresses, networkpolicies]
     verbs: [create, delete, get, list, patch, update, watch]
   - apiGroups: [opentelemetry.io]
     resources: [instrumentations]

--- a/helm-charts/sawmills-remote-operator/tests/rbac_test.yaml
+++ b/helm-charts/sawmills-remote-operator/tests/rbac_test.yaml
@@ -1,0 +1,9 @@
+suite: RBAC permissions
+templates:
+  - sawmills-role.yaml
+tests:
+  - it: allows the operator to manage collector scaler network policies
+    asserts:
+      - contains:
+          path: rules[?(@.apiGroups[0]=="networking.k8s.io")].resources
+          content: networkpolicies


### PR DESCRIPTION
sawmills-remote-operator: allow NetworkPolicy management

Unblocks SAW-7438 by giving the live 2.x remote-operator chart RBAC to reconcile the collector KEDA scaler NetworkPolicy.

Description:
- Adds `networkpolicies` to the namespaced networking RBAC rule.
- Adds a Helm unit test that asserts the permission stays rendered.

Validation:
- `helm unittest helm-charts/sawmills-remote-operator -f 'tests/rbac_test.yaml' --color`\n- `helm lint helm-charts/sawmills-remote-operator`\n- `helm template test helm-charts/sawmills-remote-operator --show-only templates/sawmills-role.yaml`\n- `cd helm-charts/sawmills-remote-operator && ./tests/run-tests.sh`\n- `trunk check --fix helm-charts/sawmills-remote-operator/templates/sawmills-role.yaml helm-charts/sawmills-remote-operator/tests/rbac_test.yaml`\n\nRefs: SAW-7438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the `sawmills-remote-operator` chart to manage Kubernetes `NetworkPolicy` resources so it can reconcile the collector KEDA scaler policy. This unblocks SAW-7438 by enabling the external scaler to be reachable again.

- **Bug Fixes**
  - Extend namespaced RBAC to include `networkpolicies` in `networking.k8s.io`.
  - Add a Helm unit test to assert the permission remains rendered.

<sup>Written for commit 7de006683cc948852fcc8cf1bbb2af36a47df8bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

