### PR TITLE
perf(sawmills-collector): slim LB telemetry remote write

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -315,6 +315,47 @@ Generate merged telemetry configuration with external labels
   {{- $config = merge $config .Values.telemetryExternalConfig.arrowConfig }}
 {{- end }}
 {{- if $hasSharedTelemetryBase }}
+{{- if eq .Values.telemetryExternalConfig.type "prometheus" }}
+  {{- $lbTelemetryOverride := .Values.loadBalancer.telemetryConfig | default dict }}
+  {{- $lbOverrideService := get $lbTelemetryOverride "service" | default dict }}
+  {{- $lbOverridePipelines := get $lbOverrideService "pipelines" | default dict }}
+  {{- $lbOverrideExporters := get $lbTelemetryOverride "exporters" | default dict }}
+  {{- $hasExplicitLBPromRWOverride := or (hasKey $lbOverridePipelines "metrics/external/prometheusremotewrite") (hasKey $lbOverrideExporters "prometheusremotewrite") }}
+  {{- $service := get $config "service" | default dict }}
+  {{- $pipelines := get $service "pipelines" | default dict }}
+  {{- if and (not $hasExplicitLBPromRWOverride) (hasKey $pipelines "metrics/external/prometheusremotewrite") }}
+  {{- $processors := get $config "processors" | default dict }}
+  {{- $_ := set $processors "filter/lb_remote_write" (dict "error_mode" "ignore" "metrics" (dict "metric" (list "not IsMatch(name, \"^(otelcol_loadbalancer_central_queue_(compressed_bytes|compressed_capacity|compressed_capacity_bytes|saturation|items|rejected_compressed_bytes(_total)?|retries|decode_failures|inflight_uncompressed_bytes|inflight_uncompressed_capacity|inflight_uncompressed_capacity_bytes|configured_consumers|active_load_balancer_replicas|effective_consumers|active_consumers|queue_demand_consumers|backend_safe_consumers_per_lb|consumer_limit_reason|consumer_pressure_state|lanes|effective_lanes|oldest_item_age(_milliseconds)?|ready_windows|ready_window_limit|ready_lanes|ready_uncompressed_bytes|scheduler_state)|otelcol_loadbalancer_backend_(latency.*|outcome.*|quarantine_total|unquarantine_total|fail_open_total|reroute_total|stale_total)|otelcol_loadbalancer_num_(backends|backend_updates|resolutions)|otelcol_loadbalancer_resolver_stale_age|otelcol_(receiver|processor)_refused_(log_records|metric_points|spans)(_total)?|otelcol_exporter_queue_(size|capacity)|otelcol_process_(cpu_seconds_total|memory_rss(_bytes)?|runtime_heap_alloc_bytes)|process_(cpu_seconds_total|resident_memory_bytes)|haproxy_(server|backend)_http_responses_total|http\\\\.server\\\\.(duration|request\\\\.duration).*)$\")"))) }}
+  {{- $_ := set $config "processors" $processors }}
+  {{- $exporters := get $config "exporters" | default dict }}
+  {{- $promRW := get $exporters "prometheusremotewrite" | default dict }}
+  {{- $_ := set $promRW "timeout" "30s" }}
+  {{- $existingExternalLabels := get $promRW "external_labels" | default dict }}
+  {{- $_ := set $promRW "external_labels" (mergeOverwrite (deepCopy $existingExternalLabels) (deepCopy (.Values.prometheusremotewrite.external_labels | default dict))) }}
+  {{- $_ := set $promRW "max_batch_request_parallelism" 1 }}
+  {{- $_ := set $promRW "max_batch_size_bytes" 6000000 }}
+  {{- $remoteWriteQueue := get $promRW "remote_write_queue" | default dict }}
+  {{- $_ := set $remoteWriteQueue "enabled" true }}
+  {{- $_ := set $remoteWriteQueue "queue_size" 500 }}
+  {{- $_ := set $remoteWriteQueue "num_consumers" 4 }}
+  {{- $_ := set $promRW "remote_write_queue" $remoteWriteQueue }}
+  {{- $_ := set $exporters "prometheusremotewrite" $promRW }}
+  {{- $_ := set $config "exporters" $exporters }}
+  {{- $externalPromRW := get $pipelines "metrics/external/prometheusremotewrite" | default dict }}
+  {{- $currentProcessors := get $externalPromRW "processors" | default list }}
+  {{- $slimProcessors := list "filter/lb_remote_write" }}
+  {{- range $processor := $currentProcessors }}
+    {{- $processorName := toString $processor }}
+    {{- if and (ne $processorName "transform/external_labels") (ne $processorName "filter/lb_remote_write") }}
+      {{- $slimProcessors = append $slimProcessors $processor }}
+    {{- end }}
+  {{- end }}
+  {{- $_ := set $externalPromRW "processors" $slimProcessors }}
+  {{- $_ := set $pipelines "metrics/external/prometheusremotewrite" $externalPromRW }}
+  {{- $_ := set $service "pipelines" $pipelines }}
+  {{- $_ := set $config "service" $service }}
+  {{- end }}
+{{- end }}
 {{- /* LB-only remote-operator OTLP ingest wiring (receiver + dedicated pipeline). */ -}}
 {{- $lbOverlay := (fromYaml (printf "receivers:\n  otlp/remote_operator:\n    protocols:\n      http:\n        endpoint: ${env:MY_POD_IP}:%v\nprocessors:\n  transform/remove_unit_preserve_service_name:\n    error_mode: ignore\n    metric_statements:\n      - context: metric\n        statements:\n          - set(metric.unit, \"\")\nservice:\n  pipelines:\n    metrics/remote_operator:\n      receivers:\n        - otlp/remote_operator\n      processors:\n        - memory_limiter\n        - transform/remove_unit_preserve_service_name\n        - deltatocumulative\n        - batch\n      exporters:\n        - routing\n        - forward\n" (.Values.telemetry.remoteOperatorOtlpHttpPort | default 14319))) }}
 {{- $config = merge $config $lbOverlay }}

