### PR TITLE
feat(sc+ro): direct notify for livetail and hotreload, collector control extension

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.13
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -21,4 +21,4 @@ version: 2.6.13
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.944.0"
+appVersion: "1.1000.0"

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -364,8 +364,6 @@ spec:
           {{- end }}
             - name: sawmills-livetail-config
               mountPath: /etc/livetail-config/
-            - name: sawmills-hot-reload-notifications
-              mountPath: /etc/hot-reload-notifications/
             - name: tmp
               mountPath: /tmp
             {{- with .Values.additionalVolumeMounts }}
@@ -417,9 +415,6 @@ spec:
         - name: sawmills-livetail-config
           configMap:
             name: {{ include "sawmills-collector.fullname" . }}-livetail-config
-        - name: sawmills-hot-reload-notifications
-          configMap:
-            name: {{ include "sawmills-collector.fullname" . }}-hot-reload-notifications
         - name: tmp
           emptyDir: {}
         {{- with .Values.additionalVolumes }}

--- a/helm-charts/sawmills-collector/templates/hot-reload-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/hot-reload-configmap.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "sawmills-collector.fullname" . }}-hot-reload-notifications
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "sawmills-collector.labels" . | nindent 4 }}
-  

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -83,7 +83,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.volumes[1].configMap.name
-          value: RELEASE-NAME-backend-drain-config-60a88d09c3fc
+          value: RELEASE-NAME-backend-drain-config-0366332b7e00
 
   - it: should keep image-scoped backend drain config maps for old replicas
     template: backend-drain-configmap.yaml
@@ -95,7 +95,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-backend-drain-config-60a88d09c3fc
+          value: RELEASE-NAME-backend-drain-config-0366332b7e00
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
           value: keep

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -236,7 +236,7 @@ telemetryExtraEnv: []
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-collector
   pullPolicy: IfNotPresent
-  tag: 1.944.0
+  tag: 1.1000.0
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 

--- a/helm-charts/sawmills-remote-operator/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.0.21"
+version: "2.0.22"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-remote-operator/Chart.yaml
+++ b/helm-charts/sawmills-remote-operator/Chart.yaml
@@ -21,4 +21,4 @@ version: "2.0.21"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.261.0"
+appVersion: "0.277.0"

--- a/helm-charts/sawmills-remote-operator/values.yaml
+++ b/helm-charts/sawmills-remote-operator/values.yaml
@@ -34,7 +34,7 @@ collectorName: ""
 image:
   repository: public.ecr.aws/s7a5m1b4/sawmills-remote-operator
   pullPolicy: Always
-  tag: 0.261.0 # Sawmills Remote Operator image tag
+  tag: 0.277.0 # Sawmills Remote Operator image tag
   # Optional image digest. When set, the chart renders repository@digest and ignores tag.
   digest: ""
 


### PR DESCRIPTION
Bump chart to 2.7.0 (breaking deploy-shape) and pair with V3 collector binary that uses direct-notify hot-reload via `collectorcontrolextension`. Drops the now-dead `sawmills-hot-reload-notifications` configMap, its volume, and the mount.

## Changes
- Image bumps: `sawmills-collector 1.944.0 → 1.1000.0`, `sawmills-remote-operator 0.261.0 → 0.277.0`. Both include the unified `collectorcontrol` direct-notify protocol (hot-reload + livetail) from SAW-7534.
- Deletes `templates/hot-reload-configmap.yaml` + the volume + the `/etc/hot-reload-notifications/` mount from `deployment.yaml`. V3 binary no longer reads them (fsnotify removed; `watch_path` config field accepted-and-ignored).
- Chart `version: 2.6.13 → 2.7.0`. Minor bump signals breaking deploy-shape change — customers MUST pair chart 2.7.x with collector image >= 1.966.0 (recommended 1.1000.0).

## Verification
- `helm template helm-charts/sawmills-collector --debug | grep -c hot-reload-notifications` → 0
- Livetail volume + mount untouched (2 refs to `sawmills-livetail-config`)
- `helm lint` clean

Linear: [SAW-7534](https://linear.app/sawmills/issue/SAW-7534)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pairs the `sawmills-collector` chart with the V3 `collectorcontrol` direct-notify flow for hot reload and livetail to meet SAW-7534, removing the old hot-reload ConfigMap and mounts. Updates default images and refreshes backend-drain test hashes, eliminating slow ConfigMap-based reloads.

- **Dependencies**
  - `sawmills-collector` chart 2.6.13 → 2.7.0 (app 1.1000.0; image 1.944.0 → 1.1000.0).
  - `sawmills-remote-operator` chart 2.0.21 → 2.0.22 (image 0.261.0 → 0.277.0).

- **Migration**
  - Use `sawmills-collector` chart 2.7.x with collector image >= 1.966.0 (recommended 1.1000.0).
  - The `sawmills-hot-reload-notifications` ConfigMap, volume, and `/etc/hot-reload-notifications/` mount are removed.

<sup>Written for commit a8915532029c2dacbc3b90d18b71aec66a9b7267. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sawmills Collector to version 2.7.0 with application version 1.1000.0
  * Updated Sawmills Remote Operator to application version 0.277.0

* **Refactor**
  * Removed hot-reload-notifications feature from Sawmills Collector

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->