### PR TITLE
feat(sawmills-collector): add metrics-api KEDA trigger

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -238,6 +238,9 @@ keda:
       enabled: false
       metricType: Value
       loadBalancerMetricType: AverageValue
+      # Defaults to external for backward compatibility. Use metrics-api for
+      # central compressed queue autoscaling. Valid values: external, metrics-api.
+      loadBalancerTriggerType: external
       metadata:
         scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
         query: >-
@@ -250,6 +253,40 @@ keda:
         # targetValue is queued LB batches per desired collector pod.
         query: sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})
         targetValue: "300"
+```
+
+For central queue autoscaling, use KEDA's `metrics-api` scaler so KEDA can create the HPA from static trigger metadata and read queue values over the scaler pod's monitoring HTTP endpoint:
+
+```yaml
+keda:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 20
+  scaling:
+    cpu:
+      enabled: false
+    memory:
+      enabled: false
+    external:
+      enabled: true
+      loadBalancerMetricType: AverageValue
+      loadBalancerTriggerType: metrics-api
+      loadBalancerMetadata:
+        # targetValue is compressed central queue bytes per desired collector pod.
+        query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+        targetValue: "10485760"
+kedaScaler:
+  enabled: true
+```
+
+Validate the staging rollout and failure modes with:
+
+```bash
+NAMESPACE=sawmills-o11y KUBIE_ENV=staging ./tests/staging/validate-central-queue-keda-metrics-api.sh
+MODE=scaler-late NAMESPACE=sawmills-o11y KUBIE_ENV=staging ./tests/staging/validate-central-queue-keda-metrics-api.sh
+MODE=bad-path NAMESPACE=sawmills-o11y KUBIE_ENV=staging ./tests/staging/validate-central-queue-keda-metrics-api.sh
+MODE=bad-query NAMESPACE=sawmills-o11y KUBIE_ENV=staging ./tests/staging/validate-central-queue-keda-metrics-api.sh
+MODE=zero-query NAMESPACE=sawmills-o11y KUBIE_ENV=staging ./tests/staging/validate-central-queue-keda-metrics-api.sh
 ```
 
 ### HAProxy Load Balancing

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -591,6 +591,14 @@ Returns "<keda-scaler-name>.<namespace>.svc.cluster.local".
 {{- end -}}
 
 {{/*
+Build a KEDA metrics-api URL for the scaler monitoring HTTP endpoint.
+*/}}
+{{- define "sawmills-collector.kedaMetricsAPIURL" -}}
+{{- $query := required "keda.scaling.external.loadBalancerMetadata.query is required for metrics-api" .query -}}
+{{- printf "http://%s:%v/query?query=%s" (include "sawmills-collector.kedaScalerSvcFQDN" .root) .root.Values.kedaScaler.service.monitoringPort (urlquery $query) -}}
+{{- end -}}
+
+{{/*
 Resolve whether to use native sidecar mode for HAProxy.
 Accepts .Values.haproxy.nativeSidecar: "false" | "true" | "auto"
 Returns "true" or "false" as a string.

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -594,6 +594,9 @@ Returns "<keda-scaler-name>.<namespace>.svc.cluster.local".
 Build a KEDA metrics-api URL for the scaler monitoring HTTP endpoint.
 */}}
 {{- define "sawmills-collector.kedaMetricsAPIURL" -}}
+{{- if not .root.Values.kedaScaler.enabled -}}
+{{- fail "kedaScaler.enabled must be true when keda.scaling.external.loadBalancerTriggerType is metrics-api" -}}
+{{- end -}}
 {{- $query := required "keda.scaling.external.loadBalancerMetadata.query is required for metrics-api" .query -}}
 {{- printf "http://%s:%v/query?query=%s" (include "sawmills-collector.kedaScalerSvcFQDN" .root) .root.Values.kedaScaler.service.monitoringPort (urlquery $query) -}}
 {{- end -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -592,6 +592,9 @@ Returns "<keda-scaler-name>.<namespace>.svc.cluster.local".
 
 {{/*
 Build a KEDA metrics-api URL for the scaler monitoring HTTP endpoint.
+Call with dict "root" set to the chart root context and "query" set to the
+plain query string. Requires kedaScaler.enabled=true. Returns:
+"http://<keda-scaler-service>:<monitoringPort>/query?query=<urlencoded-query>".
 */}}
 {{- define "sawmills-collector.kedaMetricsAPIURL" -}}
 {{- if not .root.Values.kedaScaler.enabled -}}

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -44,14 +44,20 @@ spec:
         {{- end }}
     {{- end }}
     {{- if .Values.keda.scaling.external.enabled }}
-    - type: external
+    {{- $lbTriggerType := default "external" .Values.keda.scaling.external.loadBalancerTriggerType }}
+    - type: {{ if .Values.loadBalancer.enabled }}{{ $lbTriggerType }}{{ else }}external{{ end }}
       {{- if .Values.loadBalancer.enabled }}
       metricType: {{ .Values.keda.scaling.external.loadBalancerMetricType | default .Values.keda.scaling.external.metricType }}
       {{- else }}
       metricType: {{ .Values.keda.scaling.external.metricType }}
       {{- end }}
       metadata:
-        {{- if .Values.loadBalancer.enabled }}
+        {{- if and .Values.loadBalancer.enabled (eq $lbTriggerType "metrics-api") }}
+        url: {{ include "sawmills-collector.kedaMetricsAPIURL" (dict "root" $ "query" .Values.keda.scaling.external.loadBalancerMetadata.query) | quote }}
+        format: "json"
+        valueLocation: "result"
+        targetValue: {{ .Values.keda.scaling.external.loadBalancerMetadata.targetValue | quote }}
+        {{- else if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}
         {{- if eq $key "scalerAddress" }}
         {{ $key }}: {{ tpl (toString $value) $ | quote }}

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       metadata:
         {{- if and .Values.loadBalancer.enabled (eq $lbTriggerType "metrics-api") }}
-        url: {{ include "sawmills-collector.kedaMetricsAPIURL" (dict "root" $ "query" .Values.keda.scaling.external.loadBalancerMetadata.query) | quote }}
+        url: {{ include "sawmills-collector.kedaMetricsAPIURL" (dict "root" . "query" .Values.keda.scaling.external.loadBalancerMetadata.query) | quote }}
         format: "json"
         valueLocation: "result"
         targetValue: {{ required "keda.scaling.external.loadBalancerMetadata.targetValue is required for metrics-api" .Values.keda.scaling.external.loadBalancerMetadata.targetValue | quote }}

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -56,7 +56,7 @@ spec:
         url: {{ include "sawmills-collector.kedaMetricsAPIURL" (dict "root" $ "query" .Values.keda.scaling.external.loadBalancerMetadata.query) | quote }}
         format: "json"
         valueLocation: "result"
-        targetValue: {{ .Values.keda.scaling.external.loadBalancerMetadata.targetValue | quote }}
+        targetValue: {{ required "keda.scaling.external.loadBalancerMetadata.targetValue is required for metrics-api" .Values.keda.scaling.external.loadBalancerMetadata.targetValue | quote }}
         {{- else if .Values.loadBalancer.enabled }}
         {{- range $key, $value := .Values.keda.scaling.external.loadBalancerMetadata }}
         {{- if eq $key "scalerAddress" }}

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -25,6 +25,9 @@ tests:
           path: spec.triggers[0].type
           value: external
       - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: RELEASE-NAME-keda-otel-scaler.NAMESPACE.svc.cluster.local:4418
+      - equal:
           path: spec.triggers[0].metricType
           value: AverageValue
       - equal:
@@ -81,6 +84,50 @@ tests:
       - equal:
           path: spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.policies[1].periodSeconds
           value: 60
+
+  - it: renders LB metrics-api queue scaler with AverageValue
+    release:
+      name: sawmills-collector
+      namespace: sawmills-o11y
+    set:
+      loadBalancer:
+        enabled: true
+      kedaScaler:
+        enabled: true
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+            loadBalancerTriggerType: metrics-api
+            loadBalancerMetadata:
+              query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+              targetValue: "10485760"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.triggers[0].type
+          value: metrics-api
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+      - equal:
+          path: spec.triggers[0].metadata.format
+          value: json
+      - equal:
+          path: spec.triggers[0].metadata.valueLocation
+          value: result
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "10485760"
+      - equal:
+          path: spec.triggers[0].metadata.url
+          value: http://sawmills-collector-keda-otel-scaler.sawmills-o11y.svc.cluster.local:19465/query?query=sum%28otelcol_loadbalancer_central_queue_compressed_bytes%29
+      - notExists:
+          path: spec.triggers[0].metadata.scalerAddress
 
   - it: renders KEDA HPA ownership transfer settings
     set:

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -129,6 +129,20 @@ tests:
       - notExists:
           path: spec.triggers[0].metadata.scalerAddress
 
+  - it: requires keda scaler when rendering LB metrics-api queue scaler
+    set:
+      loadBalancer:
+        enabled: true
+      keda:
+        enabled: true
+        scaling:
+          external:
+            enabled: true
+            loadBalancerTriggerType: metrics-api
+    asserts:
+      - failedTemplate:
+          errorMessage: 'kedaScaler.enabled must be true when keda.scaling.external.loadBalancerTriggerType is metrics-api'
+
   - it: renders KEDA HPA ownership transfer settings
     set:
       loadBalancer:

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -72,3 +72,25 @@ tests:
       - notMatchRegex:
           path: spec.triggers[0].metadata.scalerAddress
           pattern: '\.sawmills\.svc\.cluster\.local'
+
+  - it: resolves LB metrics-api URL from release namespace and monitoring port
+    template: templates/keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sawmills-o11y
+    set:
+      keda.enabled: true
+      keda.scaling.external.enabled: true
+      keda.scaling.external.loadBalancerTriggerType: metrics-api
+      keda.scaling.external.loadBalancerMetadata.query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+      keda.scaling.external.loadBalancerMetadata.targetValue: "10485760"
+      kedaScaler.enabled: true
+      kedaScaler.service.monitoringPort: 19466
+      loadBalancer.enabled: true
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.url
+          value: http://sawmills-collector-keda-otel-scaler.sawmills-o11y.svc.cluster.local:19466/query?query=sum%28otelcol_loadbalancer_central_queue_compressed_bytes%29
+      - notMatchRegex:
+          path: spec.triggers[0].metadata.url
+          pattern: '\.sawmills\.svc\.cluster\.local'

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -19,7 +19,7 @@ tests:
           value: my-release-keda-otel-scaler.any-ns.svc.cluster.local:9444
       - notMatchRegex:
           path: spec.triggers[0].metadata.scalerAddress
-          pattern: '\.sawmills\.svc\.cluster\.local'
+          pattern: \.sawmills\.svc\.cluster\.local
 
   - it: truncates long release names in scalerAddress to keep the service label valid
     template: templates/keda-hpa.yaml
@@ -71,7 +71,7 @@ tests:
           value: "300"
       - notMatchRegex:
           path: spec.triggers[0].metadata.scalerAddress
-          pattern: '\.sawmills\.svc\.cluster\.local'
+          pattern: \.sawmills\.svc\.cluster\.local
 
   - it: resolves LB metrics-api URL from release namespace and monitoring port
     template: templates/keda-hpa.yaml
@@ -93,4 +93,4 @@ tests:
           value: http://sawmills-collector-keda-otel-scaler.sawmills-o11y.svc.cluster.local:19466/query?query=sum%28otelcol_loadbalancer_central_queue_compressed_bytes%29
       - notMatchRegex:
           path: spec.triggers[0].metadata.url
-          pattern: '\.sawmills\.svc\.cluster\.local'
+          pattern: \.sawmills\.svc\.cluster\.local

--- a/helm-charts/sawmills-collector/tests/staging/validate-central-queue-keda-metrics-api.sh
+++ b/helm-charts/sawmills-collector/tests/staging/validate-central-queue-keda-metrics-api.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-sawmills-o11y}"
+RELEASE="${RELEASE:-sawmills-collector}"
+KUBIE_ENV="${KUBIE_ENV:-staging}"
+QUERY="${QUERY:-sum(otelcol_loadbalancer_central_queue_compressed_bytes)}"
+TARGET="${TARGET:-10485760}"
+SCALER_SVC="${SCALER_SVC:-${RELEASE}-keda-otel-scaler}"
+SCALEDOBJECT="${SCALEDOBJECT:-${RELEASE}-keda-hpa}"
+HPA="${HPA:-keda-hpa-${SCALEDOBJECT}}"
+MODE="${MODE:-happy}"
+
+run() {
+	kubie exec "${KUBIE_ENV}" "${NAMESPACE}" -- kubectl "$@"
+}
+
+ignore_run() {
+	set +e
+	run "$@"
+	set -e
+}
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+pass() {
+	echo "PASS: $*"
+}
+
+json_query="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "${QUERY}")"
+
+case "${MODE}" in
+happy | bad-path | bad-query | scaler-late | zero-query) ;;
+*) fail "unknown MODE ${MODE}" ;;
+esac
+
+if [[ ${MODE} == "bad-path" ]]; then
+	echo "Running bad-path failure mode"
+	original_url="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{.spec.triggers[0].metadata.url}')"
+	restore_url() {
+		ignore_run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${original_url}\"}]" >/dev/null
+	}
+	trap restore_url EXIT
+	bad_url="${original_url%/query*}/missing"
+	run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${bad_url}\"}]"
+	sleep 45
+	hpa_metric_type="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].type}')"
+	[[ ${hpa_metric_type} == "External" ]] || fail "bad-path changed HPA metric type to ${hpa_metric_type}"
+	restore_url
+	trap - EXIT
+	pass "bad-path failure kept HPA External and restored original URL"
+	exit 0
+fi
+
+if [[ ${MODE} == "bad-query" ]]; then
+	echo "Running bad-query failure mode"
+	original_url="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{.spec.triggers[0].metadata.url}')"
+	restore_url() {
+		ignore_run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${original_url}\"}]" >/dev/null
+	}
+	trap restore_url EXIT
+	bad_url="${original_url%%query=*}query=sum%28"
+	run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${bad_url}\"}]"
+	sleep 45
+	hpa_metric_type="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].type}')"
+	[[ ${hpa_metric_type} == "External" ]] || fail "bad-query changed HPA metric type to ${hpa_metric_type}"
+	restore_url
+	trap - EXIT
+	pass "bad-query failure kept HPA External and restored original URL"
+	exit 0
+fi
+
+if [[ ${MODE} == "zero-query" ]]; then
+	echo "Running zero-query failure mode"
+	original_url="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{.spec.triggers[0].metadata.url}')"
+	restore_url() {
+		ignore_run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${original_url}\"}]" >/dev/null
+	}
+	trap restore_url EXIT
+	zero_query="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' 'sum(sawmills_central_queue_keda_zero_probe_metric)')"
+	zero_url="${original_url%%query=*}query=${zero_query}"
+	run patch scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/triggers/0/metadata/url\",\"value\":\"${zero_url}\"}]"
+	sleep 45
+	hpa_metric_type="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].type}')"
+	[[ ${hpa_metric_type} == "External" ]] || fail "zero-query changed HPA metric type to ${hpa_metric_type}"
+
+	curl_pod="sm-keda-zero-query-check-$(date +%s)"
+	cleanup_zero_pod() {
+		ignore_run delete pod "${curl_pod}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1
+	}
+	cleanup_zero_pod
+	trap 'cleanup_zero_pod; restore_url' EXIT
+	run run "${curl_pod}" -n "${NAMESPACE}" --restart=Never --image=curlimages/curl:8.15.0 --command -- \
+		curl -fsS "${zero_url}" >/dev/null
+	set +e
+	run wait pod/"${curl_pod}" -n "${NAMESPACE}" --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+	wait_status=$?
+	set -e
+	if ((wait_status != 0)); then
+		ignore_run logs "${curl_pod}" -n "${NAMESPACE}"
+		fail "zero-query GET pod did not complete"
+	fi
+	zero_result="$(run logs "${curl_pod}" -n "${NAMESPACE}")"
+	result_value="$(
+		QUERY_RESULT="${zero_result}" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["QUERY_RESULT"])
+value = payload.get("result")
+if value != 0:
+    raise SystemExit(f"result is {value}, not 0")
+print(value)
+PY
+	)"
+	cleanup_zero_pod
+	restore_url
+	trap - EXIT
+	pass "zero-query returned ${result_value} and kept HPA External"
+	exit 0
+fi
+
+if [[ ${MODE} == "scaler-late" ]]; then
+	echo "Running scaler-late failure mode"
+	restore_scaler() {
+		ignore_run scale deployment "${SCALER_SVC}" -n "${NAMESPACE}" --replicas=1 >/dev/null
+	}
+	trap restore_scaler EXIT
+	run scale deployment "${SCALER_SVC}" -n "${NAMESPACE}" --replicas=0
+	sleep 10
+	scaler_late_timestamp="$(date +%s)"
+	run annotate scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" "sawmills.ai/scaler-late-test=${scaler_late_timestamp}" --overwrite
+	sleep 30
+	hpa_metric_type="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].type}')"
+	[[ ${hpa_metric_type} == "External" ]] || fail "scaler-late changed HPA metric type to ${hpa_metric_type}"
+	restore_scaler
+	trap - EXIT
+	run rollout status "deployment/${SCALER_SVC}" -n "${NAMESPACE}" --timeout=120s
+	pass "scaler-late failure kept HPA External and restored scaler"
+	exit 0
+fi
+
+echo "Checking rollout status"
+run rollout status "deployment/${RELEASE}" -n "${NAMESPACE}" --timeout=120s
+run rollout status "deployment/${RELEASE}-lb" -n "${NAMESPACE}" --timeout=120s
+run rollout status "deployment/${SCALER_SVC}" -n "${NAMESPACE}" --timeout=120s
+
+echo "Checking ScaledObject trigger"
+trigger_type="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{.spec.triggers[0].type}')"
+[[ ${trigger_type} == "metrics-api" ]] || fail "expected metrics-api trigger, got ${trigger_type}"
+pass "ScaledObject trigger is metrics-api"
+
+metric_type="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{.spec.triggers[0].metricType}')"
+[[ ${metric_type} == "AverageValue" ]] || fail "expected AverageValue, got ${metric_type}"
+pass "ScaledObject metricType is AverageValue"
+
+echo "Checking HPA"
+hpa_metric_type="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].type}')"
+[[ ${hpa_metric_type} == "External" ]] || fail "expected External HPA metric, got ${hpa_metric_type}"
+pass "HPA metric type is External"
+
+hpa_target="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.spec.metrics[0].external.target.averageValue}')"
+[[ ${hpa_target} == "${TARGET}" ]] || fail "expected target ${TARGET}, got ${hpa_target}"
+pass "HPA target is ${TARGET}"
+
+echo "Checking direct GET query"
+curl_pod="sm-keda-metrics-api-check-$(date +%s)"
+cleanup_curl_pod() {
+	ignore_run delete pod "${curl_pod}" -n "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1
+}
+cleanup_curl_pod
+trap cleanup_curl_pod EXIT
+run run "${curl_pod}" -n "${NAMESPACE}" --restart=Never --image=curlimages/curl:8.15.0 --command -- \
+	curl -fsS "http://${SCALER_SVC}:19465/query?query=${json_query}" >/dev/null
+set +e
+run wait pod/"${curl_pod}" -n "${NAMESPACE}" --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
+wait_status=$?
+set -e
+if ((wait_status != 0)); then
+	ignore_run logs "${curl_pod}" -n "${NAMESPACE}"
+	fail "direct GET query pod did not complete"
+fi
+query_result="$(run logs "${curl_pod}" -n "${NAMESPACE}")"
+cleanup_curl_pod
+trap - EXIT
+
+result_value="$(
+	QUERY_RESULT="${query_result}" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["QUERY_RESULT"])
+value = payload.get("result")
+if not isinstance(value, (int, float)):
+    raise SystemExit("result is not numeric")
+print(value)
+PY
+)"
+pass "direct GET query returned numeric result ${result_value}"
+
+replicas="$(run get deployment "${RELEASE}" -n "${NAMESPACE}" -o jsonpath='{.status.readyReplicas}')"
+[[ -n ${replicas} && ${replicas} != "0" ]] || fail "collector ready replicas is ${replicas:-empty}"
+
+hpa_current="$(run get hpa "${HPA}" -n "${NAMESPACE}" -o jsonpath='{.status.currentMetrics[0].external.current.averageValue}')"
+pass "HPA current AverageValue is ${hpa_current}; query result ${result_value}; ready replicas ${replicas}"
+
+echo "Checking KEDA conditions"
+conditions="$(run get scaledobject "${SCALEDOBJECT}" -n "${NAMESPACE}" -o jsonpath='{range .status.conditions[*]}{.type}={.status}:{.reason}{"\n"}{end}')"
+printf '%s\n' "${conditions}"
+printf '%s\n' "${conditions}" | grep -q 'Ready=True:ScaledObjectReady' || fail "ScaledObject is not ready"
+pass "ScaledObject Ready=True"
+
+echo "Checking recent KEDA operator errors"
+set +e
+operator_related="$(kubie exec "${KUBIE_ENV}" "${NAMESPACE}" -- kubectl logs -n keda-system deploy/keda-operator --since=10m --tail=1000 | grep -Ei "${SCALEDOBJECT}|metrics-api")"
+operator_status=$?
+set -e
+if ((operator_status != 0)); then
+	operator_related=""
+fi
+printf '%s\n' "${operator_related}"
+if printf '%s\n' "${operator_related}" | grep -Eiq 'error|failed|unable|invalid'; then
+	fail "KEDA operator logs contain recent errors"
+fi
+pass "No recent KEDA operator errors for ${SCALEDOBJECT}"
+
+echo "Checking pod restarts"
+set +e
+run get pods -n "${NAMESPACE}" | grep -E "${RELEASE}|${SCALER_SVC}"
+set -e
+pass "staging central queue metrics-api validation completed"

--- a/helm-charts/sawmills-collector/tests/staging/validate-central-queue-keda-metrics-api.sh
+++ b/helm-charts/sawmills-collector/tests/staging/validate-central-queue-keda-metrics-api.sh
@@ -7,6 +7,7 @@ KUBIE_ENV="${KUBIE_ENV:-staging}"
 QUERY="${QUERY:-sum(otelcol_loadbalancer_central_queue_compressed_bytes)}"
 TARGET="${TARGET:-10485760}"
 SCALER_SVC="${SCALER_SVC:-${RELEASE}-keda-otel-scaler}"
+MONITORING_PORT="${MONITORING_PORT:-19465}"
 SCALEDOBJECT="${SCALEDOBJECT:-${RELEASE}-keda-hpa}"
 HPA="${HPA:-keda-hpa-${SCALEDOBJECT}}"
 MODE="${MODE:-happy}"
@@ -174,7 +175,7 @@ cleanup_curl_pod() {
 cleanup_curl_pod
 trap cleanup_curl_pod EXIT
 run run "${curl_pod}" -n "${NAMESPACE}" --restart=Never --image=curlimages/curl:8.15.0 --command -- \
-	curl -fsS "http://${SCALER_SVC}:19465/query?query=${json_query}" >/dev/null
+	curl -fsS "http://${SCALER_SVC}:${MONITORING_PORT}/query?query=${json_query}" >/dev/null
 set +e
 run wait pod/"${curl_pod}" -n "${NAMESPACE}" --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s
 wait_status=$?

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -102,6 +102,24 @@ tests:
           path: data["keda.yaml"]
           pattern: '(?m)^\s*metrics/keda:\s*$'
 
+  - it: keeps central queue metrics in the default keda telemetry overlay
+    template: telemetry-keda-configmap.yaml
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'otelcol_loadbalancer_central_queue_compressed_bytes'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'otelcol_loadbalancer_central_queue_compressed_capacity'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'otelcol_loadbalancer_central_queue_saturation'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'otelcol_loadbalancer_central_queue_oldest_item_age'
+
   - it: resolves keda otlp exporter endpoint and preserves literal template-like config
     template: telemetry-keda-configmap.yaml
     release:

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -109,16 +109,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'otelcol_loadbalancer_central_queue_compressed_bytes'
+          pattern: otelcol_loadbalancer_central_queue_compressed_bytes
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'otelcol_loadbalancer_central_queue_compressed_capacity'
+          pattern: otelcol_loadbalancer_central_queue_compressed_capacity
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'otelcol_loadbalancer_central_queue_saturation'
+          pattern: otelcol_loadbalancer_central_queue_saturation
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'otelcol_loadbalancer_central_queue_oldest_item_age'
+          pattern: otelcol_loadbalancer_central_queue_oldest_item_age
 
   - it: resolves keda otlp exporter endpoint and preserves literal template-like config
     template: telemetry-keda-configmap.yaml
@@ -138,10 +138,10 @@ tests:
     asserts:
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local'
+          pattern: my-release-keda-otel-scaler\.any-ns\.svc\.cluster\.local
       - notMatchRegex:
           path: data["keda.yaml"]
-          pattern: '\.sawmills\.svc\.cluster\.local'
+          pattern: \.sawmills\.svc\.cluster\.local
       - matchRegex:
           path: data["keda.yaml"]
           pattern: '\{\{ must_stay_literal \}\}'

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -109,16 +109,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: otelcol_loadbalancer_central_queue_compressed_bytes
+          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_compressed_bytes"
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: otelcol_loadbalancer_central_queue_compressed_capacity
+          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_compressed_capacity"
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: otelcol_loadbalancer_central_queue_saturation
+          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_saturation"
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: otelcol_loadbalancer_central_queue_oldest_item_age
+          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_oldest_item_age"
 
   - it: resolves keda otlp exporter endpoint and preserves literal template-like config
     template: telemetry-keda-configmap.yaml

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -102,23 +102,23 @@ tests:
           path: data["keda.yaml"]
           pattern: '(?m)^\s*metrics/keda:\s*$'
 
-  - it: keeps central queue metrics in the default keda telemetry overlay
+  - it: keeps central queue metrics in the default keda telemetry allowlist
     template: telemetry-keda-configmap.yaml
     set:
       kedaScaler.enabled: true
     asserts:
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_compressed_bytes"
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_central_queue_compressed_bytes
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_compressed_capacity"
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_central_queue_compressed_capacity
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_saturation"
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_central_queue_saturation
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: name\s*!=\s*"otelcol_loadbalancer_central_queue_oldest_item_age"
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_central_queue_oldest_item_age
 
   - it: resolves keda otlp exporter endpoint and preserves literal template-like config
     template: telemetry-keda-configmap.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -401,6 +401,9 @@ keda:
     external:
       enabled: false
       metricType: Value
+      # LB trigger implementation. Defaults to external for backward compatibility.
+      # Valid values: external, metrics-api.
+      loadBalancerTriggerType: external
       loadBalancerMetricType: AverageValue
       metadata:
         scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
@@ -1103,7 +1106,7 @@ kedaScaler:
           metric:
             # Only pass to the collector used to export metrics to Keda metrics that can be used
             # for fallback and latency of requests.
-            - name != "haproxy_server_http_responses_total" and name != "http.server.duration" and name != "otelcol_exporter_queue_size" and name != "otelcol_exporter_queue_capacity" and name != "http.server.request.duration"
+            - name != "haproxy_server_http_responses_total" and name != "http.server.duration" and name != "otelcol_exporter_queue_size" and name != "otelcol_exporter_queue_capacity" and name != "otelcol_loadbalancer_central_queue_compressed_bytes" and name != "otelcol_loadbalancer_central_queue_compressed_capacity" and name != "otelcol_loadbalancer_central_queue_saturation" and name != "otelcol_loadbalancer_central_queue_oldest_item_age" and name != "http.server.request.duration"
     exporters:
       otlp/keda:
         endpoint: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1104,9 +1104,8 @@ kedaScaler:
         error_mode: ignore
         metrics:
           metric:
-            # Only pass to the collector used to export metrics to Keda metrics that can be used
-            # for fallback and latency of requests.
-            - name != "haproxy_server_http_responses_total" and name != "http.server.duration" and name != "otelcol_exporter_queue_size" and name != "otelcol_exporter_queue_capacity" and name != "otelcol_loadbalancer_central_queue_compressed_bytes" and name != "otelcol_loadbalancer_central_queue_compressed_capacity" and name != "otelcol_loadbalancer_central_queue_saturation" and name != "otelcol_loadbalancer_central_queue_oldest_item_age" and name != "http.server.request.duration"
+            # Drop every metric that is not in the KEDA scaler store allowlist.
+            - not IsMatch(name, "^(haproxy_server_http_responses_total|http\\.server\\.duration|otelcol_exporter_queue_size|otelcol_exporter_queue_capacity|otelcol_loadbalancer_central_queue_compressed_bytes|otelcol_loadbalancer_central_queue_compressed_capacity|otelcol_loadbalancer_central_queue_saturation|otelcol_loadbalancer_central_queue_oldest_item_age|http\\.server\\.request\\.duration)$")
     exporters:
       otlp/keda:
         endpoint: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}'


### PR DESCRIPTION
## Summary
- add loadBalancerTriggerType with backward-compatible external default
- render KEDA metrics-api trigger for central compressed queue autoscaling
- keep central queue metrics in the KEDA telemetry overlay
- add staging validation script for happy path and failure modes

## Verification
- helm unittest . -f tests/keda_hpa_test.yaml -f tests/keda_scaler_address_test.yaml -f tests/telemetry_keda_overlay_test.yaml --color
- ./tests/run-tests.sh
- helm lint . --strict
- bash -n tests/staging/validate-central-queue-keda-metrics-api.sh
- trunk check touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a KEDA `metrics-api` trigger option for central compressed queue autoscaling in the `sawmills-collector` Helm chart, keeping `external` as the default. Also switches KEDA telemetry to an explicit allowlist that includes central queue metrics and drops everything else.

- **New Features**
  - New value `keda.scaling.external.loadBalancerTriggerType` (default: `external`); set to `metrics-api` to use the scaler’s monitoring endpoint.
  - For `metrics-api` with the LB, renders a trigger with `url`, `format=json`, `valueLocation=result`, and `targetValue`. The URL is built from the scaler service FQDN, monitoring port, and the encoded `query`.
  - Requires `kedaScaler.enabled: true` for `metrics-api`, and `loadBalancerMetadata.query` and `targetValue`.
  - Telemetry: convert to a strict allowlist that keeps central queue metrics and known KEDA-related metrics, dropping all others; tightened tests and staging validation script for happy path and failure modes.

- **Migration**
  - To enable central queue autoscaling via `metrics-api`:
    - Set: `keda.enabled`, `keda.scaling.external.enabled`, `loadBalancer.enabled`, `kedaScaler.enabled` to true.
    - Set: `keda.scaling.external.loadBalancerTriggerType=metrics-api`.
    - Provide: `keda.scaling.external.loadBalancerMetadata.query` and `targetValue`.

<sup>Written for commit 8622784179fca5f9a3237894c3ddca0dab9fa8c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KEDA metrics-api based autoscaling for central queue load monitoring, complementing the existing external trigger option.
  * Introduced new `loadBalancerTriggerType` configuration option to select between external and metrics-api autoscaling strategies.

* **Documentation**
  * Extended setup guidance with metrics-api configuration examples and validation procedures.

* **Tests**
  * Added comprehensive test coverage for metrics-api autoscaling workflow and central queue metrics telemetry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->