### PR TITLE
feat(sawmills-collector): add LB pressure readiness wiring

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -780,6 +780,29 @@ Validation guardrails in this chart:
 * `compress_in_memory: true` requires `sending_queue.enabled: true`
 * `compress_in_memory: true` requires `payload_compression: snappy|zstd`
 
+#### Load Balancer Pressure Readiness
+
+`loadBalancer.pressureReadiness.enabled: true` adds the Sawmills `backend_drain` extension to LB collector pods and points the LB collector Kubernetes readiness probe at `backend_drain` `/ready`. Liveness stays on the collector `health_check` endpoint.
+
+```yaml
+loadBalancer:
+  enabled: true
+  pressureReadiness:
+    enabled: true
+    metricsEndpoint: http://${env:MY_POD_IP}:8888/metrics
+    queueSaturationFailThreshold: 0.85
+    queueSaturationRecoverThreshold: 0.60
+    inflightSaturationFailThreshold: 0.85
+    inflightSaturationRecoverThreshold: 0.60
+    memorySaturationFailThreshold: 0.85
+    memorySaturationRecoverThreshold: 0.70
+    capacityWarningThreshold: 0.60
+    rejectedQuietDuration: 1m
+    oldestItemAgeFailThreshold: 1m
+```
+
+When `memoryLimitBytes` is unset, the chart derives it from `loadBalancer.resources.limits.memory`; set `memoryLimitBytes: 0` to disable memory pressure gating for pods without memory limits. The rendered `backend_drain` config preserves configured LB `service.extensions` and appends `backend_drain`.
+
 ### Remote Operator OTLP Ingest (LB Tier)
 
 When `loadBalancer.enabled: true`, the chart now configures the LB telemetry collector to accept OTLP/HTTP metrics from remote-operator on port `14319` and exposes it on the LB service as `ro-otlp-http`.

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -803,7 +803,7 @@ loadBalancer:
 
 When `memoryLimitBytes` is unset, the chart derives it from `loadBalancer.resources.limits.memory`; set `memoryLimitBytes: 0` to disable memory pressure gating for pods without memory limits. The rendered `backend_drain` config preserves configured LB `service.extensions` and appends `backend_drain`.
 
-Pressure readiness is observable through the collector's own metrics. Use `otelcol_backend_drain_pressure_ready{reason="..."}` for the current pressure readiness state and `otelcol_backend_drain_pressure_transitions_total{state="...",reason="..."}` for ready/not-ready transitions. Reason labels are stable categories such as `queue_compressed_saturated`, `inflight_uncompressed_saturated`, `memory_saturated`, `queue_age_saturated`, `rejected_or_refused_records_increased`, and `metrics_scrape_failed`.
+Pressure readiness is observable through the collector's own metrics. Use `otelcol_backend_drain_pressure_warning{reason="..."}` for the warning band between `capacityWarningThreshold` and fail thresholds, `otelcol_backend_drain_pressure_ready{reason="..."}` for the current pressure readiness state, and `otelcol_backend_drain_pressure_transitions_total{state="...",reason="..."}` for ready/not-ready transitions. Reason labels are stable categories such as `queue_compressed_warning`, `queue_compressed_saturated`, `inflight_uncompressed_saturated`, `memory_saturated`, `queue_age_saturated`, `rejected_or_refused_records_increased`, and `metrics_scrape_failed`.
 
 ### Remote Operator OTLP Ingest (LB Tier)
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -803,6 +803,8 @@ loadBalancer:
 
 When `memoryLimitBytes` is unset, the chart derives it from `loadBalancer.resources.limits.memory`; set `memoryLimitBytes: 0` to disable memory pressure gating for pods without memory limits. The rendered `backend_drain` config preserves configured LB `service.extensions` and appends `backend_drain`.
 
