### PR TITLE
fix(sawmills-collector): support host networking for KEDA scaler

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -770,6 +770,8 @@ Enable the KEDA scaler component:
 ```yaml
 kedaScaler:
   enabled: true
+  hostNetwork:
+    enabled: false
   networkPolicy:
     enabled: true
   resources:
@@ -790,6 +792,10 @@ endpoint. By default, the namespace selector uses Kubernetes' automatic
 `kedaScaler.networkPolicy.kedaOperatorNamespaceSelector` or
 `kedaScaler.networkPolicy.kedaOperatorPodSelector` if your KEDA install uses
 different namespace or pod labels.
+
+If the cluster cannot grant NetworkPolicy management to the Sawmills operator,
+`kedaScaler.hostNetwork.enabled` can be used as a fallback for the scaler pod.
+Keep it disabled by default and prefer NetworkPolicy when RBAC allows it.
 
 ## Troubleshooting
 

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         {{- toYaml $podLabels | nindent 8 }}
     spec:
       serviceAccountName: {{ include "sawmills-collector.serviceAccountName" . }}
+      {{- if .Values.kedaScaler.hostNetwork.enabled }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.kedaScaler.hostNetwork.dnsPolicy | default "ClusterFirstWithHostNet" }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.kedaScaler.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -1,0 +1,38 @@
+suite: keda scaler deployment
+templates:
+  - templates/keda-scaler-deployment.yaml
+tests:
+  - it: does not use host networking by default
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - notExists:
+          path: spec.template.spec.dnsPolicy
+
+  - it: supports host networking for clusters that cannot allow scaler ingress with NetworkPolicy
+    set:
+      kedaScaler.enabled: true
+      kedaScaler.hostNetwork.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: supports overriding host networking dns policy
+    set:
+      kedaScaler.enabled: true
+      kedaScaler.hostNetwork:
+        enabled: true
+        dnsPolicy: Default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: Default

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1073,6 +1073,9 @@ kedaScaler:
   enabled: false
   imagePullPolicy: Always
   podSecurityContext: {}
+  hostNetwork:
+    enabled: false
+    dnsPolicy: ClusterFirstWithHostNet
   networkPolicy:
     enabled: false
     allowSameReleasePodsToOtlp: true


### PR DESCRIPTION
sawmills-collector: support KEDA scaler hostNetwork fallback

Adds a default-off hostNetwork fallback for the KEDA scaler so customer clusters that cannot grant NetworkPolicy management can still expose the external scaler to KEDA.

- adds `kedaScaler.hostNetwork.enabled` and configurable `dnsPolicy`
- documents when to use the fallback versus the preferred NetworkPolicy path
- adds helm-unittest coverage for default and enabled rendering

Linear: SAW-7438

Verification:
- `helm unittest helm-charts/sawmills-collector -f tests/keda_scaler_deployment_test.yaml --color`
- `helm template sawmills-collector helm-charts/sawmills-collector --set kedaScaler.enabled=true --set kedaScaler.hostNetwork.enabled=true --show-only templates/keda-scaler-deployment.yaml`
- `helm lint helm-charts/sawmills-collector`
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh`
- `trunk check --fix helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml helm-charts/sawmills-collector/values.yaml helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml helm-charts/sawmills-collector/README.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a default-off hostNetwork fallback for the `sawmills-collector` KEDA external scaler so clusters without NetworkPolicy RBAC can expose the scaler to KEDA and restore external metrics. Addresses Linear SAW-7438 by avoiding “empty metric spec” errors when NetworkPolicies cannot be applied.

- **New Features**
  - Adds `kedaScaler.hostNetwork.enabled` and `kedaScaler.hostNetwork.dnsPolicy` (default `ClusterFirstWithHostNet`).
  - Wires `hostNetwork` and `dnsPolicy` into the scaler Deployment when enabled; default remains off.
  - Updates README with when to use hostNetwork vs NetworkPolicy and adds helm-unittest coverage.

- **Migration**
  - If the operator cannot manage `networkpolicies`, set `kedaScaler.enabled=true` and `kedaScaler.hostNetwork.enabled=true`; otherwise keep host networking disabled and use `kedaScaler.networkPolicy.enabled=true`.

<sup>Written for commit 79bcbfee05d7f5d111c9c58a4c1d673a81cf9412. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

