### PR TITLE
feat(sawmills-collector): add LB KEDA external scaling

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -290,6 +290,37 @@ kedaScaler:
   enabled: true
 ```
 
+For load balancer pod autoscaling, prefer `loadBalancer.keda.scaling.external` with the bundled Sawmills KEDA scaler. This mode does not require a separate Prometheus or VictoriaMetrics deployment:
+
+```yaml
+loadBalancer:
+  enabled: true
+  keda:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 25
+    pollingInterval: 15
+    cooldownPeriod: 31
+    scaling:
+      cpu:
+        enabled: false
+      memory:
+        enabled: false
+      prometheus:
+        enabled: false
+      external:
+        enabled: true
+        metricType: AverageValue
+        metadata:
+          scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
+          query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+          targetValue: "10485760"
+kedaScaler:
+  enabled: true
+```
+
+Use `sum(otelcol_loadbalancer_central_queue_compressed_bytes)` with target `10485760` for byte-sized central queue scaling. The legacy item-sized fallback is `sum(otelcol_exporter_queue_size{exporter=~"loadbalancing/collector-loadbalancer.*"})` with target `300`. Custom metrics must be forwarded through collector telemetry and allowed by `kedaScaler.telemetryConfig`.
+
 ### HAProxy Load Balancing
 
 Enable HAProxy for advanced load balancing:
@@ -756,7 +787,7 @@ loadBalancer:
     className: "standard"
 ```
 
-`loadBalancer.autoscaling` renders a Kubernetes `HorizontalPodAutoscaler` with CPU and memory resource metrics, so the cluster must provide `metrics.k8s.io` data. In Prometheus/Thanos-only environments, use `loadBalancer.keda.scaling.prometheus` instead:
+`loadBalancer.autoscaling` renders a Kubernetes `HorizontalPodAutoscaler` with CPU and memory resource metrics, so the cluster must provide `metrics.k8s.io` data. Prefer `loadBalancer.keda.scaling.external` with the bundled Sawmills KEDA scaler when resource metrics are not enough. `loadBalancer.keda.scaling.prometheus` remains available as an alternative configuration path:
 
 When `loadBalancer.keda.enabled: true`, set `loadBalancer.podDisruptionBudget.minAvailable` explicitly. The default is computed from static `loadBalancer.replicas`, which can be higher than the actual pod count after KEDA scales down and can block voluntary disruptions such as node drains or upgrades.
 
@@ -771,16 +802,24 @@ loadBalancer:
     maxReplicas: 25
     scaling:
       prometheus:
-        enabled: true
+        enabled: false
         metricType: Value
         metadata:
           serverAddress: http://thanos-operator-query-frontend.monitoring:9090
           query: "histogram_quantile(0.999, sum(rate(http_server_duration_bucket[1m])) by (le))"
           threshold: "8000"
+      external:
+        enabled: true
+        metricType: AverageValue
+        metadata:
+          query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+          targetValue: "10485760"
       cpu:
         enabled: false
       memory:
         enabled: false
