### PR TITLE
feat(sawmills-collector): add LB Prometheus KEDA scaling

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -756,6 +756,29 @@ loadBalancer:
     className: "standard"
 ```
 
+`loadBalancer.autoscaling` renders a Kubernetes `HorizontalPodAutoscaler` with CPU and memory resource metrics, so the cluster must provide `metrics.k8s.io` data. In Prometheus/Thanos-only environments, use `loadBalancer.keda.scaling.prometheus` instead:
+
+```yaml
+loadBalancer:
+  enabled: true
+  keda:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 25
+    scaling:
+      prometheus:
+        enabled: true
+        metricType: Value
+        metadata:
+          serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+          query: "histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))"
+          threshold: "8000"
+      cpu:
+        enabled: false
+      memory:
+        enabled: false
+```
+
 #### Load Balancer Queue Compression Modes
 
 Configure these options in `loadBalancer.otelCollectorConfig.exporters.<loadbalancing-exporter>.sending_queue`:

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -758,9 +758,13 @@ loadBalancer:
 
 `loadBalancer.autoscaling` renders a Kubernetes `HorizontalPodAutoscaler` with CPU and memory resource metrics, so the cluster must provide `metrics.k8s.io` data. In Prometheus/Thanos-only environments, use `loadBalancer.keda.scaling.prometheus` instead:
 
+When `loadBalancer.keda.enabled: true`, set `loadBalancer.podDisruptionBudget.minAvailable` explicitly. The default is computed from static `loadBalancer.replicas`, which can be higher than the actual pod count after KEDA scales down and can block voluntary disruptions such as node drains or upgrades.
+
 ```yaml
 loadBalancer:
   enabled: true
+  podDisruptionBudget:
+    minAvailable: 2
   keda:
     enabled: true
     minReplicas: 3

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -38,7 +38,7 @@ spec:
         query: {{ required "loadBalancer.keda.scaling.prometheus.metadata.query is required when loadBalancer.keda.scaling.prometheus.enabled is true" $prometheusMetadata.query | quote }}
         threshold: {{ required "loadBalancer.keda.scaling.prometheus.metadata.threshold is required when loadBalancer.keda.scaling.prometheus.enabled is true" $prometheusMetadata.threshold | quote }}
         {{- range $key, $value := $prometheusMetadata }}
