### PR TITLE
feat(sawmills-collector): expose livetail-control container port (SAW-7456)

### DIFF
--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -284,6 +284,9 @@ spec:
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
           ports:
+            - name: livetail-control
+              containerPort: 13138
+              protocol: TCP
             {{- range $name, $config := .Values.ports }}
             - name: {{ $name }}
               containerPort: {{ $config.port }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -284,7 +284,7 @@ spec:
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
           ports:
-            - name: livetail-control
+            - name: livetail-ctrl
               containerPort: 13138
               protocol: TCP
             {{- range $name, $config := .Values.ports }}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -284,6 +284,8 @@ spec:
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
           ports:
+            # Pod-IP-only LiveTail control surface (livetailcontrolextension).
+            # Hardcoded — must NOT be added to .Values.ports (would leak via Service).
             - name: livetail-ctrl
               containerPort: 13138
               protocol: TCP

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -522,6 +522,8 @@ additionalVolumes: []
 #     mountPath: /etc/config
 additionalVolumeMounts: []
 
+# Internal LiveTail direct-notify control uses container port 13138 on main-collector.
+# Do not add it to service.ports; remote-operator reaches selected ready pods by Pod IP.
 ports: {}
 # Example of adding a port
 # grpc:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -522,8 +522,8 @@ additionalVolumes: []
 #     mountPath: /etc/config
 additionalVolumeMounts: []
 
-# Internal LiveTail direct-notify control uses container port 13138 on main-collector.
-# Do not add it to service.ports; remote-operator reaches selected ready pods by Pod IP.
+# Extra container ports. Each entry also creates a Service port.
+# Do NOT add 13138 here — LiveTail control is Pod-IP-only (declared in deployment template).
 ports: {}
 # Example of adding a port
 # grpc:


### PR DESCRIPTION
## Summary

Adds container port `13138` (named `livetail-control`) on the `main-collector` pod so remote-operator can directly POST livetail session-apply commands to the new `livetailcontrolextension` HTTP server.

## Why

Sawmills-collector PR Sawmills/sawmills-collector#987 (SAW-7456) extracts the livetail HTTP control surface from the processor into a collector-scoped extension. The extension binds `0.0.0.0:13138` and serves `POST /internal/livetail/session` with bearer auth via `$AUTH_KEY`. The chart needs to expose that container port so remote-operator can reach it on Pod IP.

## Wire format (unchanged)

- Port: `13138`
- Path: `/internal/livetail/session`
- Auth: `Authorization: Bearer \$AUTH_KEY` (env already wired from `sawmills-secret`)

## Why not a Service port?

Remote-operator selects ready collector pods by label and reaches them by Pod IP directly (see `remote-operator/cmd/operator/livetail_session.go:notifyLivetailPods`). Adding the port to the Service would surface a non-public internal control plane unnecessarily.

## Test plan
- [x] `helm template` renders `livetail-control` container port at 13138 on the main-collector container.
- [x] No Service port added.
- [ ] End-to-end smoke after both PRs merge: remote-operator → \$PodIP:13138 returns 200 + \`{"applied_count":1}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose container port 13138 (`livetail-ctrl`) on the `main-collector` pod so `remote-operator` can POST livetail session commands to the `livetailcontrolextension` HTTP server (`POST /internal/livetail/session`, Bearer `$AUTH_KEY`) per SAW-7456. Port name shortened to fit Kubernetes limits; no Service port is added since `remote-operator` reaches ready collector pods by Pod IP, and chart comments now clarify this and to not add 13138 to `.Values.ports`.

<sup>Written for commit a29b4b07d525f86ce02e69eab11656abff85e2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal-only control port to the collector deployment for LiveTail control traffic.

* **Documentation**
  * Clarified values documentation to state this control port is reached via Pod IP and must not be exposed through service ports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/177)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->