+kedaScaler:
+  enabled: true
 ```
 
 #### Load Balancer Queue Compression Modes

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -631,7 +631,12 @@ plain query string. Requires kedaScaler.enabled=true. Returns:
 {{- end -}}
 
 {{/*
-Build a loadBalancer.keda metrics-api URL for the scaler monitoring HTTP endpoint.
+Build a KEDA metrics-api URL for the load balancer scaler monitoring HTTP endpoint.
+Call with dict "root" set to the chart root context and "query" set to the
+plain query string. Requires kedaScaler.enabled=true. Fails if kedaScaler.enabled
+is false or the required query metadata is missing. Uses
+.root.Values.kedaScaler.service.monitoringPort. Returns:
+"http://<keda-scaler-service>:<monitoringPort>/query?query=<urlencoded-query>".
 */}}
 {{- define "sawmills-collector.loadBalancerKedaMetricsAPIURL" -}}
 {{- if not .root.Values.kedaScaler.enabled -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -631,6 +631,17 @@ plain query string. Requires kedaScaler.enabled=true. Returns:
 {{- end -}}
 
 {{/*
+Build a loadBalancer.keda metrics-api URL for the scaler monitoring HTTP endpoint.
+*/}}
+{{- define "sawmills-collector.loadBalancerKedaMetricsAPIURL" -}}
+{{- if not .root.Values.kedaScaler.enabled -}}
+{{- fail "kedaScaler.enabled must be true when loadBalancer.keda.scaling.external.loadBalancerTriggerType is metrics-api" -}}
+{{- end -}}
+{{- $query := required "loadBalancer.keda.scaling.external.metadata.query is required for metrics-api" .query -}}
+{{- printf "http://%s:%v/query?query=%s" (include "sawmills-collector.kedaScalerSvcFQDN" .root) .root.Values.kedaScaler.service.monitoringPort (urlquery $query) -}}
+{{- end -}}
+
+{{/*
 Resolve whether to use native sidecar mode for HAProxy.
 Accepts .Values.haproxy.nativeSidecar: "false" | "true" | "auto"
 Returns "true" or "false" as a string.

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -60,7 +60,7 @@ spec:
       {{- else }}
       metricType: {{ $external.metricType }}
       metadata:
-        scalerAddress: {{ required "loadBalancer.keda.scaling.external.metadata.scalerAddress is required when loadBalancer.keda.scaling.external.enabled is true" (tpl (toString $externalMetadata.scalerAddress) $) | quote }}
+        scalerAddress: {{ required "loadBalancer.keda.scaling.external.metadata.scalerAddress is required when loadBalancer.keda.scaling.external.enabled is true" (tpl (toString $externalMetadata.scalerAddress) .) | quote }}
         query: {{ required "loadBalancer.keda.scaling.external.metadata.query is required when loadBalancer.keda.scaling.external.enabled is true" $externalMetadata.query | quote }}
         targetValue: {{ required "loadBalancer.keda.scaling.external.metadata.targetValue is required when loadBalancer.keda.scaling.external.enabled is true" $externalMetadata.targetValue | quote }}
         {{- range $key, $value := $externalMetadata }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -1,5 +1,8 @@
 # KEDA ScaledObject for the load balancer deployment/statefulset
 {{- if and .Values.loadBalancer.enabled .Values.loadBalancer.keda.enabled }}
+{{- if and .Values.loadBalancer.keda.scaling.external.enabled (not .Values.kedaScaler.enabled) }}
+{{- fail "kedaScaler.enabled must be true when loadBalancer.keda.scaling.external.enabled is true" }}
+{{- end }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -42,6 +45,30 @@ spec:
         {{- printf "%s: %s" $key ($value | quote) | nindent 8 }}
         {{- end }}
         {{- end }}
+    {{- end }}
+    {{- if .Values.loadBalancer.keda.scaling.external.enabled }}
+    {{- $external := .Values.loadBalancer.keda.scaling.external }}
+    {{- $externalMetadata := $external.metadata }}
+    {{- $lbTriggerType := default "external" $external.loadBalancerTriggerType }}
+    - type: {{ $lbTriggerType }}
+      {{- if eq $lbTriggerType "metrics-api" }}
+      metadata:
+        url: {{ include "sawmills-collector.loadBalancerKedaMetricsAPIURL" (dict "root" . "query" $externalMetadata.query) | quote }}
+        format: "json"
+        valueLocation: "result"
+        targetValue: {{ required "loadBalancer.keda.scaling.external.metadata.targetValue is required for metrics-api" $externalMetadata.targetValue | quote }}
+      {{- else }}
+      metricType: {{ $external.metricType }}
+      metadata:
+        scalerAddress: {{ required "loadBalancer.keda.scaling.external.metadata.scalerAddress is required when loadBalancer.keda.scaling.external.enabled is true" (tpl (toString $externalMetadata.scalerAddress) $) | quote }}
+        query: {{ required "loadBalancer.keda.scaling.external.metadata.query is required when loadBalancer.keda.scaling.external.enabled is true" $externalMetadata.query | quote }}
+        targetValue: {{ required "loadBalancer.keda.scaling.external.metadata.targetValue is required when loadBalancer.keda.scaling.external.enabled is true" $externalMetadata.targetValue | quote }}
+        {{- range $key, $value := $externalMetadata }}
+        {{- if and (not (has $key (list "scalerAddress" "query" "targetValue"))) (not (kindIs "invalid" $value)) (not (and (kindIs "string" $value) (eq $value ""))) }}
+        {{- printf "%s: %s" $key ($value | quote) | nindent 8 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
     {{- end }}
     {{- if .Values.loadBalancer.keda.scaling.cpu.enabled }}
     - type: cpu

--- a/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_scaler_address_test.yaml
@@ -1,6 +1,7 @@
 suite: keda scaler address namespace templating
 templates:
   - templates/keda-hpa.yaml
+  - templates/load-balancer-keda-hpa.yaml
   - templates/keda-scaler-service.yaml
 tests:
   - it: resolves non-LB external scalerAddress from release namespace and configured port
@@ -93,4 +94,25 @@ tests:
           value: http://sawmills-collector-keda-otel-scaler.sample-namespace.svc.cluster.local:19466/query?query=sum%28otelcol_loadbalancer_central_queue_compressed_bytes%29
       - notMatchRegex:
           path: spec.triggers[0].metadata.url
+          pattern: \.sawmills\.svc\.cluster\.local
+
+  - it: resolves loadBalancer.keda external scalerAddress from release namespace and configured port
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sample-namespace
+    set:
+      kedaScaler.enabled: true
+      kedaScaler.service.kedaExternalScalerPort: 9444
+      loadBalancer.enabled: true
+      loadBalancer.keda.enabled: true
+      loadBalancer.keda.scaling.external.enabled: true
+      loadBalancer.keda.scaling.cpu.enabled: false
+      loadBalancer.keda.scaling.memory.enabled: false
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: sawmills-collector-keda-otel-scaler.sample-namespace.svc.cluster.local:9444
+      - notMatchRegex:
+          path: spec.triggers[0].metadata.scalerAddress
           pattern: \.sawmills\.svc\.cluster\.local

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -5,6 +5,121 @@ templates:
 values:
   - ../values.yaml
 tests:
+  - it: renders external scaler trigger for load balancer KEDA scaling
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sample-namespace
+    set:
+      kedaScaler:
+        enabled: true
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          minReplicas: 3
+          maxReplicas: 25
+          scaling:
+            external:
+              enabled: true
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: sawmills-collector-lb
+      - equal:
+          path: spec.minReplicaCount
+          value: 3
+      - equal:
+          path: spec.maxReplicaCount
+          value: 25
+      - equal:
+          path: spec.triggers[0].type
+          value: external
+      - equal:
+          path: spec.triggers[0].metricType
+          value: AverageValue
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: sawmills-collector-keda-otel-scaler.sample-namespace.svc.cluster.local:4418
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "10485760"
+
+  - it: requires keda scaler when load balancer external scaling is enabled
+    template: templates/load-balancer-keda-hpa.yaml
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          scaling:
+            external:
+              enabled: true
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: 'kedaScaler.enabled must be true when loadBalancer.keda.scaling.external.enabled is true'
+
+  - it: renders metrics-api trigger for load balancer KEDA scaling
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
+      namespace: sample-namespace
+    set:
+      kedaScaler:
+        enabled: true
+        service:
+          monitoringPort: 19466
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+          scaling:
+            external:
+              enabled: true
+              loadBalancerTriggerType: metrics-api
+            cpu:
+              enabled: false
+            memory:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.triggers[0].type
+          value: metrics-api
+      - notExists:
+          path: spec.triggers[0].metricType
+      - equal:
+          path: spec.triggers[0].metadata.url
+          value: http://sawmills-collector-keda-otel-scaler.sample-namespace.svc.cluster.local:19466/query?query=sum%28otelcol_loadbalancer_central_queue_compressed_bytes%29
+      - equal:
+          path: spec.triggers[0].metadata.format
+          value: json
+      - equal:
+          path: spec.triggers[0].metadata.valueLocation
+          value: result
+      - equal:
+          path: spec.triggers[0].metadata.targetValue
+          value: "10485760"
+
   - it: renders Prometheus trigger for load balancer KEDA scaling
     template: templates/load-balancer-keda-hpa.yaml
     release:

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -257,6 +257,24 @@ tests:
           path: spec.scaleTargetRef.name
           value: coinbase-logs-lb
 
+  - it: uses resourceBaseName for load balancer external scaler address
+    template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: customer-umbrella
+      namespace: customer-ns
+    set:
+      resourceBaseName: coinbase-logs
+      kedaScaler.enabled: true
+      loadBalancer.enabled: true
+      loadBalancer.keda.enabled: true
+      loadBalancer.keda.scaling.external.enabled: true
+      loadBalancer.keda.scaling.cpu.enabled: false
+      loadBalancer.keda.scaling.memory.enabled: false
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.scalerAddress
+          value: coinbase-logs-keda-otel-scaler.customer-ns.svc.cluster.local:4418
+
   - it: uses resourceBaseName for KEDA scaler deployment and service selectors
     template: templates/keda-scaler-deployment.yaml
     release:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1375,6 +1375,14 @@ loadBalancer:
           serverAddress: ""
           query: ""
           threshold: ""
+      external:
+        enabled: false
+        metricType: AverageValue
+        loadBalancerTriggerType: external
+        metadata:
+          scalerAddress: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:{{ .Values.kedaScaler.service.kedaExternalScalerPort }}'
+          query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)
+          targetValue: "10485760"
       cpu:
         enabled: true
         targetUtilization: 80


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches load balancer KEDA scaling to use the bundled internal scaler by default, removing the need for a Prometheus/VictoriaMetrics endpoint. Implements SAW-7657.

- **New Features**
  - Added `loadBalancer.keda.scaling.external` using the internal scaler with defaults: `metricType: AverageValue`, `query: sum(otelcol_loadbalancer_central_queue_compressed_bytes)`, `targetValue: "10485760"`, and a templated `scalerAddress` to the in-cluster scaler.
  - Enforces `kedaScaler.enabled: true` when external scaling is on; templates fail fast if missing. Added `metrics-api` trigger option via `loadBalancerTriggerType: metrics-api` with `sawmills-collector.loadBalancerKedaMetricsAPIURL` and strict metadata validation.
  - Prometheus trigger remains available. README updated to prefer the internal scaler and document recommended and legacy metrics. Tests added for scaler address resolution, `metrics-api`, and `resourceBaseName`.

- **Migration**
  - When enabling `loadBalancer.keda.scaling.external.enabled: true`, also set `kedaScaler.enabled: true`. Use the provided defaults or keep your existing Prometheus-based config if preferred.

<sup>Written for commit 7a67a8c493f7da345687506baed71ab745a8df2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/188?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced load-balancer autoscaling guidance with dedicated external KEDA scaler configuration path and examples.
  * Clarified supported metrics for queue-based scaling with fallback options.

* **New Features**
  * Added support for external KEDA scaler configuration for load-balancer autoscaling in resource-constrained environments.
  * Introduced metrics-API trigger mode for alternative scaling approaches.

* **Tests**
  * Added comprehensive test coverage for load-balancer KEDA autoscaling scenarios and configuration validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->