--- a/helm-charts/sawmills-collector/tests/fixtures/load_balancer_inline_promrw_override.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/load_balancer_inline_promrw_override.yaml
@@ -1,0 +1,25 @@
+loadBalancer:
+  telemetryConfig:
+    exporters:
+      prometheusremotewrite:
+        timeout: 45s
+        remote_write_queue:
+          enabled: true
+          queue_size: 123
+          num_consumers: 9
+          storage: file_storage/prw
+    processors:
+      filter/custom_keep:
+        metrics:
+          metric:
+            - 'name == "custom_metric"'
+    service:
+      pipelines:
+        metrics/external/prometheusremotewrite:
+          receivers:
+            - forward
+          processors:
+            - transform/external_labels
+            - filter/custom_keep
+          exporters:
+            - prometheusremotewrite

--- a/helm-charts/sawmills-collector/tests/fixtures/shared_telemetry_inherited_promrw_override.yaml
+++ b/helm-charts/sawmills-collector/tests/fixtures/shared_telemetry_inherited_promrw_override.yaml
@@ -1,0 +1,22 @@
+telemetryConfig:
+  exporters:
+    prometheusremotewrite:
+      external_labels:
+        inherited_label: inherited_value
+      remote_write_queue:
+        storage: file_storage/prw
+  processors:
+    filter/inherited_keep:
+      metrics:
+        metric:
+          - 'name != "drop_me"'
+  service:
+    pipelines:
+      metrics/external/prometheusremotewrite:
+        receivers:
+          - forward
+        processors:
+          - transform/external_labels
+          - filter/inherited_keep
+        exporters:
+          - prometheusremotewrite

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -124,6 +124,119 @@ tests:
           path: data["telemetry-config.yaml"]
           pattern: '(?ms)^\s*metrics/pressure_readiness:\n\s+exporters:\n\s+- prometheus/pressure_readiness\n\s+processors:\n\s+- filter/pressure_readiness\n\s+receivers:\n\s+- forward\n'
 
