### PR TITLE
fix(remote-operator): default image repository for reused values

### DIFF
--- a/helm-charts/sawmills-remote-operator/templates/_helpers.tpl
+++ b/helm-charts/sawmills-remote-operator/templates/_helpers.tpl
@@ -34,10 +34,13 @@ Create chart name and version as used by the chart label.
 Build the remote-operator image reference. If image.digest is set, pin by digest and ignore image.tag.
 */}}
 {{- define "sawmills-remote-operator.image" -}}
-{{- if .Values.image.digest -}}
-{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- $image := default dict .Values.image -}}
+{{- $repository := default "public.ecr.aws/s7a5m1b4/sawmills-remote-operator" $image.repository -}}
+{{- if $image.digest -}}
+{{- printf "%s@%s" $repository $image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- $tag := required "image.tag is required when image.digest is not set" $image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 {{- end }}
 

--- a/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
+++ b/helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml
@@ -13,6 +13,17 @@ tests:
           path: spec.template.spec.containers[0].image
           value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator@sha256:deadbeef
 
+  - it: should default image repository when reused values only contain tag
+    set:
+      apiKey: test-key
+      collectorName: sawmills-collector
+      image.repository: null
+      image.tag: 0.262.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/s7a5m1b4/sawmills-remote-operator:0.262.0
+
   - it: should pass managed collector and haproxy image digests
     set:
       apiKey: test-key


### PR DESCRIPTION
remote-operator: Default image repository for reused values

Fixes the BigID remote-operator chart upgrade blocker where Helm `--reuse-values` carries forward old values containing `image.tag` but not `image.repository`. The 2.2.x chart then rendered `image: %!s(<nil>):0.262.0`, producing invalid YAML before the customer-side operator could upgrade.

- Default only the remote-operator image repository in the chart helper when reused values omit it.
- Keep `image.tag` required unless `image.digest` is set, so we do not silently render a chart-version image tag.
- Add a regression test for the old BigID reused-values shape.

Test plan:
- [x] RED: `helm unittest helm-charts/sawmills-remote-operator -f tests/image_digest_test.yaml --color` failed before the helper fix with invalid YAML from `%!s(<nil>):0.262.0`.
- [x] GREEN: `helm unittest helm-charts/sawmills-remote-operator -f tests/image_digest_test.yaml --color`
- [x] `helm template test helm-charts/sawmills-remote-operator --set apiKey=test --set collectorName=test --set image.tag=0.262.0 --set-json image.repository=null --debug`
- [x] `helm lint helm-charts/sawmills-remote-operator`
- [x] `helm template test-release helm-charts/sawmills-remote-operator --values helm-charts/sawmills-remote-operator/values.yaml`
- [x] `helm-charts/sawmills-remote-operator/tests/run-tests.sh`
- [x] `trunk check helm-charts/sawmills-remote-operator/templates/_helpers.tpl helm-charts/sawmills-remote-operator/tests/image_digest_test.yaml`
- [x] `git diff --check`

SAW-7500

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Helm chart image rendering for `sawmills-remote-operator` when upgrading with `--reuse-values` by defaulting the image repository if only `image.tag` is present, preventing invalid YAML and unblocking BigID upgrades. Addresses SAW-7500 by removing the chart upgrade blocker.

- **Bug Fixes**
  - Default `image.repository` to `public.ecr.aws/s7a5m1b4/sawmills-remote-operator` when reused values omit it but include `image.tag`.
  - Keep `image.tag` required unless `image.digest` is set.
  - Add a regression test for the reused-values shape seen in BigID deployments.

<sup>Written for commit 4f993215fc55148754952948675c8b5158f9e789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm chart image configuration now supports digest-based container image references alongside tag-based references with automatic default repository assignment.

* **Tests**
  * Added test coverage for default image repository handling in Helm deployment configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->