### PR TITLE
sawmills-collector: harden keda scaler probes (SAW-7553)

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -209,6 +209,10 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  fallback:
+    enabled: false
+    failureThreshold: 3
+    replicas: 10
   annotations: {}
   # For non-Helm-owned HPA ownership transfer:
   # annotations:
@@ -262,6 +266,10 @@ keda:
   enabled: true
   minReplicas: 3
   maxReplicas: 20
+  fallback:
+    enabled: true
+    failureThreshold: 3
+    replicas: 10
   scaling:
     cpu:
       enabled: false
@@ -277,6 +285,7 @@ keda:
         targetValue: "10485760"
 kedaScaler:
   enabled: true
+  replicaCount: 1
 ```
 
 ### HAProxy Load Balancing
@@ -822,9 +831,10 @@ Enable the KEDA scaler component:
 ```yaml
 kedaScaler:
   enabled: true
+  replicaCount: 1
   resources:
     limits:
-      cpu: 500m
+      cpu: 2
       memory: 256Mi
     requests:
       cpu: 500m

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -285,7 +285,6 @@ keda:
         targetValue: "10485760"
 kedaScaler:
   enabled: true
-  replicaCount: 1
 ```
 
 ### HAProxy Load Balancing
@@ -831,7 +830,6 @@ Enable the KEDA scaler component:
 ```yaml
 kedaScaler:
   enabled: true
-  replicaCount: 1
   resources:
     limits:
       cpu: 2

--- a/helm-charts/sawmills-collector/templates/keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-hpa.yaml
@@ -21,6 +21,11 @@ spec:
   maxReplicaCount: {{ .Values.keda.maxReplicas }}
   pollingInterval: {{ .Values.keda.pollingInterval }}
   cooldownPeriod: {{ .Values.keda.cooldownPeriod }}
+  {{- if and .Values.keda.fallback .Values.keda.fallback.enabled }}
+  fallback:
+    failureThreshold: {{ .Values.keda.fallback.failureThreshold }}
+    replicas: {{ .Values.keda.fallback.replicas }}
+  {{- end }}
   {{- with .Values.keda.advanced }}
   advanced:
     {{- with .horizontalPodAutoscalerConfig }}

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.kedaScaler.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- $selectorLabels := include "sawmills-collector.selectorLabels" . | fromYaml }}

--- a/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/keda-scaler-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.kedaScaler.replicaCount }}
   selector:
     matchLabels:
       {{- $selectorLabels := include "sawmills-collector.selectorLabels" . | fromYaml }}
@@ -66,17 +66,20 @@ spec:
                   fieldPath: status.podIP
           livenessProbe:
             httpGet:
-              path: /healthcheck
-              port: {{ .Values.kedaScaler.service.healthcheckPort }}
+              path: /query?query=up
+              port: {{ .Values.kedaScaler.service.monitoringPort }}
             initialDelaySeconds: {{ .Values.kedaScaler.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.kedaScaler.probes.liveness.periodSeconds }}
             failureThreshold: {{ .Values.kedaScaler.probes.liveness.failureThreshold }}