+  - it: renders slim LB remote-write telemetry path by default
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*filter/lb_remote_write:\n\s+error_mode: ignore\n\s+metrics:\n\s+metric:\n\s+- not IsMatch\(name, ".*"\)\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'otelcol_loadbalancer_central_queue_.*compressed_bytes'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'otelcol_loadbalancer_backend_.*latency.*quarantine_total'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'haproxy_.*http_responses_total'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'otelcol_\(receiver\|processor\)_refused_.*log_records'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'otelcol_process_.*cpu_seconds_total'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'http\\\\.server\\\\.'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'request\\\\.duration'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+max_batch_request_parallelism: 1\n\s+max_batch_size_bytes: 6000000\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 4\n\s+queue_size: 500\n\s+retry_on_failure:\n\s+enabled: true\n\s+initial_interval: 2s\n\s+max_elapsed_time: 5s\n\s+max_interval: 5s\n\s+timeout: 30s\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/lb_remote_write\n\s+receivers:\n\s+- forward\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'otelcol_loadbalancer_backend_request_bytes'
+
+  - it: skips slim LB remote-write overlay for arrow external telemetry
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetryExternalConfig.type: arrow
+    asserts:
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'filter/lb_remote_write'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'max_batch_request_parallelism: 1'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'queue_size: 500'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/otelarrow:\n\s+exporters:\n\s+- otelarrow\n\s+processors:\n\s+- transform/external_labels\n\s+receivers:\n\s+- forward\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:'
+
+  - it: preserves explicit inline LB remote-write overrides
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+      - fixtures/load_balancer_inline_promrw_override.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'filter/lb_remote_write'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'queue_size: 500'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 9\n\s+queue_size: 123\n\s+storage: file_storage/prw\n\s+retry_on_failure:\n\s+enabled: true\n\s+initial_interval: 2s\n\s+max_elapsed_time: 5s\n\s+max_interval: 5s\n\s+timeout: 45s\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- transform/external_labels\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
+
+  - it: preserves inherited remote-write queue extras and custom processors
+    template: load-balancer-telemetry-configmap.yaml
+    values:
+      - ../values.yaml
+      - fixtures/shared_telemetry_inherited_promrw_override.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*filter/lb_remote_write:\n\s+error_mode: ignore\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*filter/inherited_keep:\n\s+metrics:\n\s+metric:\n\s+- name != "drop_me"\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+inherited_label: inherited_value\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+max_batch_request_parallelism: 1\n\s+max_batch_size_bytes: 6000000\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 4\n\s+queue_size: 500\n\s+storage: file_storage/prw\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/lb_remote_write\n\s+- filter/inherited_keep\n\s+receivers:\n\s+- forward\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+
   - it: exposes the pressure endpoint port on the LB telemetry collector
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
@@ -94,7 +94,10 @@ tests:
           pattern: 'num_consumers: 20'
 
   # =========================================================================
-  # Verify LB telemetry-collector gets the same protection
+  # Verify LB telemetry-collector keeps bounded retries while using its
+  # slimmer remote-write tuning. The LB path is intentionally slower/lower
+  # concurrency than the default collector telemetry path because readiness
+  # and KEDA use a separate pressure endpoint.
   # =========================================================================
 
   - it: "NEW CONFIG: LB telemetry-collector also has bounded retries"
@@ -107,7 +110,7 @@ tests:
           path: data["telemetry-config.yaml"]
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'timeout: 10s'
+          pattern: 'timeout: 30s'
       - matchRegex:
           path: data["telemetry-config.yaml"]
           pattern: 'max_elapsed_time: 5s'
@@ -116,10 +119,10 @@ tests:
           pattern: 'max_interval: 5s'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'queue_size: 2000'
