### PR TITLE
feat(lb-keda): use trigger-specific ScaledObject names

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -617,6 +617,24 @@ Returns "<keda-scaler-name>.<namespace>.svc.cluster.local".
 {{- end -}}
 
 {{/*
+Get the load balancer KEDA ScaledObject name.
+Use distinct names for the external scaler trigger families so KEDA creates a
+fresh child HPA when migrating from legacy CPU/resource-backed ScaledObjects.
+Legacy Prometheus and resource-only configurations keep the original name.
+*/}}
+{{- define "sawmills-collector.loadBalancerKedaScaledObjectName" -}}
+{{- $suffix := "-lb-keda-hpa" -}}
+{{- $external := .Values.loadBalancer.keda.scaling.external -}}
+{{- $triggerType := default "external" $external.loadBalancerTriggerType -}}
+{{- if and $external.enabled (eq $triggerType "external") -}}
+{{- $suffix = "-lb-keda-external-hpa" -}}
+{{- else if and $external.enabled (eq $triggerType "metrics-api") -}}
+{{- $suffix = "-lb-keda-metrics-api-hpa" -}}
+{{- end -}}
+{{- printf "%s%s" (include "sawmills-collector.fullname" . | trunc 39 | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Build a KEDA metrics-api URL for the scaler monitoring HTTP endpoint.
 Call with dict "root" set to the chart root context and "query" set to the
 plain query string. Requires kedaScaler.enabled=true. Returns:

--- a/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-keda-hpa.yaml
@@ -6,7 +6,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "sawmills-collector.fullname" . }}-lb-keda-hpa
+  name: {{ include "sawmills-collector.loadBalancerKedaScaledObjectName" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/revision: {{ .Release.Revision | quote }}

--- a/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_keda_hpa_test.yaml
@@ -32,6 +32,9 @@ tests:
       - isKind:
           of: ScaledObject
       - equal:
+          path: metadata.name
+          value: sawmills-collector-lb-keda-external-hpa
+      - equal:
           path: spec.scaleTargetRef.kind
           value: Deployment
       - equal:
@@ -103,6 +106,9 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
+          path: metadata.name
+          value: sawmills-collector-lb-keda-metrics-api-hpa
+      - equal:
           path: spec.triggers[0].type
           value: metrics-api
       - notExists:
@@ -149,6 +155,9 @@ tests:
           count: 1
       - isKind:
           of: ScaledObject
+      - equal:
+          path: metadata.name
+          value: sawmills-collector-lb-keda-hpa
       - equal:
           path: spec.scaleTargetRef.kind
           value: Deployment
@@ -255,6 +264,8 @@ tests:
 
   - it: renders load balancer ScaledObject when autoscaling and KEDA are both enabled
     template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
     set:
       loadBalancer:
         enabled: true
@@ -278,6 +289,9 @@ tests:
           count: 1
       - isKind:
           of: ScaledObject
+      - equal:
+          path: metadata.name
+          value: sawmills-collector-lb-keda-hpa
 
   - it: suppresses load balancer HPA when load balancer KEDA is enabled
     template: templates/load-balancer-hpa.yaml
@@ -305,6 +319,8 @@ tests:
 
   - it: renders CPU and memory triggers with KEDA metricType syntax
     template: templates/load-balancer-keda-hpa.yaml
+    release:
+      name: sawmills-collector
     set:
       loadBalancer:
         enabled: true
@@ -320,6 +336,9 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - equal:
+          path: metadata.name
+          value: sawmills-collector-lb-keda-hpa
       - equal:
           path: spec.triggers[0].type
           value: cpu


### PR DESCRIPTION
Render distinct load balancer KEDA ScaledObject names for external scaler and metrics-api trigger modes so KEDA creates fresh child HPAs during trigger family migrations. Keep the legacy ScaledObject name for Prometheus and resource-only modes to avoid unnecessary rename churn for existing configurations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates trigger-specific KEDA ScaledObject names for the load balancer so migrations between `external` and `metrics-api` triggers create fresh HPAs. Keeps the legacy name for Prometheus and resource-only modes, supporting SAW-7657 without renaming existing setups.

- **Refactors**
  - Added a helper to compute trigger-specific ScaledObject names and updated the template to use it.
  - Extended tests to assert names for `external`, `metrics-api`, and legacy configurations.

<sup>Written for commit bf57bd195825149ffde8e10fb642ede0814108ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/189?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced load balancer KEDA ScaledObject naming logic to be more flexible and configurable, supporting different scaling trigger types while maintaining platform naming constraints.

* **Tests**
  * Added comprehensive test coverage for the updated naming logic across multiple KEDA scaling configuration scenarios and trigger types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->