### PR TITLE
fix(sawmills-collector): correct LB pressure readiness defaults

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -588,7 +588,7 @@ rollout:
       readinessPath: /ready
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
-      serviceExtensions: [health_check, cgroupruntime]
+      serviceExtensions: [health_check, cgroup_runtime]
       duration: 120s
       shutdownReserve: 10s
     preStopSleepSeconds: 15
@@ -608,7 +608,7 @@ rollout:
       readinessPath: /ready
       drainPath: /drain
       healthCheckEndpoint: http://${env:MY_POD_IP}:13133/healthcheck
-      serviceExtensions: [health_check, cgroupruntime]
+      serviceExtensions: [health_check, cgroup_runtime]
       duration: 120s
       shutdownReserve: 10s
 ```
@@ -616,7 +616,7 @@ rollout:
 With that topology enabled, the chart:
 
 * Adds a separate `backend_drain` config overlay as an extra `--config`, including S3-backed main collector configs.
-* Preserves the main collector extension list by defaulting to `health_check`, `cgroupruntime`, and appending `backend_drain` unless `otelCollectorConfig.service.extensions` already specifies a custom list.
+* Preserves the main collector extension list by defaulting to `health_check`, `cgroup_runtime`, and appending `backend_drain` unless `otelCollectorConfig.service.extensions` already specifies a custom list.
 * When the main collector config comes from S3, mirror any extra `service.extensions` entries in `rollout.main.drain.serviceExtensions`, because the chart cannot inspect or merge the remote extension list for you.
 * Configures the drain-aware readiness server to mirror the normal `health_check` endpoint until drain starts, so readiness still tracks real collector health.
 * Switches the main collector readiness probe to the drain-aware endpoint.
@@ -789,7 +789,7 @@ loadBalancer:
   enabled: true
   pressureReadiness:
     enabled: true
-    metricsEndpoint: http://${env:MY_POD_IP}:8888/metrics
+    metricsEndpoint: http://${env:MY_POD_IP}:19465/metrics
     queueSaturationFailThreshold: 0.85
     queueSaturationRecoverThreshold: 0.60
     inflightSaturationFailThreshold: 0.85

--- a/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/backend-drain-configmap.yaml
@@ -4,7 +4,7 @@
 {{- if and (kindIs "map" .Values.otelCollectorConfig) (hasKey .Values.otelCollectorConfig "service") (kindIs "map" .Values.otelCollectorConfig.service) (hasKey .Values.otelCollectorConfig.service "extensions") }}
 {{- $serviceExtensions = deepCopy .Values.otelCollectorConfig.service.extensions }}
 {{- else }}
-{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") $mainDrain.serviceExtensions) }}
+{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroup_runtime") $mainDrain.serviceExtensions) }}
 {{- end }}
 {{- $filteredServiceExtensions := list }}
 {{- range $serviceExtensions }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -5,7 +5,7 @@
 {{- if and (kindIs "map" $lbConfig) (hasKey $lbConfig "service") (kindIs "map" $lbConfig.service) (hasKey $lbConfig.service "extensions") }}
 {{- $serviceExtensions = deepCopy $lbConfig.service.extensions }}
 {{- else }}
-{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroupruntime") $lbPressure.serviceExtensions) }}
+{{- $serviceExtensions = deepCopy (default (list "health_check" "cgroup_runtime") $lbPressure.serviceExtensions) }}
 {{- end }}
 {{- $filteredServiceExtensions := list }}
 {{- range $serviceExtensions }}
@@ -51,7 +51,7 @@ data:
         {{- end }}
         pressure_check:
           enabled: true
-          metrics_endpoint: {{ default "http://${env:MY_POD_IP}:8888/metrics" $lbPressure.metricsEndpoint }}
+          metrics_endpoint: {{ default "http://${env:MY_POD_IP}:19465/metrics" $lbPressure.metricsEndpoint }}
           queue_saturation_fail_threshold: {{ default 0.85 $lbPressure.queueSaturationFailThreshold }}
           queue_saturation_recover_threshold: {{ default 0.60 $lbPressure.queueSaturationRecoverThreshold }}
           inflight_saturation_fail_threshold: {{ default 0.85 $lbPressure.inflightSaturationFailThreshold }}

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -71,7 +71,7 @@ tests:
           pattern: '(?ms)^extensions:\n\s+backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 120s\n'
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n'
 
   - it: should not render lifecycle patch marker on upgrades
     template: deployment.yaml

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -53,10 +53,10 @@ tests:
           count: 1
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n\s+pressure_check:\n\s+enabled: true\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:8888/metrics\n\s+queue_saturation_fail_threshold: 0.85\n\s+queue_saturation_recover_threshold: 0.6\n\s+inflight_saturation_fail_threshold: 0.85\n\s+inflight_saturation_recover_threshold: 0.6\n\s+memory_saturation_fail_threshold: 0.85\n\s+memory_saturation_recover_threshold: 0.7\n\s+capacity_warning_threshold: 0.6\n\s+fail_checks: 2\n\s+recover_checks: 3\n\s+rejected_quiet_duration: 1m\n\s+oldest_item_age_fail_threshold: 1m\n\s+memory_limit_bytes: 536870912\n'
+          pattern: '(?ms)backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n\s+pressure_check:\n\s+enabled: true\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:19465/metrics\n\s+queue_saturation_fail_threshold: 0.85\n\s+queue_saturation_recover_threshold: 0.6\n\s+inflight_saturation_fail_threshold: 0.85\n\s+inflight_saturation_recover_threshold: 0.6\n\s+memory_saturation_fail_threshold: 0.85\n\s+memory_saturation_recover_threshold: 0.7\n\s+capacity_warning_threshold: 0.6\n\s+fail_checks: 2\n\s+recover_checks: 3\n\s+rejected_quiet_duration: 1m\n\s+oldest_item_age_fail_threshold: 1m\n\s+memory_limit_bytes: 536870912\n'
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroupruntime\n\s+- backend_drain\n'
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n'
 
   - it: keeps s3 LB config and appends readiness overlay arg
     template: load-balancer.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -113,7 +113,7 @@ rollout:
       # chart cannot inspect the remote file directly.
       serviceExtensions:
         - health_check
-        - cgroupruntime
+        - cgroup_runtime
       # Keep drain.duration + shutdownReserve below
       # rollout.terminationGracePeriodSeconds so the collector still has time
       # to handle SIGTERM after the drain hook returns.
@@ -592,7 +592,7 @@ otelCollectorConfig: {}
 #   health_check:
 #     endpoint: ${env:MY_POD_IP}:13133
 
-#   cgroupruntime:
+#   cgroup_runtime:
 #     gomaxprocs:
 #       enabled: true
 #     gomemlimit:
@@ -600,7 +600,7 @@ otelCollectorConfig: {}
 #       ratio: 0.8
 
 # service:
-#   extensions: [health_check, cgroupruntime]
+#   extensions: [health_check, cgroup_runtime]
 #   telemetry:
 #     logs:
 #       level: info
@@ -982,7 +982,7 @@ telemetryConfig:
       max_stale: 1m
 
   extensions:
-    cgroupruntime:
+    cgroup_runtime:
       gomaxprocs:
         enabled: true
       gomemlimit:
@@ -1003,7 +1003,7 @@ telemetryConfig:
     forward:
 
   service:
-    extensions: [health_check, cgroupruntime]
+    extensions: [health_check, cgroup_runtime]
     pipelines:
       metrics/customer_collector:
         receivers: [otlp/customer_collector]
@@ -1155,7 +1155,7 @@ kedaScaler:
         send_batch_size: 1024
         timeout: 1s
     extensions:
-      cgroupruntime:
+      cgroup_runtime:
         gomaxprocs:
           enabled: true
         gomemlimit:
@@ -1166,7 +1166,7 @@ kedaScaler:
     service:
       extensions:
         - health_check
-        - cgroupruntime
+        - cgroup_runtime
       pipelines:
         metrics:
           receivers:
@@ -1281,7 +1281,7 @@ loadBalancer:
     # Defaults to HAProxy /ready when HAProxy HTTP readiness is enabled,
     # otherwise to collector health_check.
     healthCheckEndpoint: ""
-    metricsEndpoint: http://${env:MY_POD_IP}:8888/metrics
+    metricsEndpoint: http://${env:MY_POD_IP}:19465/metrics
     queueSaturationFailThreshold: 0.85
     queueSaturationRecoverThreshold: 0.60
     inflightSaturationFailThreshold: 0.85
@@ -1298,7 +1298,7 @@ loadBalancer:
     memoryLimitBytes: null
     serviceExtensions:
       - health_check
-      - cgroupruntime
+      - cgroup_runtime
   # Pod disruption budget for LB pods. Enabled by default to prevent
   # simultaneous voluntary disruptions (node scale-down, upgrades)
   # from taking all LB pods offline at once.


### PR DESCRIPTION
## Summary
- default LB pressure readiness metrics endpoint to the in-pod telemetry Prometheus endpoint on `:19465`
- use `cgroup_runtime` as the service extension id in backend drain and LB readiness overlays
- update chart tests and docs so the staging-discovered failure mode is covered

## Evidence
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh` -> 206 tests passed
- `helm lint helm-charts/sawmills-collector` -> 0 failed
- `helm template sawmills-collector helm-charts/sawmills-collector --set loadBalancer.enabled=true --set loadBalancer.pressureReadiness.enabled=true --set loadBalancer.resources.limits.memory=512Mi` -> renders `cgroup_runtime` and `metrics_endpoint: http://${env:MY_POD_IP}:19465/metrics`