+Pressure readiness is observable through the collector's own metrics. Use `otelcol_backend_drain_pressure_ready{reason="..."}` for the current pressure readiness state and `otelcol_backend_drain_pressure_transitions_total{state="...",reason="..."}` for ready/not-ready transitions. Reason labels are stable categories such as `queue_compressed_saturated`, `inflight_uncompressed_saturated`, `memory_saturated`, `queue_age_saturated`, `rejected_or_refused_records_increased`, and `metrics_scrape_failed`.
+
 ### Remote Operator OTLP Ingest (LB Tier)
 
 When `loadBalancer.enabled: true`, the chart now configures the LB telemetry collector to accept OTLP/HTTP metrics from remote-operator on port `14319` and exposes it on the LB service as `ro-otlp-http`.

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -505,6 +505,23 @@ to prevent invalid GOMEMLIMIT values that would crash Go pods at startup.
 {{- end }}
 
 {{/*
+Compute Kubernetes memory quantity bytes for backend_drain pressure checks.
+Accepts Gi and Mi suffixes to match the existing GOMEMLIMIT helper.
+*/}}
+{{- define "sawmills-collector.memoryBytes" -}}
+{{- $raw := . | toString -}}
+{{- if hasSuffix "Gi" $raw -}}
+  {{- $num := trimSuffix "Gi" $raw | float64 -}}
+  {{- printf "%.0f" (mulf $num 1073741824) -}}
+{{- else if hasSuffix "Mi" $raw -}}
+  {{- $num := trimSuffix "Mi" $raw | float64 -}}
+  {{- printf "%.0f" (mulf $num 1048576) -}}
+{{- else -}}
+  {{- fail (printf "memoryBytes: unsupported memory format %q — use Gi or Mi (e.g. \"4Gi\", \"512Mi\")" $raw) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Check if any HAProxy mapping has TLS enabled (only when HAProxy is actually enabled)
 */}}
 {{- define "sawmills-collector.haproxyTlsEnabled" -}}

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -1,0 +1,70 @@
+{{- $lbPressure := .Values.loadBalancer.pressureReadiness | default dict }}
+{{- if and .Values.loadBalancer.enabled ($lbPressure.enabled | default false) }}
+{{- $lbConfig := default dict .Values.loadBalancer.otelCollectorConfig }}
+{{- $serviceExtensions := list }}
+{{- if and (kindIs "map" $lbConfig) (hasKey $lbConfig "service") (kindIs "map" $lbConfig.service) (hasKey $lbConfig.service "extensions") }}
+{{- $serviceExtensions = deepCopy $lbConfig.service.extensions }}
+{{- else }}
+{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") $lbPressure.serviceExtensions) }}
+{{- end }}
+{{- $filteredServiceExtensions := list }}
+{{- range $serviceExtensions }}
+{{- if . }}
+{{- $filteredServiceExtensions = append $filteredServiceExtensions . }}
+{{- end }}
+{{- end }}
+{{- if not (has "backend_drain" $filteredServiceExtensions) }}
+{{- $filteredServiceExtensions = append $filteredServiceExtensions "backend_drain" }}
+{{- end }}
+{{- $healthCheckEndpoint := default "http://${env:MY_POD_IP}:13133/healthcheck" $lbPressure.healthCheckEndpoint }}
+{{- if and .Values.haproxy.enabled (eq ((dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower) "http") (not $lbPressure.healthCheckEndpoint) }}
+{{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (dig "probes" "readiness" "port" 13135 .Values.haproxy) (dig "probes" "readiness" "path" "/ready" .Values.haproxy) }}
+{{- end }}
+{{- $memoryLimitBytes := "" }}
+{{- if and (hasKey $lbPressure "memoryLimitBytes") (not (kindIs "invalid" (get $lbPressure "memoryLimitBytes"))) }}
+{{- $memoryLimitBytes = get $lbPressure "memoryLimitBytes" }}
+{{- end }}
+{{- if or (eq (toString $memoryLimitBytes) "") (eq (toString $memoryLimitBytes) "<nil>") }}
+{{- $memoryLimitBytes = 0 }}
+{{- if and (not .Values.loadBalancer.resources.disableLimits) .Values.loadBalancer.resources.limits .Values.loadBalancer.resources.limits.memory }}
+{{- $memoryLimitBytes = include "sawmills-collector.memoryBytes" (.Values.loadBalancer.resources.limits.memory | toString) }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sawmills-collector.fullname" . }}-load-balancer-readiness-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sawmills-collector.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    extensions:
+      backend_drain:
+        endpoint: ${env:MY_POD_IP}:{{ default 13137 $lbPressure.port }}
+        readiness_path: {{ default "/ready" $lbPressure.readinessPath }}
+        drain_path: {{ default "/drain" $lbPressure.drainPath }}
+        health_check_endpoint: {{ $healthCheckEndpoint }}
+        drain_duration: {{ default "15s" $lbPressure.drainDuration }}
+        {{- with $lbPressure.requestTimeout }}
+        request_timeout: {{ . }}
+        {{- end }}
+        pressure_check:
+          enabled: true
+          metrics_endpoint: {{ default "http://${env:MY_POD_IP}:8888/metrics" $lbPressure.metricsEndpoint }}
+          queue_saturation_fail_threshold: {{ default 0.85 $lbPressure.queueSaturationFailThreshold }}
+          queue_saturation_recover_threshold: {{ default 0.60 $lbPressure.queueSaturationRecoverThreshold }}
+          inflight_saturation_fail_threshold: {{ default 0.85 $lbPressure.inflightSaturationFailThreshold }}
+          inflight_saturation_recover_threshold: {{ default 0.60 $lbPressure.inflightSaturationRecoverThreshold }}
+          memory_saturation_fail_threshold: {{ default 0.85 $lbPressure.memorySaturationFailThreshold }}
+          memory_saturation_recover_threshold: {{ default 0.70 $lbPressure.memorySaturationRecoverThreshold }}
+          capacity_warning_threshold: {{ default 0.60 $lbPressure.capacityWarningThreshold }}
+          fail_checks: {{ default 2 $lbPressure.failChecks }}
+          recover_checks: {{ default 3 $lbPressure.recoverChecks }}
+          rejected_quiet_duration: {{ default "1m" $lbPressure.rejectedQuietDuration }}
+          oldest_item_age_fail_threshold: {{ default "1m" $lbPressure.oldestItemAgeFailThreshold }}
+          memory_limit_bytes: {{ $memoryLimitBytes }}
+    service:
+      extensions:
+{{- toYaml $filteredServiceExtensions | nindent 8 }}
+{{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -7,6 +7,8 @@
 {{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
 {{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
 {{- $lbStartupProbe := .Values.rollout.loadBalancer.probes.startup | default dict }}
+{{- $lbPressureReadiness := .Values.loadBalancer.pressureReadiness | default dict }}
+{{- $lbPressureReadinessEnabled := and .Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) }}
 {{- $haproxyReadinessType := (dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower }}
 {{- $haproxyReadinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy }}
 {{- $haproxyReadinessPort := dig "probes" "readiness" "port" 13135 .Values.haproxy }}
@@ -127,9 +129,16 @@ spec:
                 - ALL
           image: {{ include "sawmills-collector.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if $lbOtelS3Path }}
+          {{- if or $lbOtelS3Path $lbPressureReadinessEnabled }}
           args:
+            {{- if $lbOtelS3Path }}
             - "--config={{ $lbOtelS3Path }}{{- if $lbOtelEncryptionKey }}@{{ $lbOtelEncryptionKey }}{{- end }}"
+            {{- else }}
+            - "--config=file:/etc/otel/config.yaml"
+            {{- end }}
+            {{- if $lbPressureReadinessEnabled }}
+            - "--config=file:/etc/otel/load-balancer-readiness-config.yaml"
+            {{- end }}
           {{- end }}
           env:
             {{- include "sawmills-collector.runtimeConfigEnv" . | nindent 12 }}
@@ -174,7 +183,10 @@ spec:
             failureThreshold: {{ .Values.rollout.loadBalancer.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
-              {{- if .Values.haproxy.enabled }}
+              {{- if $lbPressureReadinessEnabled }}
+              path: {{ default "/ready" $lbPressureReadiness.readinessPath }}
+              port: {{ default 13137 $lbPressureReadiness.port }}
+              {{- else if .Values.haproxy.enabled }}
               path: {{ $haproxyReadinessPath }}
               port: {{ $haproxyReadinessPort }}  # Route through HAProxy to ensure backend is UP before receiving traffic
               {{- else }}
@@ -214,6 +226,11 @@ spec:
             - name: sawmills-collector-config-load-balancer
               mountPath: /etc/otel/config.yaml
               subPath: config.yaml
+          {{- end }}
+          {{- if $lbPressureReadinessEnabled }}
+            - name: sawmills-load-balancer-readiness-config
+              mountPath: /etc/otel/load-balancer-readiness-config.yaml
+              subPath: load-balancer-readiness-config.yaml
           {{- end }}
             - name: tmp
               mountPath: /tmp
@@ -354,6 +371,14 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- end }}
+        {{- if $lbPressureReadinessEnabled }}
+        - name: sawmills-load-balancer-readiness-config
+          configMap:
+            name: {{ include "sawmills-collector.fullname" . }}-load-balancer-readiness-config
+            items:
+              - key: config.yaml
+                path: load-balancer-readiness-config.yaml
         {{- end }}
         {{- if not $lbTelemetryOtelS3Path }}
         - name: sawmills-load-balancer-telemetry-config

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -1,0 +1,103 @@
+suite: load balancer pressure readiness
+templates:
+  - load-balancer.yaml
+  - load-balancer-readiness-configmap.yaml
+tests:
+  - it: renders pressure-aware backend_drain readiness for LB pods
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.resources.limits.memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --config=file:/etc/otel/config.yaml
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --config=file:/etc/otel/load-balancer-readiness-config.yaml
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13137
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: sawmills-load-balancer-readiness-config
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: sawmills-load-balancer-readiness-config
+
+  - it: renders pressure_check config with queue and memory thresholds
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.resources.limits.memory: 512Mi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n\s+pressure_check:\n\s+enabled: true\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:8888/metrics\n\s+queue_saturation_fail_threshold: 0.85\n\s+queue_saturation_recover_threshold: 0.6\n\s+inflight_saturation_fail_threshold: 0.85\n\s+inflight_saturation_recover_threshold: 0.6\n\s+memory_saturation_fail_threshold: 0.85\n\s+memory_saturation_recover_threshold: 0.7\n\s+capacity_warning_threshold: 0.6\n\s+fail_checks: 2\n\s+recover_checks: 3\n\s+rejected_quiet_duration: 1m\n\s+oldest_item_age_fail_threshold: 1m\n\s+memory_limit_bytes: 536870912\n'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
+
+  - it: keeps s3 LB config and appends readiness overlay arg
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.otelConfig.s3path: s3://bucket/lb.yaml
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --config=s3://bucket/lb.yaml
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: --config=file:/etc/otel/load-balancer-readiness-config.yaml
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: sawmills-load-balancer-readiness-config
+
+  - it: does not render LB readiness overlay when disabled
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honors explicit zero memory limit as memory gate disabled
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.memoryLimitBytes: 0
+      loadBalancer.resources.limits.memory: 512Mi
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'memory_limit_bytes: 0'

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1268,6 +1268,37 @@ loadBalancer:
   #     extensions: [health_check, file_storage/otc]
   extraEnv: []
   ports: {}
+  # Optional pressure-aware readiness for LB collector pods. When enabled, the
+  # chart adds the existing Sawmills backend_drain extension to the LB config
+  # and points the Kubernetes readiness probe at backend_drain /ready. Liveness
+  # stays on the collector health_check endpoint.
+  pressureReadiness:
+    enabled: false
+    port: 13137
+    readinessPath: /ready
+    drainPath: /drain
+    drainDuration: 15s
+    # Defaults to HAProxy /ready when HAProxy HTTP readiness is enabled,
+    # otherwise to collector health_check.
+    healthCheckEndpoint: ""
+    metricsEndpoint: http://${env:MY_POD_IP}:8888/metrics
+    queueSaturationFailThreshold: 0.85
+    queueSaturationRecoverThreshold: 0.60
+    inflightSaturationFailThreshold: 0.85
+    inflightSaturationRecoverThreshold: 0.60
+    memorySaturationFailThreshold: 0.85
+    memorySaturationRecoverThreshold: 0.70
+    capacityWarningThreshold: 0.60
+    failChecks: 2
+    recoverChecks: 3
+    rejectedQuietDuration: 1m
+    oldestItemAgeFailThreshold: 1m
+    # When unset, derived from loadBalancer.resources.limits.memory. Set 0 to
+    # disable memory pressure gating for limitless pods.
+    memoryLimitBytes: null
+    serviceExtensions:
+      - health_check
+      - cgroupruntime
   # Pod disruption budget for LB pods. Enabled by default to prevent
   # simultaneous voluntary disruptions (node scale-down, upgrades)
   # from taking all LB pods offline at once.


### PR DESCRIPTION
## Summary
- adds loadBalancer.pressureReadiness values and documentation
- renders an LB backend_drain readiness overlay config
- routes LB collector readiness to backend_drain /ready when enabled while liveness remains health_check
- derives memory_limit_bytes from loadBalancer.resources.limits.memory, with explicit 0 supported to disable memory gating

## Red / Green
- RED: `helm unittest helm-charts/sawmills-collector -f 'tests/load_balancer_pressure_readiness_test.yaml'` failed before implementation because the overlay/probe/config did not exist
- RED: explicit `memoryLimitBytes: 0` test failed until template stopped treating zero as empty
- GREEN: pressure readiness unit test passes

## Verification
- `helm lint helm-charts/sawmills-collector`
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh` (26 suites / 206 tests)

SAW-7500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pressure-aware readiness for LB collector pods by routing Kubernetes readiness to the `backend_drain` `/ready` endpoint while keeping liveness on `health_check`. Supports SAW-7500 by shedding traffic under queue/inflight/memory pressure and exposes clear readiness and warning metrics.

- **New Features**
  - Opt-in via `loadBalancer.pressureReadiness.enabled: true`.
  - Adds a readiness overlay ConfigMap and `--config=file:/etc/otel/load-balancer-readiness-config.yaml` for LB pods.
  - Readiness probes target `backend_drain` (`port: 13137`, `path: /ready`); liveness stays on `:13133/healthcheck`.
  - Pressure checks read from `metricsEndpoint` and gate on queue, inflight, and memory thresholds; derives `memory_limit_bytes` from `loadBalancer.resources.limits.memory` (`0` disables).
  - Preserves existing `service.extensions` and appends `backend_drain`; defaults `health_check_endpoint` to HAProxy `/ready` when HAProxy HTTP readiness is enabled, otherwise to collector `health_check`.
  - Documents metrics: `otelcol_backend_drain_pressure_ready`, `otelcol_backend_drain_pressure_transitions_total`, and `otelcol_backend_drain_pressure_warning` with stable reason labels.

- **Migration**
  - Off by default; enable with `loadBalancer.pressureReadiness.enabled: true`.
  - If pods have no memory limit, set `pressureReadiness.memoryLimitBytes` (or `0` to disable); otherwise it derives from `loadBalancer.resources.limits.memory` (Gi/Mi only).

<sup>Written for commit 18012be969357611334bca319fa8f96347e5b706. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added load balancer pressure readiness configuration for improved pod health gating with memory and saturation thresholds.
  * New configuration options for readiness probe endpoints, drain duration, and memory limit settings.

* **Documentation**
  * Updated README with pressure readiness feature documentation and configuration examples.

* **Tests**
  * Added comprehensive test suite for load balancer pressure readiness rendering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->