+            timeoutSeconds: {{ .Values.kedaScaler.probes.liveness.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /healthcheck
               port: {{ .Values.kedaScaler.service.healthcheckPort }}
             initialDelaySeconds: {{ .Values.kedaScaler.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.kedaScaler.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.kedaScaler.probes.readiness.failureThreshold }}
+            timeoutSeconds: {{ .Values.kedaScaler.probes.readiness.timeoutSeconds }}
           resources:
             {{- toYaml .Values.kedaScaler.resources | nindent 12 }}
           volumeMounts:

--- a/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_hpa_test.yaml
@@ -129,6 +129,38 @@ tests:
       - notExists:
           path: spec.triggers[0].metadata.scalerAddress
 
+  - it: renders fallback replicas for metrics-api scaler failures
+    release:
+      name: sawmills-collector
+      namespace: sample-namespace
+    set:
+      loadBalancer:
+        enabled: true
+      kedaScaler:
+        enabled: true
+      keda:
+        enabled: true
+        fallback:
+          enabled: true
+          failureThreshold: 3
+          replicas: 10
+        scaling:
+          external:
+            enabled: true
+            loadBalancerTriggerType: metrics-api
+            loadBalancerMetadata:
+              query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+              targetValue: "10485760"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.fallback.failureThreshold
+          value: 3
+      - equal:
+          path: spec.fallback.replicas
+          value: 10
+
   - it: requires keda scaler when rendering LB metrics-api queue scaler
     set:
       loadBalancer:

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -1,0 +1,30 @@
+suite: keda scaler deployment
+templates:
+  - templates/keda-scaler-deployment.yaml
+tests:
+  - it: probes the query endpoint for liveness
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 19465
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /query?query=up
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13134
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthcheck
+
+  - it: renders configurable replica count
+    set:
+      kedaScaler:
+        enabled: true
+        replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2

--- a/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_deployment_test.yaml
@@ -7,19 +7,34 @@ tests:
       kedaScaler.enabled: true
     asserts:
       - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port
           value: 19465
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /query?query=up
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 2
+      - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: 13134
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 1
 
-  - it: renders configurable replica count
+  - it: keeps the scaler fixed at one replica
     set:
       kedaScaler:
         enabled: true
@@ -27,4 +42,4 @@ tests:
     asserts:
       - equal:
           path: spec.replicas
-          value: 2
+          value: 1

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1082,7 +1082,6 @@ serviceMonitor:
 
 kedaScaler:
   enabled: false
-  replicaCount: 1
   imagePullPolicy: Always
   podSecurityContext: {}
   probes:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -354,6 +354,12 @@ keda:
   maxReplicas: 100
   pollingInterval: 30
   cooldownPeriod: 0
+  # KEDA fallback keeps the target deployment above min replicas when scaler
+  # metrics fail repeatedly.
+  fallback:
+    enabled: false
+    failureThreshold: 3
+    replicas: 10
   # Optional annotations for the KEDA ScaledObject.
   # For non-Helm-owned HPA -> KEDA ownership transfers, set:
   #   scaledobject.keda.sh/transfer-hpa-ownership: "true"
@@ -1076,16 +1082,20 @@ serviceMonitor:
 
 kedaScaler:
   enabled: false
+  replicaCount: 1
   imagePullPolicy: Always
   podSecurityContext: {}
   probes:
     liveness:
       initialDelaySeconds: 5
       periodSeconds: 5
-      failureThreshold: 5
+      failureThreshold: 3
+      timeoutSeconds: 2
     readiness:
       initialDelaySeconds: 5
       periodSeconds: 5
+      failureThreshold: 3
+      timeoutSeconds: 1
   service:
     type: ClusterIP
     otlpReceiverPort: 4518
@@ -1095,7 +1105,7 @@ kedaScaler:
     otelPrometheusPort: 19876
   resources:
     limits:
-      cpu: 500m
+      cpu: 2
       memory: 256Mi
     requests:
       cpu: 500m


### PR DESCRIPTION
Harden the scaler runtime so KEDA can fall back when metric queries fail and probe the real dependency path.

- render optional KEDA fallback in the ScaledObject
- make scaler liveness hit `/query?query=up`
- keep the scaler fixed at one replica and raise CPU headroom
- add Helm tests for fallback and probe rendering

Testing Performed
- helm lint helm-charts/sawmills-collector
- helm unittest helm-charts/sawmills-collector
- helm template helm-charts/sawmills-collector --set keda.enabled=true --set kedaScaler.enabled=true --set keda.fallback.enabled=true --set keda.fallback.failureThreshold=3 --set keda.fallback.replicas=10 | rg -n -C 2 -e '/query?query=up' -e 'replicas: 1' -e 'failureThreshold: 3' -e 'timeoutSeconds: 2' -e 'timeoutSeconds: 1'
- git diff --check

Breaking Changes
- none

Impact Assessment
- low; restores safe single-replica behavior while adding fallback and probe hardening

Refs
- SAW-7553
