### PR TITLE
sawmills-collector: Add LB pressure readiness endpoint

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -883,7 +883,7 @@ loadBalancer:
   enabled: true
   pressureReadiness:
     enabled: true
-    metricsEndpoint: http://${env:MY_POD_IP}:19465/metrics
+    metricsEndpoint: http://${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}/metrics
     queueSaturationFailThreshold: 0.85
     queueSaturationRecoverThreshold: 0.60
     inflightSaturationFailThreshold: 0.85
@@ -897,6 +897,8 @@ loadBalancer:
 ```
 
 When `memoryLimitBytes` is unset, the chart derives it from `loadBalancer.resources.limits.memory`; set `memoryLimitBytes: 0` to disable memory pressure gating for pods without memory limits. The rendered `backend_drain` config preserves configured LB `service.extensions` and appends `backend_drain`.
+
+By default, pressure readiness scrapes a small LB telemetry collector Prometheus endpoint on `telemetry.pressurePrometheus.port` (`19466`) instead of the full telemetry Prometheus endpoint. That endpoint keeps only the queue, inflight, memory, rejected/refused, and queue-age metrics needed by `backend_drain`. For S3-backed LB telemetry configs or standalone custom LB telemetry configs without the shared telemetry base, the chart defaults readiness to the regular telemetry endpoint unless `metricsEndpoint` is explicitly set, because the custom config must include the matching pressure exporter.
 
 Pressure readiness is observable through the collector's own metrics. Use `otelcol_backend_drain_pressure_warning{reason="..."}` for the warning band between `capacityWarningThreshold` and fail thresholds, `otelcol_backend_drain_pressure_ready{reason="..."}` for the current pressure readiness state, and `otelcol_backend_drain_pressure_transitions_total{state="...",reason="..."}` for ready/not-ready transitions. Reason labels are stable categories such as `queue_compressed_warning`, `queue_compressed_saturated`, `inflight_uncompressed_saturated`, `memory_saturated`, `queue_age_saturated`, `rejected_or_refused_records_increased`, and `metrics_scrape_failed`.
 

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -295,23 +295,39 @@ Generate merged telemetry configuration with external labels
 Generate merged telemetry configuration with external labels
 */}}
 {{- define "sawmills-collector.loadBalancerTelemetryConfig" -}}
-{{- if .Values.telemetryConfig }}
-{{- $config := deepCopy .Values.telemetryConfig }}
-{{- if .Values.haproxy.enabled }}
+{{- $baseTelemetryConfig := .Values.telemetryConfig }}
+{{- $hasSharedTelemetryBase := not (empty .Values.telemetryConfig) }}
+{{- if .Values.loadBalancer.telemetryConfig }}
+  {{- if $hasSharedTelemetryBase }}
+    {{- $baseTelemetryConfig = mergeOverwrite (deepCopy .Values.telemetryConfig) .Values.loadBalancer.telemetryConfig }}
+  {{- else }}
+    {{- $baseTelemetryConfig = deepCopy .Values.loadBalancer.telemetryConfig }}
+  {{- end }}
+{{- end }}
+{{- if $baseTelemetryConfig }}
+{{- $config := deepCopy $baseTelemetryConfig }}
+{{- if and $hasSharedTelemetryBase .Values.haproxy.enabled }}
   {{- $config = merge $config .Values.haproxyConfig }}
 {{- end }}
-{{- if eq .Values.telemetryExternalConfig.type "prometheus" }}
+{{- if and $hasSharedTelemetryBase (eq .Values.telemetryExternalConfig.type "prometheus") }}
   {{- $config = merge $config .Values.telemetryExternalConfig.prometheusConfig }}
-{{- else if eq .Values.telemetryExternalConfig.type "arrow" }}
+{{- else if and $hasSharedTelemetryBase (eq .Values.telemetryExternalConfig.type "arrow") }}
   {{- $config = merge $config .Values.telemetryExternalConfig.arrowConfig }}
 {{- end }}
+{{- if $hasSharedTelemetryBase }}
 {{- /* LB-only remote-operator OTLP ingest wiring (receiver + dedicated pipeline). */ -}}
 {{- $lbOverlay := (fromYaml (printf "receivers:\n  otlp/remote_operator:\n    protocols:\n      http:\n        endpoint: ${env:MY_POD_IP}:%v\nprocessors:\n  transform/remove_unit_preserve_service_name:\n    error_mode: ignore\n    metric_statements:\n      - context: metric\n        statements:\n          - set(metric.unit, \"\")\nservice:\n  pipelines:\n    metrics/remote_operator:\n      receivers:\n        - otlp/remote_operator\n      processors:\n        - memory_limiter\n        - transform/remove_unit_preserve_service_name\n        - deltatocumulative\n        - batch\n      exporters:\n        - routing\n        - forward\n" (.Values.telemetry.remoteOperatorOtlpHttpPort | default 14319))) }}
 {{- $config = merge $config $lbOverlay }}
+{{- $lbPressureReadiness := .Values.loadBalancer.pressureReadiness | default dict }}
+{{- if ($lbPressureReadiness.enabled | default false) }}
+  {{- $pressureOverlay := (fromYaml "exporters:\n  prometheus/pressure_readiness:\n    endpoint: ${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}\n    metric_expiration: 1m\nprocessors:\n  filter/pressure_readiness:\n    error_mode: ignore\n    metrics:\n      metric:\n        - not IsMatch(name, \"^(otelcol_loadbalancer_central_queue_compressed_bytes|otelcol_loadbalancer_central_queue_compressed_capacity|otelcol_loadbalancer_central_queue_compressed_capacity_bytes|otelcol_loadbalancer_central_queue_saturation|otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes|otelcol_loadbalancer_central_queue_inflight_uncompressed_capacity|otelcol_loadbalancer_central_queue_inflight_uncompressed_capacity_bytes|otelcol_loadbalancer_central_queue_rejected_compressed_bytes|otelcol_loadbalancer_central_queue_rejected_compressed_bytes_total|otelcol_loadbalancer_central_queue_oldest_item_age|otelcol_loadbalancer_central_queue_oldest_item_age_milliseconds|otelcol_process_memory_rss|otelcol_process_memory_rss_bytes|otelcol_process_runtime_heap_alloc_bytes|otelcol_receiver_refused_log_records|otelcol_receiver_refused_log_records_total|otelcol_receiver_refused_metric_points|otelcol_receiver_refused_metric_points_total|otelcol_receiver_refused_spans|otelcol_receiver_refused_spans_total|otelcol_processor_refused_log_records|otelcol_processor_refused_log_records_total|otelcol_processor_refused_metric_points|otelcol_processor_refused_metric_points_total|otelcol_processor_refused_spans|otelcol_processor_refused_spans_total)$\")\nservice:\n  pipelines:\n    metrics/pressure_readiness:\n      receivers:\n        - forward\n      processors:\n        - filter/pressure_readiness\n      exporters:\n        - prometheus/pressure_readiness\n") }}
+  {{- $config = merge $config $pressureOverlay }}
+{{- end }}
 {{- /* Override transform/external_labels processor with dynamic config */ -}}
 {{- if and (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
+{{- end }}
 {{- end }}
 {{- toYaml $config }}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -1,5 +1,18 @@
 {{- $lbPressure := .Values.loadBalancer.pressureReadiness | default dict }}
 {{- if and .Values.loadBalancer.enabled ($lbPressure.enabled | default false) }}
+{{- $defaultPressureMetricsEndpoint := "http://${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}/metrics" }}
+{{- $defaultTelemetryMetricsEndpoint := "http://${env:MY_POD_IP}:${env:PROMETHEUS_PORT}/metrics" }}
+{{- $lbTelemetryOtelConfig := default dict .Values.loadBalancer.telemetryOtelConfig }}
+{{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
+{{- $hasSharedTelemetryBase := not (empty .Values.telemetryConfig) }}
+{{- $defaultMetricsEndpoint := $defaultPressureMetricsEndpoint }}
+{{- if or $lbTelemetryOtelS3Path (not $hasSharedTelemetryBase) }}
+{{- $defaultMetricsEndpoint = $defaultTelemetryMetricsEndpoint }}
+{{- end }}
+{{- $pressureMetricsEndpoint := default $defaultMetricsEndpoint $lbPressure.metricsEndpoint }}
+{{- if and $hasSharedTelemetryBase (not $lbTelemetryOtelS3Path) (or (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:19465/metrics") (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:8888/metrics") (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:${env:PROMETHEUS_PORT}/metrics")) }}
+{{- $pressureMetricsEndpoint = $defaultPressureMetricsEndpoint }}
+{{- end }}
 {{- $lbConfig := default dict .Values.loadBalancer.otelCollectorConfig }}
 {{- $serviceExtensions := list }}
 {{- if and (kindIs "map" $lbConfig) (hasKey $lbConfig "service") (kindIs "map" $lbConfig.service) (hasKey $lbConfig.service "extensions") }}
@@ -51,7 +64,7 @@ data:
         {{- end }}
         pressure_check:
           enabled: true
-          metrics_endpoint: {{ default "http://${env:MY_POD_IP}:19465/metrics" $lbPressure.metricsEndpoint }}
+          metrics_endpoint: {{ $pressureMetricsEndpoint }}
           queue_saturation_fail_threshold: {{ default 0.85 $lbPressure.queueSaturationFailThreshold }}
           queue_saturation_recover_threshold: {{ default 0.60 $lbPressure.queueSaturationRecoverThreshold }}
           inflight_saturation_fail_threshold: {{ default 0.85 $lbPressure.inflightSaturationFailThreshold }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-telemetry-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-telemetry-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 data:
   telemetry-config.yaml: |
-    {{- if .Values.telemetryConfig }}
+    {{- if or .Values.telemetryConfig .Values.loadBalancer.telemetryConfig }}
       {{- include "sawmills-collector.loadBalancerTelemetryConfig" . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -142,6 +142,12 @@ spec:
           {{- end }}
           env:
             {{- include "sawmills-collector.runtimeConfigEnv" . | nindent 12 }}
+            {{- if $lbPressureReadinessEnabled }}
+            - name: PRESSURE_PROMETHEUS_PORT
+              value: {{ .Values.telemetry.pressurePrometheus.port | default 19466 | quote }}
+            - name: PROMETHEUS_PORT
+              value: {{ .Values.telemetry.prometheus.port | quote }}
+            {{- end }}
             {{- if and (not .Values.loadBalancer.resources.disableLimits) .Values.loadBalancer.resources.limits .Values.loadBalancer.resources.limits.memory }}
             {{- $memLimit := .Values.loadBalancer.resources.limits.memory | toString }}
             - name: GOMEMLIMIT
@@ -284,6 +290,10 @@ spec:
               value: {{ .Values.collectorId }}
             - name: PROMETHEUS_PORT
               value: {{ .Values.telemetry.prometheus.port | quote }}
+            {{- if $lbPressureReadinessEnabled }}
+            - name: PRESSURE_PROMETHEUS_PORT
+              value: {{ .Values.telemetry.pressurePrometheus.port | default 19466 | quote }}
+            {{- end }}
             - name: PROMETHEUS_REMOTE_WRITE_ENDPOINT
               value: {{ .Values.prometheusremotewrite.endpoint }}
             - name: PROMETHEUS_REMOTE_WRITE_API_KEY
@@ -321,6 +331,11 @@ spec:
             - name: prometheus
               containerPort: {{ .Values.telemetry.prometheus.port }}
               protocol: TCP
+            {{- if $lbPressureReadinessEnabled }}
+            - name: pressure-prom
+              containerPort: {{ .Values.telemetry.pressurePrometheus.port | default 19466 }}
+              protocol: TCP
+            {{- end }}
             - name: ro-otlp-http
               containerPort: {{ .Values.telemetry.remoteOperatorOtlpHttpPort | default 14319 }}
               protocol: TCP

--- a/helm-charts/sawmills-collector/tests/fixtures/load_balancer_inline_telemetry_config.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/load_balancer_inline_telemetry_config.yaml
@@ -1,0 +1,20 @@
+telemetryConfig:
+  exporters:
+    debug/main_marker: {}
+  service:
+    pipelines:
+      metrics/main_marker:
+        receivers: []
+        exporters:
+          - debug/main_marker
+
+loadBalancer:
+  telemetryConfig:
+    exporters:
+      debug/lb_marker: {}
+    service:
+      pipelines:
+        metrics/lb_marker:
+          receivers: []
+          exporters:
+            - debug/lb_marker

--- a/helm-charts/sawmills-collector/tests/fixtures/load_balancer_standalone_telemetry_config.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/load_balancer_standalone_telemetry_config.yaml
@@ -1,0 +1,12 @@
+telemetryConfig: null
+
+loadBalancer:
+  telemetryConfig:
+    exporters:
+      debug/lb_marker: {}
+    service:
+      pipelines:
+        metrics/lb_marker:
+          receivers: []
+          exporters:
+            - debug/lb_marker

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -159,6 +159,12 @@ tests:
     asserts:
       - matchRegex:
           path: data["telemetry-config.yaml"]
+          pattern: 'debug/main_marker:'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'metrics/main_marker:'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
           pattern: 'debug/lb_marker:'
       - matchRegex:
           path: data["telemetry-config.yaml"]

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -1,6 +1,7 @@
 suite: load balancer pressure readiness
 templates:
   - load-balancer.yaml
+  - load-balancer-telemetry-configmap.yaml
   - load-balancer-readiness-configmap.yaml
 tests:
   - it: renders pressure-aware backend_drain readiness for LB pods
@@ -53,10 +54,157 @@ tests:
           count: 1
       - matchRegex:
           path: data["config.yaml"]
-          pattern: '(?ms)backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n\s+pressure_check:\n\s+enabled: true\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:19465/metrics\n\s+queue_saturation_fail_threshold: 0.85\n\s+queue_saturation_recover_threshold: 0.6\n\s+inflight_saturation_fail_threshold: 0.85\n\s+inflight_saturation_recover_threshold: 0.6\n\s+memory_saturation_fail_threshold: 0.85\n\s+memory_saturation_recover_threshold: 0.7\n\s+capacity_warning_threshold: 0.6\n\s+fail_checks: 2\n\s+recover_checks: 3\n\s+check_interval: 1s\n\s+rejected_quiet_duration: 1m\n\s+oldest_item_age_fail_threshold: 1m\n\s+memory_limit_bytes: 536870912\n'
+          pattern: '(?ms)backend_drain:\n\s+endpoint: \$\{env:MY_POD_IP\}:13137\n\s+readiness_path: /ready\n\s+drain_path: /drain\n\s+health_check_endpoint: http://\$\{env:MY_POD_IP\}:13133/healthcheck\n\s+drain_duration: 15s\n\s+pressure_check:\n\s+enabled: true\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics\n\s+queue_saturation_fail_threshold: 0.85\n\s+queue_saturation_recover_threshold: 0.6\n\s+inflight_saturation_fail_threshold: 0.85\n\s+inflight_saturation_recover_threshold: 0.6\n\s+memory_saturation_fail_threshold: 0.85\n\s+memory_saturation_recover_threshold: 0.7\n\s+capacity_warning_threshold: 0.6\n\s+fail_checks: 2\n\s+recover_checks: 3\n\s+check_interval: 1s\n\s+rejected_quiet_duration: 1m\n\s+oldest_item_age_fail_threshold: 1m\n\s+memory_limit_bytes: 536870912\n'
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n'
+
+  - it: normalizes legacy explicit pressure metrics endpoints to the small pressure endpoint
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.metricsEndpoint: http://${env:MY_POD_IP}:19465/metrics
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:19465/metrics'
+
+  - it: keeps S3-backed telemetry readiness on the regular metrics endpoint by default
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.telemetryOtelConfig.s3path: s3://bucket/lb-telemetry.yaml
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PROMETHEUS_PORT\}/metrics'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics'
+
+  - it: defines the regular telemetry port env when S3-backed readiness uses it
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.telemetryOtelConfig.s3path: s3://bucket/lb-telemetry.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: PROMETHEUS_PORT
+            value: "19465"
+
+  - it: renders a pressure-only Prometheus endpoint for LB readiness
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*prometheus/pressure_readiness:\n\s+endpoint: \$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}\n\s+metric_expiration: 1m\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*filter/pressure_readiness:\n\s+error_mode: ignore\n\s+metrics:\n\s+metric:\n\s+- not IsMatch\(name, ".*otelcol_loadbalancer_central_queue_compressed_bytes.*otelcol_loadbalancer_central_queue_oldest_item_age.*otelcol_process_memory_rss.*otelcol_receiver_refused_log_records.*otelcol_receiver_refused_log_records_total.*otelcol_receiver_refused_metric_points.*otelcol_receiver_refused_metric_points_total.*otelcol_receiver_refused_spans.*otelcol_receiver_refused_spans_total.*otelcol_processor_refused_log_records.*otelcol_processor_refused_log_records_total.*otelcol_processor_refused_metric_points.*otelcol_processor_refused_metric_points_total.*otelcol_processor_refused_spans.*otelcol_processor_refused_spans_total.*"\)\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/pressure_readiness:\n\s+exporters:\n\s+- prometheus/pressure_readiness\n\s+processors:\n\s+- filter/pressure_readiness\n\s+receivers:\n\s+- forward\n'
+
+  - it: exposes the pressure endpoint port on the LB telemetry collector
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].env
+          content:
+            name: PRESSURE_PROMETHEUS_PORT
+            value: "19466"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].env
+          content:
+            name: PRESSURE_PROMETHEUS_PORT
+            value: "19466"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].ports
+          content:
+            name: pressure-prom
+            containerPort: 19466
+            protocol: TCP
+
+  - it: merges inline LB telemetry config with the required base config
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+      - fixtures/load_balancer_inline_telemetry_config.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'debug/lb_marker:'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'metrics/lb_marker:'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*memory_limiter:\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint:'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*forward:\s*\{\}\s*$'
+
+  - it: keeps standalone custom LB telemetry readiness on the regular metrics endpoint
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - fixtures/load_balancer_standalone_telemetry_config.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PROMETHEUS_PORT\}/metrics'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics'
+
+  - it: does not render pressure exporter for standalone custom LB telemetry
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - fixtures/load_balancer_standalone_telemetry_config.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'debug/lb_marker:'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'prometheus/pressure_readiness'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'metrics/pressure_readiness'
 
   - it: keeps s3 LB config and appends readiness overlay arg
     template: load-balancer.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -326,6 +326,9 @@ telemetry:
   # Prometheus port for the telemetry collector, can be used by customers to scrape metrics
   prometheus:
     port: 19465
+  # Small Prometheus endpoint used by LB backend_drain pressure readiness.
+  pressurePrometheus:
+    port: 19466
   # OTLP/HTTP ingest port on the telemetry collector for remote-operator metrics
   remoteOperatorOtlpHttpPort: 14319
 
@@ -1014,7 +1017,7 @@ telemetryConfig:
         - context: metric
           statement: route() where not IsMatch(name, "otelcol_processor_central_thp|otelcol_processor_thp|otelcol_processor_qmp")
           pipelines: [metrics/system]
-    forward:
+    forward: {}
 
   service:
     extensions: [health_check, cgroup_runtime]
@@ -1254,6 +1257,9 @@ loadBalancer:
   telemetryOtelConfig:
     s3path: ""
     encryptionKey: ""
+  # Optional inline telemetry config for the LB telemetry sidecar. Defaults to
+  # telemetryConfig when unset.
+  telemetryConfig: null
   # Direct LB OTel config. Queue compression options are configured under
   # otelCollectorConfig.exporters.<loadbalancing-exporter>.sending_queue:
   #   payload_compression: snappy|zstd|none
@@ -1298,7 +1304,10 @@ loadBalancer:
     # Defaults to HAProxy /ready when HAProxy HTTP readiness is enabled,
     # otherwise to collector health_check.
     healthCheckEndpoint: ""
-    metricsEndpoint: http://${env:MY_POD_IP}:19465/metrics
+    # Defaults to the small pressure endpoint when the chart renders inline LB
+    # telemetry config. Defaults to the regular telemetry endpoint for S3-backed
+    # LB telemetry unless an explicit value is provided.
+    metricsEndpoint: ""
     queueSaturationFailThreshold: 0.85
     queueSaturationRecoverThreshold: 0.60
     inflightSaturationFailThreshold: 0.85


### PR DESCRIPTION
Refs: SAW-7500

LB pressure readiness now gets a small Prometheus endpoint instead of scraping the full telemetry endpoint. This keeps S3-backed and standalone custom telemetry configs safe by defaulting them to the regular endpoint unless explicitly configured.

Description:
- Add `telemetry.pressurePrometheus.port` and render `prometheus/pressure_readiness` with a narrow queue/memory/refusal allowlist.
- Default LB pressure readiness to the pressure endpoint only when the chart renders the pressure exporter; keep S3/standalone custom telemetry on `${env:PROMETHEUS_PORT}` by default.
- Add Helm unit coverage for legacy endpoint normalization, S3-backed telemetry, partial LB telemetry merge, and standalone custom telemetry.

Validation:
- `helm unittest helm-charts/sawmills-collector -f 'tests/load_balancer_pressure_readiness_test.yaml'` -> 13/13 passed\n- `./tests/run-tests.sh` -> 27 suites / 234 tests passed\n- `helm lint helm-charts/sawmills-collector`\n- `git diff --check`\n- `trunk check` on changed files -> no issues\n- scoped adversarial review -> PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small Prometheus endpoint for LB pressure readiness to reduce scrape load and expose only the needed metrics. Defaults to this endpoint when using the shared telemetry base; S3-backed and standalone custom telemetry stay on the regular endpoint unless explicitly configured. Addresses SAW-7500.

- New Features
  - Added `telemetry.pressurePrometheus.port` (default 19466) and exporter `prometheus/pressure_readiness` with a narrow metric allowlist.
  - Defaulted readiness `metricsEndpoint` to `http://${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}/metrics` when the chart renders the pressure exporter; normalizes legacy explicit endpoints to this.
  - Kept S3-backed and standalone custom LB telemetry on `http://${env:MY_POD_IP}:${env:PROMETHEUS_PORT}/metrics` by default.
  - Supported merging `loadBalancer.telemetryConfig` with the shared `telemetryConfig`; no pressure exporter is rendered for standalone custom configs.
  - Exposes the pressure endpoint port on the telemetry sidecar and wires `PRESSURE_PROMETHEUS_PORT`/`PROMETHEUS_PORT` env vars where needed.

- Migration
  - No action needed.
  - To use the smaller scrape with standalone custom telemetry, add the `prometheus/pressure_readiness` exporter and set `loadBalancer.pressureReadiness.metricsEndpoint` to `http://${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}/metrics`.
  - Override the pressure port via `telemetry.pressurePrometheus.port`.

<sup>Written for commit 9d7cce40d4f2e8ddaad1d1350ec3e096b4afdf2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pressure readiness support for load balancers with a dedicated Prometheus endpoint on port 19466 for improved backend drain monitoring.
  * Introduced environment-driven port configuration for enhanced deployment flexibility.

* **Documentation**
  * Updated README to clarify pressure readiness endpoint behavior and fallback scenarios across different telemetry configurations.

* **Tests**
  * Expanded test coverage for pressure readiness across various telemetry configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->