+          pattern: 'queue_size: 500'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'num_consumers: 20'
+          pattern: 'num_consumers: 4'
 
   # =========================================================================
   # Guard: retry_on_failure must always be enabled (never accidentally disabled)

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1259,6 +1259,13 @@ loadBalancer:
     encryptionKey: ""
   # Optional inline telemetry config for the LB telemetry sidecar. Defaults to
   # telemetryConfig when unset.
+  #
+  # When inline LB telemetry inherits the shared prometheus external config, the
+  # template narrows only the LB prometheusremotewrite path: it keeps local
+  # debug/pressure metrics available, exports a slim allowlist remotely, moves
+  # static labels to exporter external_labels, and uses lower-concurrency queue
+  # tuning because readiness/KEDA use the separate pressure endpoint. Explicit
+  # inline LB prometheusremotewrite pipeline or exporter overrides are preserved.
   telemetryConfig: null
   # Direct LB OTel config. Queue compression options are configured under
   # otelCollectorConfig.exporters.<loadbalancing-exporter>.sending_queue:


### PR DESCRIPTION
Refs: SAW-7500

Summary:
- Adds a slim LB-only Prometheus remote-write telemetry path for inherited LB telemetry configs.
- Moves LB PRW external labels into exporter external_labels and removes transform/external_labels from the LB PRW pipeline.
- Keeps only actionable LB metrics before remote write and bounds PRW timeout, queue consumers, queue size, batch size, and batch parallelism.
- Preserves explicit inline LB PRW exporter/pipeline overrides and preserves inherited custom queue keys/custom processors.

Red:
- Base chart failed the new slim-path test: no filter/lb_remote_write, PRW timeout stayed 10s, queue stayed 2000/20, and PRW pipeline kept transform/external_labels.
- Explicit inline override regression test failed before the guard: chart clobbered custom timeout/queue/processors.
- Inherited PRW override regression test failed before the merge fix: storage/custom processor/external labels were dropped.

Green:
- helm unittest helm-charts/sawmills-collector -f tests/*telemetry*test.yaml -f tests/*load_balancer*test.yaml: 9 suites, 64 tests passed.
- helm-charts/sawmills-collector/tests/run-tests.sh: 27 suites, 238 tests passed.
- helm lint helm-charts/sawmills-collector passed.
- trunk check focused chart files passed.
- git diff --check passed.

Adversarial review:
- Codex review found the explicit inline override clobber; fixed with fixture coverage.
- Codex review found inherited PRW custom config clobber; fixed with fixture coverage.
- Final Codex review found no blocking chart issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slims the load-balancer Prometheus remote-write path to send only actionable metrics and lowers concurrency to reduce pressure on the backend. Addresses SAW-7500 and preserves user overrides.

- New Features
  - Adds a slim LB-only `metrics/external/prometheusremotewrite` path when shared external telemetry is Prometheus.
  - Moves static labels to exporter `prometheusremotewrite.external_labels` and removes `transform/external_labels` from the LB pipeline.
  - Filters to an allowlist of LB, HAProxy, otelcol, and HTTP server metrics before remote write.
  - Tunes remote write for lower concurrency: timeout 30s, queue_size 500, num_consumers 4, max_batch_request_parallelism 1, max_batch_size_bytes 6MB.

- Bug Fixes
  - Preserves explicit inline LB overrides for the `prometheusremotewrite` exporter and pipeline.
  - Keeps inherited extras (queue storage, custom processors, external labels) when merging shared telemetry.
  - Skips the slim overlay when external telemetry type is `arrow`.
  - Ensures bounded retries remain enabled on the LB path.

<sup>Written for commit ec60f10c8a1398edd204f92803796f21a65011e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test fixtures and test cases for load balancer Prometheus remote write telemetry configuration, including inline overrides and inherited shared telemetry scenarios.

* **Documentation**
  * Added clarification on how load balancer telemetry inherits and applies Prometheus remote write configuration from shared bases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->