### PR TITLE
chore(charts): bump RO/SC image tags - livetail notify (SAW-7456)

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.6.13
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.558.0"
+appVersion: "1.944.0"

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -232,7 +232,7 @@ telemetryExtraEnv: []
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-collector
   pullPolicy: IfNotPresent
-  tag: 1.770.0
+  tag: 1.944.0
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 

--- a/helm-charts/sawmills-remote-operator/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: "2.0.21"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.247.0"
+appVersion: "0.261.0"

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -34,7 +34,7 @@ collectorName: ""
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
-  tag: 0.247.0 # Sawmills Remote Operator image tag
+  tag: 0.261.0 # Sawmills Remote Operator image tag
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 


### PR DESCRIPTION
## Summary

- `sawmills-collector`: `1.770.0` → `1.944.0`
- `sawmills-remote-operator`: `0.247.0` → `0.261.0`

## Why

Brings chart defaults forward so fresh installs without `image.tag` overrides get the livetail control extension (collector `≥ v1.937.0`) and the matching remote-operator livetail fast-start dispatcher (`≥ v0.259.0`) shipped under SAW-7456.

Follow-up to #177 (chart structure for port 13138). Per past `chore(charts): bump default image tags` convention (#137), version bumps live in their own PR.

## SAW-7456 minimums vs. selected

| Component | Min for SAW-7456 | Selected | Latest at PR time |
|---|---|---|---|
| sawmills-collector | `v1.937.0` | **`1.944.0`** | `v1.944.0` |
| sawmills-remote-operator | `v0.259.0` | **`0.261.0`** | `v0.261.0` |

Selected = latest released; picks up bugfixes shipped on top of the SAW-7456 feature commits.

## Test plan
- [x] `helm template helm-charts/sawmills-collector` renders new image tag
- [x] `helm template helm-charts/sawmills-remote-operator` renders new image tag
- [ ] Smoke deploy on a non-prod fresh-install path (customer simulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update default Helm chart image tags and sync Chart `appVersion`s so fresh installs get SAW-7456 livetail features by default and Helm metadata matches the shipped images.

- **Dependencies**
  - `sawmills-collector`: 1.770.0 → 1.944.0
  - `sawmills-remote-operator`: 0.247.0 → 0.261.0

<sup>Written for commit 03b87a7ab670c6383600f7532384a83c790815b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sawmills Collector to container image version 1.944.0
  * Updated Sawmills Remote Operator to container image version 0.261.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->