### PR TITLE
feat(sawmills-collector): expose telemetry sidecar pprof

### DIFF
--- a/helm-charts/sawmills-collector/Chart.yaml
+++ b/helm-charts/sawmills-collector/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.0
+version: 2.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -111,6 +111,23 @@ Changing `resourceBaseName` on an existing release changes rendered resource nam
 
 When overriding `affinity` or `loadBalancer.affinity` with `resourceBaseName` set, use the selector label values rendered by the chart: `<resourceBaseName>` for the collector and `<resourceBaseName>-lb` for the load balancer. The default affinity blocks are rewritten automatically; arbitrary custom selector values are not.
 
+### Telemetry Sidecar Pprof
+
+The main collector uses pprof port `1777`. When telemetry sidecar profiling is
+needed, enable a separate pod-local pprof endpoint on port `1778`:
+
+```yaml
+telemetry:
+  pprof:
+    enabled: true
+    port: 1778
+    configSource: chart
+```
+
+Use `configSource: chart` for inline telemetry configs. Use
+`configSource: external` only when both the main and LB telemetry configs are
+loaded from S3 and already contain the pprof extension.
+
 ### Pin Images By Digest
 
 Set `image.digest` to render the collector image as `repository@digest` instead of `repository:tag`:

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -287,7 +287,179 @@ Generate merged telemetry configuration with external labels
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}
+{{- include "sawmills-collector.addTelemetryPprof" (dict "root" . "config" $config) }}
 {{- toYaml $config }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Validate telemetry-sidecar pprof config source and pod-local port safety.
+*/}}
+{{- define "sawmills-collector.validateTelemetryPprof" -}}
+{{- $pprof := .Values.telemetry.pprof | default dict -}}
+{{- if ($pprof.enabled | default false) }}
+  {{- $configSource := default "chart" $pprof.configSource -}}
+  {{- if not (has $configSource (list "chart" "external")) }}
+    {{- fail (printf "telemetry.pprof.configSource must be one of: chart, external (got %q)" $configSource) }}
+  {{- end }}
+  {{- $pprofPortValue := 1778 -}}
+  {{- if hasKey $pprof "port" }}
+    {{- $pprofPortValue = $pprof.port -}}
+  {{- end }}
+  {{- if not (regexMatch "^[0-9]+$" (toString $pprofPortValue)) }}
+    {{- fail (printf "telemetry.pprof.port must be an integer between 1 and 65535 (got %q)" (toString $pprofPortValue)) }}
+  {{- end }}
+  {{- $pprofPort := int $pprofPortValue -}}
+  {{- if or (lt $pprofPort 1) (gt $pprofPort 65535) }}
+    {{- fail (printf "telemetry.pprof.port must be between 1 and 65535 (got %d)" $pprofPort) }}
+  {{- end }}
+  {{- $telemetryPrometheusPort := int (default 19465 .Values.telemetry.prometheus.port) -}}
+  {{- if eq $pprofPort $telemetryPrometheusPort }}
+    {{- fail (printf "telemetry.pprof.port %d conflicts with telemetry.prometheus.port" $pprofPort) }}
+  {{- end }}
+  {{- if eq $pprofPort 13133 }}
+    {{- fail (printf "telemetry.pprof.port %d conflicts with main collector health_check port 13133" $pprofPort) }}
+  {{- end }}
+  {{- if eq $pprofPort 13134 }}
+    {{- fail (printf "telemetry.pprof.port %d conflicts with telemetry collector health_check port 13134" $pprofPort) }}
+  {{- end }}
+  {{- if eq $pprofPort 1777 }}
+    {{- fail (printf "telemetry.pprof.port %d conflicts with main collector pprof port 1777" $pprofPort) }}
+  {{- end }}
+  {{- if eq $pprofPort 13138 }}
+    {{- fail (printf "telemetry.pprof.port %d conflicts with main collector LiveTail control port 13138" $pprofPort) }}
+  {{- end }}
+  {{- range $name, $portConfig := (.Values.ports | default dict) }}
+    {{- $port := int (default 0 $portConfig.port) -}}
+    {{- if and (gt $port 0) (eq $pprofPort $port) }}
+      {{- fail (printf "telemetry.pprof.port %d conflicts with ports.%s.port" $pprofPort $name) }}
+    {{- end }}
+  {{- end }}
+  {{- range $name, $servicePort := (.Values.service.ports | default dict) }}
+    {{- $targetPort := int (default 0 $servicePort.from) -}}
+    {{- if and (gt $targetPort 0) (eq $pprofPort $targetPort) }}
+      {{- fail (printf "telemetry.pprof.port %d conflicts with service.ports.%s.from" $pprofPort $name) }}
+    {{- end }}
+  {{- end }}
+  {{- $mainDrain := .Values.rollout.main.drain | default dict -}}
+  {{- if and .Values.loadBalancer.enabled ($mainDrain.enabled | default false) }}
+    {{- $mainDrainPort := int (default 13137 $mainDrain.port) -}}
+    {{- if eq $pprofPort $mainDrainPort }}
+      {{- fail (printf "telemetry.pprof.port %d conflicts with rollout.main.drain.port" $pprofPort) }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.haproxy.enabled }}
+    {{- range $name, $mapping := (.Values.haproxy.mapping | default dict) }}
+      {{- $port := int (default 0 $mapping.from) -}}
+      {{- if and (gt $port 0) (eq $pprofPort $port) }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.mapping.%s.from" $pprofPort $name) }}
+      {{- end }}
+      {{- $to := $mapping.to | default dict -}}
+      {{- $targetPort := int (default 0 $to.port) -}}
+      {{- if and (gt $targetPort 0) (eq $pprofPort $targetPort) }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.mapping.%s.to.port" $pprofPort $name) }}
+      {{- end }}
+    {{- end }}
+    {{- $siblingFallback := .Values.haproxy.sibling_fallback | default dict -}}
+    {{- if ($siblingFallback.enabled | default false) }}
+      {{- $siblingCheck := $siblingFallback.check | default dict -}}
+      {{- $siblingCheckPort := int (default 13136 $siblingCheck.port) -}}
+      {{- if eq $pprofPort $siblingCheckPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.sibling_fallback.check.port" $pprofPort) }}
+      {{- end }}
+    {{- end }}
+    {{- if (.Values.haproxy.prometheus.enabled | default false) }}
+      {{- $haproxyPrometheusPort := int (default 8405 .Values.haproxy.prometheus.port) -}}
+      {{- if eq $pprofPort $haproxyPrometheusPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.prometheus.port" $pprofPort) }}
+      {{- end }}
+    {{- end }}
+    {{- if (.Values.haproxy.stats.enabled | default false) }}
+      {{- $haproxyStatsPort := int (default 8406 .Values.haproxy.stats.port) -}}
+      {{- if eq $pprofPort $haproxyStatsPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.stats.port" $pprofPort) }}
+      {{- end }}
+    {{- end }}
+    {{- if (.Values.haproxy.healthcheck.enabled | default false) }}
+      {{- $haproxyHealthPort := int (default 13135 .Values.haproxy.healthcheck.port) -}}
+      {{- if eq $pprofPort $haproxyHealthPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.healthcheck.port" $pprofPort) }}
+      {{- end }}
+      {{- $forwardingHealth := .Values.haproxy.healthcheck.forwarding_health | default dict -}}
+      {{- if ($forwardingHealth.enabled | default false) }}
+        {{- $forwardingHealthPort := int (default 13136 $forwardingHealth.port) -}}
+        {{- if eq $pprofPort $forwardingHealthPort }}
+          {{- fail (printf "telemetry.pprof.port %d conflicts with haproxy.healthcheck.forwarding_health.port" $pprofPort) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.loadBalancer.enabled }}
+    {{- range $name, $portConfig := (.Values.loadBalancer.ports | default dict) }}
+      {{- $port := int (default 0 $portConfig.port) -}}
+      {{- if and (gt $port 0) (eq $pprofPort $port) }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with loadBalancer.ports.%s.port" $pprofPort $name) }}
+      {{- end }}
+    {{- end }}
+    {{- range $name, $servicePort := (.Values.loadBalancer.service.ports | default dict) }}
+      {{- $targetPort := int (default 0 $servicePort.from) -}}
+      {{- if and (gt $targetPort 0) (eq $pprofPort $targetPort) }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with loadBalancer.service.ports.%s.from" $pprofPort $name) }}
+      {{- end }}
+    {{- end }}
+    {{- $remoteOperatorPort := int (default 14319 .Values.telemetry.remoteOperatorOtlpHttpPort) -}}
+    {{- if eq $pprofPort $remoteOperatorPort }}
+      {{- fail (printf "telemetry.pprof.port %d conflicts with telemetry.remoteOperatorOtlpHttpPort" $pprofPort) }}
+    {{- end }}
+    {{- $lbPressure := .Values.loadBalancer.pressureReadiness | default dict -}}
+    {{- if ($lbPressure.enabled | default false) }}
+      {{- $pressurePrometheusPort := int (default 19466 .Values.telemetry.pressurePrometheus.port) -}}
+      {{- if eq $pprofPort $pressurePrometheusPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with telemetry.pressurePrometheus.port" $pprofPort) }}
+      {{- end }}
+      {{- $pressureReadinessPort := int (default 13137 $lbPressure.port) -}}
+      {{- if eq $pprofPort $pressureReadinessPort }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with loadBalancer.pressureReadiness.port" $pprofPort) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- $telemetryOtelConfig := default dict .Values.telemetryOtelConfig -}}
+  {{- $lbTelemetryOtelConfig := default dict .Values.loadBalancer.telemetryOtelConfig -}}
+  {{- $telemetryS3Path := default "" $telemetryOtelConfig.s3path -}}
+  {{- $lbTelemetryS3Path := default "" $lbTelemetryOtelConfig.s3path -}}
+  {{- if and (eq $configSource "chart") (or $telemetryS3Path (and .Values.loadBalancer.enabled $lbTelemetryS3Path)) }}
+    {{- fail "telemetry.pprof.configSource must be external when telemetry pprof is enabled with S3-backed telemetry config; ensure the S3 telemetry config contains the pprof extension" }}
+  {{- end }}
+  {{- if and (eq $configSource "external") (not $telemetryS3Path) }}
+    {{- fail "telemetry.pprof.configSource=external requires telemetryOtelConfig.s3path because Helm will not inject pprof into inline telemetry config" }}
+  {{- end }}
+  {{- if and (eq $configSource "external") .Values.loadBalancer.enabled (not $lbTelemetryS3Path) }}
+    {{- fail "telemetry.pprof.configSource=external requires loadBalancer.telemetryOtelConfig.s3path when loadBalancer.enabled=true because Helm will not inject pprof into inline LB telemetry config" }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Add pprof to a telemetry-sidecar collector config when telemetry.pprof.enabled=true.
+The sidecar uses TELEMETRY_PPROF_PORT so it never collides with main collector pprof.
+*/}}
+{{- define "sawmills-collector.addTelemetryPprof" -}}
+{{- $root := .root -}}
+{{- $config := .config -}}
+{{- $pprofValues := $root.Values.telemetry.pprof | default dict -}}
+{{- if and $config (($pprofValues.enabled | default false)) (eq (default "chart" $pprofValues.configSource) "chart") }}
+  {{- $extensions := get $config "extensions" | default dict }}
+  {{- $pprof := get $extensions "pprof" | default dict }}
+  {{- $_ := set $pprof "endpoint" "0.0.0.0:${env:TELEMETRY_PPROF_PORT}" }}
+  {{- $_ := set $extensions "pprof" $pprof }}
+  {{- $_ := set $config "extensions" $extensions }}
+  {{- $service := get $config "service" | default dict }}
+  {{- $serviceExtensions := get $service "extensions" | default list }}
+  {{- if not (has "pprof" $serviceExtensions) }}
+    {{- $serviceExtensions = append $serviceExtensions "pprof" }}
+  {{- end }}
+  {{- $_ := set $service "extensions" $serviceExtensions }}
+  {{- $_ := set $config "service" $service }}
 {{- end }}
 {{- end -}}
 
@@ -370,6 +542,7 @@ Generate merged telemetry configuration with external labels
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}
 {{- end }}
+{{- include "sawmills-collector.addTelemetryPprof" (dict "root" . "config" $config) }}
 {{- toYaml $config }}
 {{- end }}
 {{- end -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -294,6 +294,7 @@ Generate merged telemetry configuration with external labels
 
 {{/*
 Validate telemetry-sidecar pprof config source and pod-local port safety.
+Emits no output; calls fail when configuration would expose or break pprof.
 */}}
 {{- define "sawmills-collector.validateTelemetryPprof" -}}
 {{- $pprof := .Values.telemetry.pprof | default dict -}}
@@ -336,8 +337,12 @@ Validate telemetry-sidecar pprof config source and pod-local port safety.
     {{- end }}
   {{- end }}
   {{- range $name, $servicePort := (.Values.service.ports | default dict) }}
-    {{- $targetPort := int (default 0 $servicePort.from) -}}
-    {{- if and (gt $targetPort 0) (eq $pprofPort $targetPort) }}
+    {{- $targetPortValue := default 0 $servicePort.from -}}
+    {{- if eq (toString $targetPortValue) "telemetry-pprof" }}
+      {{- fail (printf "telemetry.pprof.port %d conflicts with service.ports.%s.from targetPort telemetry-pprof" $pprofPort $name) }}
+    {{- end }}
+    {{- $targetPort := int $targetPortValue -}}
+    {{- if and (regexMatch "^[0-9]+$" (toString $targetPortValue)) (gt $targetPort 0) (eq $pprofPort $targetPort) }}
       {{- fail (printf "telemetry.pprof.port %d conflicts with service.ports.%s.from" $pprofPort $name) }}
     {{- end }}
   {{- end }}
@@ -402,8 +407,12 @@ Validate telemetry-sidecar pprof config source and pod-local port safety.
       {{- end }}
     {{- end }}
     {{- range $name, $servicePort := (.Values.loadBalancer.service.ports | default dict) }}
-      {{- $targetPort := int (default 0 $servicePort.from) -}}
-      {{- if and (gt $targetPort 0) (eq $pprofPort $targetPort) }}
+      {{- $targetPortValue := default 0 $servicePort.from -}}
+      {{- if eq (toString $targetPortValue) "telemetry-pprof" }}
+        {{- fail (printf "telemetry.pprof.port %d conflicts with loadBalancer.service.ports.%s.from targetPort telemetry-pprof" $pprofPort $name) }}
+      {{- end }}
+      {{- $targetPort := int $targetPortValue -}}
+      {{- if and (regexMatch "^[0-9]+$" (toString $targetPortValue)) (gt $targetPort 0) (eq $pprofPort $targetPort) }}
         {{- fail (printf "telemetry.pprof.port %d conflicts with loadBalancer.service.ports.%s.from" $pprofPort $name) }}
       {{- end }}
     {{- end }}
@@ -442,6 +451,7 @@ Validate telemetry-sidecar pprof config source and pod-local port safety.
 {{/*
 Add pprof to a telemetry-sidecar collector config when telemetry.pprof.enabled=true.
 The sidecar uses TELEMETRY_PPROF_PORT so it never collides with main collector pprof.
+Mutates the passed config in place and emits no YAML output.
 */}}
 {{- define "sawmills-collector.addTelemetryPprof" -}}
 {{- $root := .root -}}

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -12,6 +12,7 @@
 {{- $telemetryOtelConfig := default (dict) .Values.telemetryOtelConfig }}
 {{- $telemetryOtelS3Path := default "" $telemetryOtelConfig.s3path }}
 {{- $telemetryOtelEncryptionKey := default "" $telemetryOtelConfig.encryptionKey }}
+{{- include "sawmills-collector.validateTelemetryPprof" . }}
 {{- if $mainCollectorDrainEnabled }}
 {{- $drainDuration := default "15s" $mainDrain.duration }}
 {{- $shutdownReserve := default "10s" $mainDrain.shutdownReserve }}
@@ -194,6 +195,10 @@ spec:
               value: {{ .Values.collectorId }}
             - name: PROMETHEUS_PORT
               value: {{ .Values.telemetry.prometheus.port | quote }}
+            {{- if .Values.telemetry.pprof.enabled }}
+            - name: TELEMETRY_PPROF_PORT
+              value: {{ .Values.telemetry.pprof.port | default 1778 | quote }}
+            {{- end }}
             - name: PROMETHEUS_REMOTE_WRITE_ENDPOINT
               value: {{ .Values.prometheusremotewrite.endpoint }}
             - name: PROMETHEUS_REMOTE_WRITE_API_KEY
@@ -214,6 +219,11 @@ spec:
             - name: prometheus
               containerPort: {{ .Values.telemetry.prometheus.port }}
               protocol: TCP
+            {{- if .Values.telemetry.pprof.enabled }}
+            - name: telemetry-pprof
+              containerPort: {{ .Values.telemetry.pprof.port | default 1778 }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthcheck

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -6,6 +6,7 @@
 {{- $lbTelemetryOtelConfig := default (dict) .Values.loadBalancer.telemetryOtelConfig }}
 {{- $lbTelemetryOtelS3Path := default "" $lbTelemetryOtelConfig.s3path }}
 {{- $lbTelemetryOtelEncryptionKey := default "" $lbTelemetryOtelConfig.encryptionKey }}
+{{- include "sawmills-collector.validateTelemetryPprof" . }}
 {{- $lbStartupProbe := .Values.rollout.loadBalancer.probes.startup | default dict }}
 {{- $lbPressureReadiness := .Values.loadBalancer.pressureReadiness | default dict }}
 {{- $lbPressureReadinessEnabled := and .Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) }}
@@ -290,6 +291,10 @@ spec:
               value: {{ .Values.collectorId }}
             - name: PROMETHEUS_PORT
               value: {{ .Values.telemetry.prometheus.port | quote }}
+            {{- if .Values.telemetry.pprof.enabled }}
+            - name: TELEMETRY_PPROF_PORT
+              value: {{ .Values.telemetry.pprof.port | default 1778 | quote }}
+            {{- end }}
             {{- if $lbPressureReadinessEnabled }}
             - name: PRESSURE_PROMETHEUS_PORT
               value: {{ .Values.telemetry.pressurePrometheus.port | default 19466 | quote }}
@@ -331,6 +336,11 @@ spec:
             - name: prometheus
               containerPort: {{ .Values.telemetry.prometheus.port }}
               protocol: TCP
+            {{- if .Values.telemetry.pprof.enabled }}
+            - name: telemetry-pprof
+              containerPort: {{ .Values.telemetry.pprof.port | default 1778 }}
+              protocol: TCP
+            {{- end }}
             {{- if $lbPressureReadinessEnabled }}
             - name: pressure-prom
               containerPort: {{ .Values.telemetry.pressurePrometheus.port | default 19466 }}

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -262,6 +262,166 @@ tests:
             containerPort: 19466
             protocol: TCP
 
+  - it: exposes telemetry sidecar pprof on the LB pod when enabled
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].env
+          content:
+            name: TELEMETRY_PPROF_PORT
+            value: "1778"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].ports
+          content:
+            name: telemetry-pprof
+            containerPort: 1778
+            protocol: TCP
+
+  - it: rejects telemetry sidecar pprof collision with LB pressure metrics port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 19466
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 19466 conflicts with telemetry.pressurePrometheus.port"
+
+  - it: rejects telemetry sidecar pprof collision with remote-operator telemetry ingest port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 14319
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 14319 conflicts with telemetry.remoteOperatorOtlpHttpPort"
+
+  - it: rejects telemetry sidecar pprof collision with HAProxy sibling check port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.sibling_fallback.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13136
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13136 conflicts with haproxy.sibling_fallback.check.port"
+
+  - it: rejects telemetry sidecar pprof collision with LB customer receiver port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.ports.otlp.port: 1778
+      loadBalancer.ports.otlp.protocol: TCP
+      telemetry.pprof.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with loadBalancer.ports.otlp.port"
+
+  - it: rejects telemetry sidecar pprof exposure through LB service target port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      loadBalancer.service.ports.debug.from: 1778
+      loadBalancer.service.ports.debug.to.port: 1778
+      loadBalancer.service.ports.debug.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with loadBalancer.service.ports.debug.from"
+
+  - it: rejects telemetry sidecar pprof collision with LB pressure readiness port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      rollout.main.drain.port: 13139
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13137
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13137 conflicts with loadBalancer.pressureReadiness.port"
+
+  - it: rejects telemetry sidecar pprof collision with worker drain port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13137
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13137 conflicts with rollout.main.drain.port"
+
+  - it: fails LB telemetry sidecar pprof with S3 config unless externally injected
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      loadBalancer.telemetryOtelConfig.s3path: s3://collector-bucket/lb-telemetry.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.configSource must be external when telemetry pprof is enabled with S3-backed telemetry config; ensure the S3 telemetry config contains the pprof extension"
+
+  - it: rejects externally injected LB telemetry pprof without LB S3 telemetry config
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.configSource: external
+      telemetryOtelConfig.s3path: s3://collector-bucket/main-telemetry.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.configSource=external requires loadBalancer.telemetryOtelConfig.s3path when loadBalancer.enabled=true because Helm will not inject pprof into inline LB telemetry config"
+
+  - it: allows LB telemetry sidecar pprof with S3 config when externally injected
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.configSource: external
+      telemetryOtelConfig.s3path: s3://collector-bucket/main-telemetry.yaml
+      loadBalancer.telemetryOtelConfig.s3path: s3://collector-bucket/lb-telemetry.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].env
+          content:
+            name: TELEMETRY_PPROF_PORT
+            value: "1778"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].ports
+          content:
+            name: telemetry-pprof
+            containerPort: 1778
+            protocol: TCP
+
   - it: merges inline LB telemetry config with the required base config
     template: load-balancer-telemetry-configmap.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -348,6 +348,20 @@ tests:
       - failedTemplate:
           errorMessage: "telemetry.pprof.port 1778 conflicts with loadBalancer.service.ports.debug.from"
 
+  - it: rejects telemetry sidecar pprof exposure through named LB service target port
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+      loadBalancer.service.ports.debug.from: telemetry-pprof
+      loadBalancer.service.ports.debug.to.port: 1779
+      loadBalancer.service.ports.debug.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with loadBalancer.service.ports.debug.from targetPort telemetry-pprof"
+
   - it: rejects telemetry sidecar pprof collision with LB pressure readiness port
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
@@ -137,6 +137,23 @@ tests:
           path: data["telemetry-config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- pprof\n'
 
+  - it: "NEW CONFIG: chart-managed telemetry pprof wires the telemetry sidecar pod port"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].env
+          content:
+            name: TELEMETRY_PPROF_PORT
+            value: "1778"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].ports
+          content:
+            name: telemetry-pprof
+            containerPort: 1778
+            protocol: TCP
+
   - it: "NEW CONFIG: telemetry sidecar pprof overrides stale inline endpoint"
     template: telemetry-configmap.yaml
     set:
@@ -267,6 +284,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "telemetry.pprof.port 1778 conflicts with service.ports.debug.from"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects named service target port exposure"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      service.ports.debug.from: telemetry-pprof
+      service.ports.debug.to.port: 1779
+      service.ports.debug.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with service.ports.debug.from targetPort telemetry-pprof"
 
   - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy listener collision"
     template: deployment.yaml

--- a/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_exporter_resilience_test.yaml
@@ -1,5 +1,6 @@
 suite: test telemetry exporter resilience - self-monitoring must never destabilize the collector
 templates:
+  - deployment.yaml
   - telemetry-configmap.yaml
   - load-balancer-telemetry-configmap.yaml
 tests:
@@ -123,6 +124,269 @@ tests:
       - matchRegex:
           path: data["telemetry-config.yaml"]
           pattern: 'num_consumers: 4'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof is opt-in on a non-conflicting port"
+    template: telemetry-configmap.yaml
+    set:
+      telemetry.pprof.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^extensions:\n(?:.*\n)*?\s+pprof:\n\s+endpoint: 0\.0\.0\.0:\$\{env:TELEMETRY_PPROF_PORT\}\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- pprof\n'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof overrides stale inline endpoint"
+    template: telemetry-configmap.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetryConfig.extensions.pprof.endpoint: 0.0.0.0:1777
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'endpoint: 0\.0\.0\.0:\$\{env:TELEMETRY_PPROF_PORT\}'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '0\.0\.0\.0:1777'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof is absent by default"
+    template: telemetry-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?m)^\s+pprof:'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects invalid config source"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.configSource: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: 'telemetry.pprof.configSource must be one of: chart, external (got "invalid")'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects explicit zero port"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port must be between 1 and 65535 (got 0)"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects boolean port"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'telemetry.pprof.port must be an integer between 1 and 65535 (got "true")'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects fractional port"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 1.5
+    asserts:
+      - failedTemplate:
+          errorMessage: 'telemetry.pprof.port must be an integer between 1 and 65535 (got "1.5")'
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects port above tcp range"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 65536
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port must be between 1 and 65535 (got 65536)"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects prometheus port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 19465
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 19465 conflicts with telemetry.prometheus.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects telemetry healthcheck port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13134
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13134 conflicts with telemetry collector health_check port 13134"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects main healthcheck port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13133
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13133 conflicts with main collector health_check port 13133"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects main pprof port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 1777
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1777 conflicts with main collector pprof port 1777"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects LiveTail control port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13138
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13138 conflicts with main collector LiveTail control port 13138"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects customer receiver port collision"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      ports.otlp.port: 1778
+      ports.otlp.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with ports.otlp.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects service target port exposure"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      service.ports.debug.from: 1778
+      service.ports.debug.to.port: 1778
+      service.ports.debug.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with service.ports.debug.from"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy listener collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      telemetry.pprof.enabled: true
+      haproxy.mapping.logs.from: 1778
+      haproxy.mapping.logs.to.port: 4318
+      haproxy.mapping.logs.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 1778 conflicts with haproxy.mapping.logs.from"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy backend target collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 4318
+      haproxy.mapping.logs.from: 10000
+      haproxy.mapping.logs.to.port: 4318
+      haproxy.mapping.logs.to.protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 4318 conflicts with haproxy.mapping.logs.to.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy prometheus port collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.prometheus.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 8405
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 8405 conflicts with haproxy.prometheus.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy stats port collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.stats.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 8406
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 8406 conflicts with haproxy.stats.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy healthcheck port collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.healthcheck.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13135
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13135 conflicts with haproxy.healthcheck.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof rejects HAProxy forwarding health port collision"
+    template: deployment.yaml
+    set:
+      haproxy.enabled: true
+      haproxy.healthcheck.enabled: true
+      haproxy.healthcheck.forwarding_health.enabled: true
+      telemetry.pprof.enabled: true
+      telemetry.pprof.port: 13136
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.port 13136 conflicts with haproxy.healthcheck.forwarding_health.port"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof requires external config source for S3 telemetry config"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetryOtelConfig.s3path: s3://collector-bucket/telemetry.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.configSource must be external when telemetry pprof is enabled with S3-backed telemetry config; ensure the S3 telemetry config contains the pprof extension"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof external source requires S3 telemetry config"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.configSource: external
+    asserts:
+      - failedTemplate:
+          errorMessage: "telemetry.pprof.configSource=external requires telemetryOtelConfig.s3path because Helm will not inject pprof into inline telemetry config"
+
+  - it: "NEW CONFIG: telemetry sidecar pprof allows S3 telemetry config when externally injected"
+    template: deployment.yaml
+    set:
+      telemetry.pprof.enabled: true
+      telemetry.pprof.configSource: external
+      telemetryOtelConfig.s3path: s3://collector-bucket/telemetry.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].env
+          content:
+            name: TELEMETRY_PPROF_PORT
+            value: "1778"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="telemetry-collector")].ports
+          content:
+            name: telemetry-pprof
+            containerPort: 1778
+            protocol: TCP
+
+  - it: "NEW CONFIG: LB telemetry sidecar pprof is opt-in on the same sidecar port"
+    template: load-balancer-telemetry-configmap.yaml
+    set:
+      loadBalancer.enabled: true
+      telemetry.pprof.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^extensions:\n(?:.*\n)*?\s+pprof:\n\s+endpoint: 0\.0\.0\.0:\$\{env:TELEMETRY_PPROF_PORT\}\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- pprof\n'
 
   # =========================================================================
   # Guard: retry_on_failure must always be enabled (never accidentally disabled)

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -326,6 +326,15 @@ telemetry:
   # Prometheus port for the telemetry collector, can be used by customers to scrape metrics
   prometheus:
     port: 19465
+  # Optional pprof endpoint for the telemetry sidecar. Uses a different port
+  # than the main collector pprof endpoint because containers in a pod share
+  # the same network namespace.
+  pprof:
+    enabled: false
+    port: 1778
+    # chart: Helm injects pprof into inline telemetry configs.
+    # external: every rendered telemetry sidecar uses S3 config that already contains pprof.
+    configSource: chart
   # Small Prometheus endpoint used by LB backend_drain pressure readiness.
   pressurePrometheus:
     port: 19466


### PR DESCRIPTION
Refs: SAW-7500

## Summary
- Add opt-in telemetry.pprof values for the telemetry sidecar on port 1778.
- Inject pprof into inline main/LB telemetry configs and require external injection for S3 telemetry configs.
- Validate the sidecar pprof port against known pod-local listeners and Service targetPorts so pprof is not accidentally exposed or collided.

## Red / Green
Red:
- Focused Helm pprof tests failed before implementation because the telemetry pprof extension, service extension, env, and container port were absent.

Green:
- helm unittest helm-charts/sawmills-collector -f tests/telemetry_exporter_resilience_test.yaml -f tests/load_balancer_pressure_readiness_test.yaml: PASS, 57 tests.
- cd helm-charts/sawmills-collector && ./tests/run-tests.sh: PASS, 27 suites / 274 tests.
- helm lint helm-charts/sawmills-collector: PASS.
- git diff --check: PASS.

## Review Notes
- Adversarial review found boolean/fractional port rendering and endpoint binding issues; both were fixed.
- Endpoint now binds 0.0.0.0:${env:TELEMETRY_PPROF_PORT}, so kubectl port-forward and in-pod localhost checks work while Service validation keeps it unexposed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in pprof endpoint for the telemetry sidecar to enable safe, pod-local profiling on port 1778. Adds strict Helm guards to prevent collisions and accidental Service exposure, including LB paths. SAW-7500.

- New Features
  - Opt-in telemetry sidecar pprof on port 1778 with `TELEMETRY_PPROF_PORT` and a dedicated container port.
  - `telemetry.pprof.configSource`: use "chart" for inline configs, "external" when telemetry config is from S3 (main and LB must both be S3 when enabled).
  - Helm validation prevents conflicts with pod-local listeners, HAProxy/LB ports, `telemetry.remoteOperatorOtlpHttpPort`, and any Service targetPorts (including named `telemetry-pprof`) so pprof stays unexposed.
  - README updated, tests expanded to cover Service exposure and LB scenarios, chart bumped to 2.8.1.

- Bug Fixes
  - Rejects non-integer or out-of-range pprof ports.
  - Binds the pprof endpoint to 0.0.0.0 to support kubectl port-forward and in-pod checks.

<sup>Written for commit d8379eb77772c21b838a3f30231f6e3d8aca3e4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry sidecar pprof endpoint support with configurable port (default 1778) and configuration source options.

* **Documentation**
  * Added telemetry sidecar pprof configuration documentation.

* **Tests**
  * Added comprehensive test coverage for telemetry sidecar pprof functionality and validation.

* **Chores**
  * Bumped Helm chart version to 2.8.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/helm-charts/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->