## SAW-7500 staging finding
Staging showed `/healthcheck=200` while `/ready=503` because pressure readiness scraped `:8888/metrics`, which was not listening in LB pods. The same pod exposed the required central queue/process metrics through the telemetry sidecar at `:19465/metrics`.

SAW-7500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LB pressure readiness defaults by scraping the telemetry sidecar at :19465 and aligning service extension IDs to `cgroup_runtime`, preventing false `/ready=503` on LB pods. Addresses SAW-7500 by making LB readiness reflect real queue pressure during rollouts.

- **Bug Fixes**
  - Default `metricsEndpoint` to `http://${env:MY_POD_IP}:19465/metrics` for LB pressure readiness (values, templates, tests, README).
  - Use `cgroup_runtime` in backend drain and LB readiness overlays; replace `cgroupruntime` across configs/tests/docs.
  - Update chart tests to cover the staging failure mode where `:8888/metrics` wasn’t present.

<sup>Written for commit 440e7f8c08002ed10a61db4c9de33cf8c393b73d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized service extension naming from `cgroupruntime` to `cgroup_runtime` across collector, telemetry, and KEDA scaler configurations
  * Updated default metrics endpoint port from `8888` to `19465` for load balancer readiness

* **Documentation**
  * Updated Helm chart documentation and test cases to reflect naming and port configuration changes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->