-        {{- if and (not (has $key (list "serverAddress" "query" "threshold"))) (not (empty $value)) }}
+        {{- if and (not (has $key (list "serverAddress" "query" "threshold"))) (not (kindIs "invalid" $value)) (not (and (kindIs "string" $value) (eq $value ""))) }}
         {{- printf "%s: %s" $key ($value | quote) | nindent 8 }}
         {{- end }}
         {{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -29,6 +29,14 @@ spec:
     {{- end }}
   {{- end }}
   triggers:
+    {{- if .Values.loadBalancer.keda.scaling.prometheus.enabled }}
+    - type: prometheus
+      metricType: {{ .Values.loadBalancer.keda.scaling.prometheus.metricType }}
+      metadata:
+        {{- range $key, $value := .Values.loadBalancer.keda.scaling.prometheus.metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
     {{- if .Values.loadBalancer.keda.scaling.cpu.enabled }}
     - type: cpu
       metricType: Utilization

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -30,11 +30,17 @@ spec:
   {{- end }}
   triggers:
     {{- if .Values.loadBalancer.keda.scaling.prometheus.enabled }}
+    {{- $prometheusMetadata := .Values.loadBalancer.keda.scaling.prometheus.metadata }}
     - type: prometheus
       metricType: {{ .Values.loadBalancer.keda.scaling.prometheus.metricType }}
       metadata:
-        {{- range $key, $value := .Values.loadBalancer.keda.scaling.prometheus.metadata }}
-        {{ $key }}: {{ $value | quote }}
+        serverAddress: {{ required "loadBalancer.keda.scaling.prometheus.metadata.serverAddress is required when loadBalancer.keda.scaling.prometheus.enabled is true" $prometheusMetadata.serverAddress | quote }}
+        query: {{ required "loadBalancer.keda.scaling.prometheus.metadata.query is required when loadBalancer.keda.scaling.prometheus.enabled is true" $prometheusMetadata.query | quote }}
+        threshold: {{ required "loadBalancer.keda.scaling.prometheus.metadata.threshold is required when loadBalancer.keda.scaling.prometheus.enabled is true" $prometheusMetadata.threshold | quote }}
+        {{- range $key, $value := $prometheusMetadata }}
+        {{- if and (not (has $key (list "serverAddress" "query" "threshold"))) (not (empty $value)) }}
+        {{- printf "%s: %s" $key ($value | quote) | nindent 8 }}
+        {{- end }}
         {{- end }}
     {{- end }}
     {{- if .Values.loadBalancer.keda.scaling.cpu.enabled }}

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -89,6 +89,24 @@ tests:
           path: spec.scaleTargetRef.kind
           value: StatefulSet
 
+  - it: requires Prometheus metadata when load balancer Prometheus scaling is enabled
+    template: templates/load-balancer-keda-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          scaling:
+            prometheus:
+              enabled: true
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: 'loadBalancer.keda.scaling.prometheus.metadata.serverAddress is required when loadBalancer.keda.scaling.prometheus.enabled is true'
+
   - it: renders load balancer ScaledObject when autoscaling and KEDA are both enabled
     template: templates/load-balancer-keda-hpa.yaml
     set:

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -107,6 +107,37 @@ tests:
       - failedTemplate:
           errorMessage: 'loadBalancer.keda.scaling.prometheus.metadata.serverAddress is required when loadBalancer.keda.scaling.prometheus.enabled is true'
 
+  - it: renders false and zero Prometheus metadata values
+    template: templates/load-balancer-keda-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          scaling:
+            prometheus:
+              enabled: true
+              metadata:
+                serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+                query: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+                threshold: "8000"
+                ignoreNullValues: false
+                activationThreshold: 0
+                emptyOptionalValue: ""
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.ignoreNullValues
+          value: "false"
+      - equal:
+          path: spec.triggers[0].metadata.activationThreshold
+          value: "0"
+      - notExists:
+          path: spec.triggers[0].metadata.emptyOptionalValue
+
   - it: renders load balancer ScaledObject when autoscaling and KEDA are both enabled
     template: templates/load-balancer-keda-hpa.yaml
     set:

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -1,10 +1,146 @@
 suite: Load Balancer KEDA HPA Tests
 templates:
   - templates/load-balancer-keda-hpa.yaml
+  - templates/load-balancer-hpa.yaml
 values:
   - ../values.yaml
 tests:
+  - it: renders Prometheus trigger for load balancer KEDA scaling
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sample-namespace
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          minReplicas: 3
+          maxReplicas: 25
+          scaling:
+            prometheus:
+              enabled: true
+              metricType: Value
+              metadata:
+                serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+                query: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+                threshold: "8000"
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: sawmills-collector-lb
+      - equal:
+          path: spec.minReplicaCount
+          value: 3
+      - equal:
+          path: spec.maxReplicaCount
+          value: 25
+      - equal:
+          path: spec.triggers[0].type
+          value: prometheus
+      - equal:
+          path: spec.triggers[0].metricType
+          value: Value
+      - equal:
+          path: spec.triggers[0].metadata.serverAddress
+          value: http://thanos-operator-query-frontend.monitoring:9090
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+      - equal:
+          path: spec.triggers[0].metadata.threshold
+          value: "8000"
+
+  - it: targets StatefulSet for Prometheus scaling when load balancer storage is enabled
+    template: templates/load-balancer-keda-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        storage:
+          enabled: true
+        keda:
+          enabled: true
+          scaling:
+            prometheus:
+              enabled: true
+              metadata:
+                serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+                query: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+                threshold: "8000"
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+
+  - it: renders load balancer ScaledObject when autoscaling and KEDA are both enabled
+    template: templates/load-balancer-keda-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        autoscaling:
+          enabled: true
+        keda:
+          enabled: true
+          scaling:
+            prometheus:
+              enabled: true
+              metadata:
+                serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+                query: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+                threshold: "8000"
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+
+  - it: suppresses load balancer HPA when load balancer KEDA is enabled
+    template: templates/load-balancer-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        autoscaling:
+          enabled: true
+        keda:
+          enabled: true
+          scaling:
+            prometheus:
+              enabled: true
+              metadata:
+                serverAddress: http://thanos-operator-query-frontend.monitoring:9090
+                query: histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))
+                threshold: "8000"
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders CPU and memory triggers with KEDA metricType syntax
+    template: templates/load-balancer-keda-hpa.yaml
     set:
       loadBalancer:
         enabled: true

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1367,6 +1367,13 @@ loadBalancer:
                 value: 1
             stabilizationWindowSeconds: 0
     scaling:
+      prometheus:
+        enabled: false
+        metricType: Value
+        metadata:
+          serverAddress: ""
+          query: ""
+          threshold: ""
       cpu:
         enabled: true
         targetUtilization: 80


### PR DESCRIPTION
## Summary

Render loadBalancer.keda.scaling.prometheus triggers for the LB ScaledObject and document the Prometheus/Thanos-only path.

## Changes Made

* \[x] Feature addition
* \[ ] Bug fix
* \[x] Documentation update
* \[ ] Breaking change
* \[ ] Configuration change
* \[ ] Performance improvement



## Testing Performed

<!-- Check all that apply -->

* \[x] Helm template validation (`helm template --debug`)
* \[x] Helm lint check (`helm lint`)
* \[ ] Dry run installation (`helm install --dry-run`)
* \[ ] Deployed to test environment
* \[ ] Manual testing completed
* \[ ] Regression testing performed

### Test Details

<!-- Describe how you tested these changes -->

**Commands used:**

```bash
# Add the commands you used to test
```

**Test environments:**

* \[ ] Local development
* \[ ] Staging environment
* \[ ] Customer test environment

**Results:**

* Expected: <!-- What you expected to happen -->
* Actual: <!-- What actually happened -->

## Breaking Changes

<!-- Check one -->

* \[ ] No breaking changes
* \[ ] Contains breaking changes (describe below)

**Breaking Change Details:**

<!-- If this is a breaking change, describe: -->

* **What breaks:**
* **Migration path:**
* **Version compatibility:**

## Impact Assessment

<!-- Describe the impact of these changes -->

* **Who is affected:**
* **What systems are affected:**
* **Rollback plan:**

## Documentation Updated

<!-- Check all that apply -->

* \[ ] Chart README.md updated
* \[ ] Configuration examples added/updated
* \[ ] CHANGELOG.md updated
* \[ ] Inline comments added for complex logic
* \[ ] Not applicable (no documentation changes needed)

## Additional Notes

<!-- Any additional context, screenshots, or information -->

***

## Checklist

* \[ ] I have read the [contribution guidelines](README.md#contributing)
* \[ ] I have tested my changes thoroughly
* \[ ] I have updated documentation as needed
* \[ ] I have added the appropriate version label (`version:patch`, `version:minor`, or `version:major`)
* \[ ] I have tagged @sawmills/engineers for review
* \[ ] I have provided clear commit messages

***

@sawmills/engineers Please review this contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus/Thanos-based KEDA autoscaling for the load balancer tier so clusters without `metrics-server` can scale. When Prometheus KEDA is enabled, we render an LB `ScaledObject`, validate required Prometheus fields at template time, and suppress the resource HPA. This satisfies SAW-7382.

- **New Features**
  - Add `loadBalancer.keda.scaling.prometheus` with `metricType` and required `metadata.serverAddress/query/threshold`.
  - Render `type: prometheus` trigger for the LB `ScaledObject` (targets `StatefulSet` when LB storage is enabled).
  - Pass through optional Prometheus metadata; preserve `false`/`0` values and ignore empty strings.
  - Suppress LB HPA when KEDA is on; HPA remains for `metrics-server` environments.
  - README adds a Prometheus-only example and PDB `minAvailable` guidance; tests cover trigger rendering, target selection, HPA suppression, metadata validation, and edge cases.

- **Migration**
  - Enable with:
    - `loadBalancer.keda.enabled: true`
    - `loadBalancer.keda.scaling.prometheus.enabled: true`
    - set `serverAddress`, `query`, `threshold`; set `cpu.enabled: false` and `memory.enabled: false`
  - No change needed if you stay on HPA.
  - If using PDBs, set `loadBalancer.podDisruptionBudget.minAvailable` explicitly to avoid scale-down/drain stalls with KEDA.

<sup>Written for commit 3bab80dfd32d5e4714c491bc513ea1c2aa48914f. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus-based autoscaling support for the load balancer tier via KEDA.

* **Documentation**
  * Added examples and guidance for Prometheus-only environments and KEDA configuration.
  * Clarified that when KEDA is enabled, the load balancer PodDisruptionBudget's minAvailable must be set explicitly.

* **Tests**
  * Expanded test suite to cover Prometheus KEDA triggers, failure cases, and multiple scaling scenarios.

* **Chores**
  * Bumped chart version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->