### PR TITLE
SAW-7500: support absolute CPU HPA targets

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -183,6 +183,9 @@ autoscaling:
   enabled: true
   minReplicas: 3
   maxReplicas: 50
+  # Optional absolute per-pod CPU target, e.g. 400m. When set, the HPA uses
+  # Resource/AverageValue instead of CPU utilization.
+  targetCPUAverageValue: ""
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
   behavior:
@@ -725,6 +728,15 @@ Enable a separate load balancer deployment:
 loadBalancer:
   enabled: true
   replicas: 3
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 50
+    # Optional absolute per-pod CPU target, e.g. 400m. When set, the HPA uses
+    # Resource/AverageValue instead of CPU utilization.
+    targetCPUAverageValue: ""
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   minReadySeconds: 15
   strategy:
     type: RollingUpdate

--- a/helm-charts/sawmills-collector/templates/hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/hpa.yaml
@@ -12,8 +12,16 @@ spec:
     name: {{ include "sawmills-collector.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if or .Values.autoscaling.targetCPUAverageValue .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetCPUAverageValue }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaling.targetCPUAverageValue }}
+    {{- else if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
@@ -29,6 +37,7 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- end }}
   {{- with .Values.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-hpa.yaml
@@ -16,9 +16,16 @@ spec:
     name: {{ include "sawmills-collector.fullname" . }}-lb
   minReplicas: {{ .Values.loadBalancer.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.loadBalancer.autoscaling.maxReplicas }}
-  {{- if or .Values.loadBalancer.autoscaling.targetCPUUtilizationPercentage .Values.loadBalancer.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- if or .Values.loadBalancer.autoscaling.targetCPUAverageValue .Values.loadBalancer.autoscaling.targetCPUUtilizationPercentage .Values.loadBalancer.autoscaling.targetMemoryUtilizationPercentage }}
   metrics:
-  {{- if .Values.loadBalancer.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if .Values.loadBalancer.autoscaling.targetCPUAverageValue }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.loadBalancer.autoscaling.targetCPUAverageValue }}
+  {{- else if .Values.loadBalancer.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu

--- a/helm-charts/sawmills-collector/tests/hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/hpa_test.yaml
@@ -19,6 +19,28 @@ tests:
           path: spec.scaleTargetRef.name
           value: RELEASE-NAME
 
+  - it: renders absolute CPU average value target when configured
+    set:
+      autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 0
+        targetCPUAverageValue: 400m
+      keda:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: AverageValue
+      - equal:
+          path: spec.metrics[0].resource.target.averageValue
+          value: 400m
+
   - it: does not render the standard HPA when KEDA is enabled
     set:
       autoscaling:

--- a/helm-charts/sawmills-collector/tests/load_balancer_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_hpa_test.yaml
@@ -52,6 +52,33 @@ tests:
           path: spec.maxReplicas
           value: 20
 
+  - it: should render absolute CPU average value target when configured
+    set:
+      loadBalancer:
+        enabled: true
+        autoscaling:
+          enabled: true
+          minReplicas: 2
+          maxReplicas: 10
+          targetCPUUtilizationPercentage: 0
+          targetMemoryUtilizationPercentage: 0
+          targetCPUAverageValue: 400m
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: AverageValue
+      - equal:
+          path: spec.metrics[0].resource.target.averageValue
+          value: 400m
+
   - it: should target StatefulSet when storage is enabled
     set:
       loadBalancer:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -334,6 +334,10 @@ autoscaling:
   enabled: false
   minReplicas: 3
   maxReplicas: 50
+  # Optional absolute per-pod CPU target, e.g. 400m. When set, the HPA uses
+  # Resource/AverageValue instead of CPU utilization, so scaling is not coupled
+  # to low CPU requests.
+  targetCPUAverageValue: ""
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
   # Add behavior configuration for faster scaling
@@ -1376,6 +1380,10 @@ loadBalancer:
     enabled: false
     minReplicas: 3
     maxReplicas: 50
+    # Optional absolute per-pod CPU target, e.g. 400m. When set, the HPA uses
+    # Resource/AverageValue instead of CPU utilization, so scaling is not coupled
+    # to low CPU requests.
+    targetCPUAverageValue: ""
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
     behavior:


### PR DESCRIPTION
sawmills-collector: Support absolute CPU HPA targets

Adds an optional per-pod CPU AverageValue HPA target so LB scaling can be decoupled from low CPU requests.

Description:
- Add targetCPUAverageValue to standard and load-balancer HPA values.
- Render Resource/AverageValue when configured, preserving Utilization as the default path.
- Cover standard and LB HPA rendering with helm unit tests and update chart docs.

Validation:
- helm unittest -f tests/load_balancer_hpa_test.yaml -f tests/hpa_test.yaml .
- ./tests/run-tests.sh
- helm lint helm-charts/sawmills-collector
- helm template test-release helm-charts/sawmills-collector --set loadBalancer.enabled=true --set loadBalancer.autoscaling.enabled=true --set loadBalancer.autoscaling.targetCPUUtilizationPercentage=0 --set loadBalancer.autoscaling.targetMemoryUtilizationPercentage=0 --set loadBalancer.autoscaling.targetCPUAverageValue=400m
- trunk check --fix <changed files>

Refs SAW-7500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional absolute CPU HPA targets (AverageValue) for the collector and LB so autoscaling can be based on per-pod CPU (e.g., 400m) instead of % of request. This decouples LB scaling from low CPU requests and supports SAW-7500’s goal to stabilize BigID on large clusters.

- **New Features**
  - Added `autoscaling.targetCPUAverageValue` and `loadBalancer.autoscaling.targetCPUAverageValue`.
  - When set, the HPA renders CPU as `Resource/AverageValue`; CPU `Utilization` remains the default.
  - README updated and Helm unit tests added for standard and LB HPAs.

- **Migration**
  - Enable by setting `autoscaling.targetCPUAverageValue: 400m` or `loadBalancer.autoscaling.targetCPUAverageValue: 400m`.
  - When set, CPU utilization is ignored; memory utilization (if set) still applies.

<sup>Written for commit 8b82ec53ae80f67fce7bcfe2e46f1b2d981d32ed. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `targetCPUAverageValue` configuration field for autoscaling in both collector and load balancer HPA.

* **Documentation**
  * Updated Helm chart documentation for the new autoscaling configuration option.

* **Tests**
  * Added test cases verifying the new autoscaling functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->