### PR TITLE
sawmills-collector: Use PRW external labels

### DIFF
--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -288,8 +288,10 @@ Mutates the passed config in place and emits no YAML output.
 {{- end -}}
 
 {{/*
-Remove the legacy external-label transform from the Prometheus remote write
-pipeline while preserving any other custom processors.
+Remove the legacy transform-only external-label processor from the Prometheus
+remote write pipeline. If custom processors are configured beside the
+transform, preserve the explicit chain because those processors may depend on
+the attributes the transform adds before export.
 */}}
 {{- define "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" -}}
 {{- $config := .config -}}
@@ -298,20 +300,21 @@ pipeline while preserving any other custom processors.
   {{- $pipelines := get $service "pipelines" | default dict -}}
   {{- $promRWPipeline := get $pipelines "metrics/external/prometheusremotewrite" | default dict -}}
   {{- if hasKey $promRWPipeline "processors" -}}
+    {{- $hasExternalLabelProcessor := false -}}
     {{- $keptProcessors := list -}}
     {{- range $processor := (get $promRWPipeline "processors" | default list) -}}
       {{- if ne (toString $processor) "transform/external_labels" -}}
         {{- $keptProcessors = append $keptProcessors $processor -}}
+      {{- else -}}
+        {{- $hasExternalLabelProcessor = true -}}
       {{- end -}}
     {{- end -}}
-    {{- if empty $keptProcessors -}}
+    {{- if and $hasExternalLabelProcessor (empty $keptProcessors) -}}
       {{- $_ := unset $promRWPipeline "processors" -}}
-    {{- else -}}
-      {{- $_ := set $promRWPipeline "processors" $keptProcessors -}}
+      {{- $_ := set $pipelines "metrics/external/prometheusremotewrite" $promRWPipeline -}}
+      {{- $_ := set $service "pipelines" $pipelines -}}
+      {{- $_ := set $config "service" $service -}}
     {{- end -}}
-    {{- $_ := set $pipelines "metrics/external/prometheusremotewrite" $promRWPipeline -}}
-    {{- $_ := set $service "pipelines" $pipelines -}}
-    {{- $_ := set $config "service" $service -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -599,12 +602,22 @@ Generate merged telemetry configuration with external labels
   {{- $_ := set $config "exporters" $exporters }}
   {{- $externalPromRW := get $pipelines "metrics/external/prometheusremotewrite" | default dict }}
   {{- $currentProcessors := get $externalPromRW "processors" | default list }}
-  {{- $slimProcessors := list "filter/lb_remote_write" }}
+  {{- $hasExternalLabelProcessor := false }}
+  {{- $customProcessors := list }}
   {{- range $processor := $currentProcessors }}
     {{- $processorName := toString $processor }}
-    {{- if and (ne $processorName "transform/external_labels") (ne $processorName "filter/lb_remote_write") }}
-      {{- $slimProcessors = append $slimProcessors $processor }}
+    {{- if eq $processorName "transform/external_labels" }}
+      {{- $hasExternalLabelProcessor = true }}
+    {{- else if ne $processorName "filter/lb_remote_write" }}
+      {{- $customProcessors = append $customProcessors $processor }}
     {{- end }}
+  {{- end }}
+  {{- $slimProcessors := list "filter/lb_remote_write" }}
+  {{- if and $hasExternalLabelProcessor (not (empty $customProcessors)) }}
+    {{- $slimProcessors = append $slimProcessors "transform/external_labels" }}
+  {{- end }}
+  {{- range $processor := $customProcessors }}
+    {{- $slimProcessors = append $slimProcessors $processor }}
   {{- end }}
   {{- $_ := set $externalPromRW "processors" $slimProcessors }}
   {{- $_ := set $pipelines "metrics/external/prometheusremotewrite" $externalPromRW }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -317,6 +317,29 @@ pipeline while preserving any other custom processors.
 {{- end -}}
 
 {{/*
+Return true when any configured telemetry pipeline still references the legacy
+external-label transform. This keeps the default Prometheus remote write path
+exporter-native while preserving custom and Arrow pipelines that use the
+processor contract directly.
+*/}}
+{{- define "sawmills-collector.usesExternalLabelProcessor" -}}
+{{- $config := .config -}}
+{{- $usesExternalLabelProcessor := false -}}
+{{- if $config -}}
+  {{- $service := get $config "service" | default dict -}}
+  {{- $pipelines := get $service "pipelines" | default dict -}}
+  {{- range $_, $pipeline := $pipelines -}}
+    {{- range $processor := (get $pipeline "processors" | default list) -}}
+      {{- if eq (toString $processor) "transform/external_labels" -}}
+        {{- $usesExternalLabelProcessor = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $usesExternalLabelProcessor }}true{{ else }}false{{ end -}}
+{{- end -}}
+
+{{/*
 Generate merged telemetry configuration with external labels
 */}}
 {{- define "sawmills-collector.telemetryConfig" -}}
@@ -332,8 +355,7 @@ Generate merged telemetry configuration with external labels
 {{- else if eq .Values.telemetryExternalConfig.type "arrow" }}
   {{- $config = merge $config .Values.telemetryExternalConfig.arrowConfig }}
 {{- end }}
-{{- /* Arrow has no exporter-native external_labels, so keep the transform path there. */ -}}
-{{- if and (eq .Values.telemetryExternalConfig.type "arrow") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
+{{- if and (eq (include "sawmills-collector.usesExternalLabelProcessor" (dict "config" $config)) "true") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}
@@ -602,8 +624,7 @@ Generate merged telemetry configuration with external labels
   {{- include "sawmills-collector.applyPrometheusRemoteWriteExternalLabels" (dict "root" . "config" $config) }}
   {{- include "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" (dict "config" $config) }}
 {{- end }}
-{{- /* Arrow has no exporter-native external_labels, so keep the transform path there. */ -}}
-{{- if and (eq .Values.telemetryExternalConfig.type "arrow") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
+{{- if and (eq (include "sawmills-collector.usesExternalLabelProcessor" (dict "config" $config)) "true") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -269,6 +269,54 @@ metric_statements: []
 {{- end -}}
 
 {{/*
+Add configured external labels directly to the prometheusremotewrite exporter.
+This avoids datapoint-level transform work on the Prometheus remote write path.
+Mutates the passed config in place and emits no YAML output.
+*/}}
+{{- define "sawmills-collector.applyPrometheusRemoteWriteExternalLabels" -}}
+{{- $root := .root -}}
+{{- $config := .config -}}
+{{- $labels := $root.Values.prometheusremotewrite.external_labels | default dict -}}
+{{- if and $config (not (empty $labels)) -}}
+  {{- $exporters := get $config "exporters" | default dict -}}
+  {{- $promRW := get $exporters "prometheusremotewrite" | default dict -}}
+  {{- $existingExternalLabels := get $promRW "external_labels" | default dict -}}
+  {{- $_ := set $promRW "external_labels" (mergeOverwrite (deepCopy $existingExternalLabels) (deepCopy $labels)) -}}
+  {{- $_ := set $exporters "prometheusremotewrite" $promRW -}}
+  {{- $_ := set $config "exporters" $exporters -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Remove the legacy external-label transform from the Prometheus remote write
+pipeline while preserving any other custom processors.
+*/}}
+{{- define "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" -}}
+{{- $config := .config -}}
+{{- if $config -}}
+  {{- $service := get $config "service" | default dict -}}
+  {{- $pipelines := get $service "pipelines" | default dict -}}
+  {{- $promRWPipeline := get $pipelines "metrics/external/prometheusremotewrite" | default dict -}}
+  {{- if hasKey $promRWPipeline "processors" -}}
+    {{- $keptProcessors := list -}}
+    {{- range $processor := (get $promRWPipeline "processors" | default list) -}}
+      {{- if ne (toString $processor) "transform/external_labels" -}}
+        {{- $keptProcessors = append $keptProcessors $processor -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if empty $keptProcessors -}}
+      {{- $_ := unset $promRWPipeline "processors" -}}
+    {{- else -}}
+      {{- $_ := set $promRWPipeline "processors" $keptProcessors -}}
+    {{- end -}}
+    {{- $_ := set $pipelines "metrics/external/prometheusremotewrite" $promRWPipeline -}}
+    {{- $_ := set $service "pipelines" $pipelines -}}
+    {{- $_ := set $config "service" $service -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Generate merged telemetry configuration with external labels
 */}}
 {{- define "sawmills-collector.telemetryConfig" -}}
@@ -279,11 +327,13 @@ Generate merged telemetry configuration with external labels
 {{- end }}
 {{- if eq .Values.telemetryExternalConfig.type "prometheus" }}
   {{- $config = merge $config .Values.telemetryExternalConfig.prometheusConfig }}
+  {{- include "sawmills-collector.applyPrometheusRemoteWriteExternalLabels" (dict "root" . "config" $config) }}
+  {{- include "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" (dict "config" $config) }}
 {{- else if eq .Values.telemetryExternalConfig.type "arrow" }}
   {{- $config = merge $config .Values.telemetryExternalConfig.arrowConfig }}
 {{- end }}
-{{- /* Override transform/external_labels processor with dynamic config */ -}}
-{{- if and (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
+{{- /* Arrow has no exporter-native external_labels, so keep the transform path there. */ -}}
+{{- if and (eq .Values.telemetryExternalConfig.type "arrow") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}
@@ -493,6 +543,8 @@ Generate merged telemetry configuration with external labels
 {{- end }}
 {{- if and $hasSharedTelemetryBase (eq .Values.telemetryExternalConfig.type "prometheus") }}
   {{- $config = merge $config .Values.telemetryExternalConfig.prometheusConfig }}
+  {{- include "sawmills-collector.applyPrometheusRemoteWriteExternalLabels" (dict "root" . "config" $config) }}
+  {{- include "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" (dict "config" $config) }}
 {{- else if and $hasSharedTelemetryBase (eq .Values.telemetryExternalConfig.type "arrow") }}
   {{- $config = merge $config .Values.telemetryExternalConfig.arrowConfig }}
 {{- end }}
@@ -546,8 +598,12 @@ Generate merged telemetry configuration with external labels
   {{- $pressureOverlay := (fromYaml "exporters:\n  prometheus/pressure_readiness:\n    endpoint: ${env:MY_POD_IP}:${env:PRESSURE_PROMETHEUS_PORT}\n    metric_expiration: 1m\nprocessors:\n  filter/pressure_readiness:\n    error_mode: ignore\n    metrics:\n      metric:\n        - not IsMatch(name, \"^(otelcol_loadbalancer_central_queue_compressed_bytes|otelcol_loadbalancer_central_queue_compressed_capacity|otelcol_loadbalancer_central_queue_compressed_capacity_bytes|otelcol_loadbalancer_central_queue_saturation|otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes|otelcol_loadbalancer_central_queue_inflight_uncompressed_capacity|otelcol_loadbalancer_central_queue_inflight_uncompressed_capacity_bytes|otelcol_loadbalancer_central_queue_rejected_compressed_bytes|otelcol_loadbalancer_central_queue_rejected_compressed_bytes_total|otelcol_loadbalancer_central_queue_oldest_item_age|otelcol_loadbalancer_central_queue_oldest_item_age_milliseconds|otelcol_process_memory_rss|otelcol_process_memory_rss_bytes|otelcol_process_runtime_heap_alloc_bytes|otelcol_receiver_refused_log_records|otelcol_receiver_refused_log_records_total|otelcol_receiver_refused_metric_points|otelcol_receiver_refused_metric_points_total|otelcol_receiver_refused_spans|otelcol_receiver_refused_spans_total|otelcol_processor_refused_log_records|otelcol_processor_refused_log_records_total|otelcol_processor_refused_metric_points|otelcol_processor_refused_metric_points_total|otelcol_processor_refused_spans|otelcol_processor_refused_spans_total)$\")\nservice:\n  pipelines:\n    metrics/pressure_readiness:\n      receivers:\n        - forward\n      processors:\n        - filter/pressure_readiness\n      exporters:\n        - prometheus/pressure_readiness\n") }}
   {{- $config = merge $config $pressureOverlay }}
 {{- end }}
-{{- /* Override transform/external_labels processor with dynamic config */ -}}
-{{- if and (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
+{{- if eq .Values.telemetryExternalConfig.type "prometheus" }}
+  {{- include "sawmills-collector.applyPrometheusRemoteWriteExternalLabels" (dict "root" . "config" $config) }}
+  {{- include "sawmills-collector.removePrometheusRemoteWriteExternalLabelProcessor" (dict "config" $config) }}
+{{- end }}
+{{- /* Arrow has no exporter-native external_labels, so keep the transform path there. */ -}}
+{{- if and (eq .Values.telemetryExternalConfig.type "arrow") (hasKey $config "processors") (hasKey $config.processors "transform/external_labels") .Values.prometheusremotewrite .Values.prometheusremotewrite.external_labels }}
   {{- $processor := include "sawmills-collector.externalLabelsProcessor" . | fromYaml }}
   {{- $_ := set $config.processors "transform/external_labels" $processor }}
 {{- end }}

--- a/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
+++ b/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
@@ -2,8 +2,7 @@ suite: test external labels helper functions
 templates:
   - telemetry-configmap.yaml
 tests:
-  # Test 1: externalLabelsProcessor helper with all external labels
-  - it: should generate correct transform processor with ALL external labels
+  - it: should apply Prometheus remote write labels through exporter external_labels
     set:
       prometheusremotewrite:
         endpoint: https://test.example.com
@@ -23,41 +22,21 @@ tests:
           path: data["telemetry-config.yaml"]
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'transform/external_labels:'
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+cluster: us-east-1\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+environment: production\n\s+pipeline_id: test-pipeline-123\n\s+pipeline_name: test-pipeline\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+team: platform\n'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'error_mode: ignore'
-      - matchRegex:
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+receivers:\n\s+- forward\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+      - notMatchRegex:
           path: data["telemetry-config.yaml"]
           pattern: 'context: datapoint'
-      # Test ALL external labels are present in transform processor
-      - matchRegex:
+      - notMatchRegex:
           path: data["telemetry-config.yaml"]
           pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["collector_name"\], "\${env:COLLECTOR_NAME}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pod_name"\], "\${env:MY_POD_NAME}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_id"\], "test-pipeline-123"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_name"\], "test-pipeline"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["environment"\], "production"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["cluster"\], "us-east-1"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["team"\], "platform"\)'
 
-  # Test 2: externalLabelsProcessor helper with additional pipeline labels
-  - it: should generate correct transform processor with pipeline labels
+  - it: should merge chart labels with existing Prometheus remote write external_labels
     set:
       prometheusremotewrite:
         endpoint: https://test.example.com
@@ -65,92 +44,29 @@ tests:
           collector_id: ${env:COLLECTOR_ID}
           collector_name: ${env:COLLECTOR_NAME}
           pod_name: ${env:MY_POD_NAME}
-          pipeline_id: test-pipeline-123
-          pipeline_name: test-pipeline
-          environment: production
+      telemetryConfig:
+        exporters:
+          prometheusremotewrite:
+            endpoint: ${env:PROMETHEUS_REMOTE_WRITE_ENDPOINT}
+            external_labels:
+              inherited_label: inherited_value
+              collector_id: old-value
+        service:
+          pipelines:
+            metrics/external/prometheusremotewrite:
+              receivers: [forward]
+              exporters: [prometheusremotewrite]
       telemetryExternalConfig:
         type: "prometheus"
     asserts:
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_id"\], "test-pipeline-123"\)'
-      - matchRegex:
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+inherited_label: inherited_value\n\s+pod_name: \$\{env:MY_POD_NAME\}\n'
+      - notMatchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_name"\], "test-pipeline"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["environment"\], "production"\)'
+          pattern: 'collector_id: old-value'
 
-  # Test 3: externalLabelsProcessor helper with no external labels
-  - it: should generate empty transform processor when no external labels
-    set:
-      prometheusremotewrite:
-        endpoint: https://test.example.com
-        external_labels: null
-      telemetryExternalConfig:
-        type: "prometheus"
-    asserts:
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'transform/external_labels:'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'error_mode: ignore'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'metric_statements: \[\]'
-
-  # Test 4: transform processor gets ALL external labels (no duplicate exporter config)
-  - it: should add ALL external labels via transform processor only
-    set:
-      prometheusremotewrite:
-        endpoint: https://test.example.com
-        external_labels:
-          collector_id: ${env:COLLECTOR_ID}
-          collector_name: ${env:COLLECTOR_NAME}
-          pod_name: ${env:MY_POD_NAME}
-          pipeline_id: test-pipeline-456
-          pipeline_name: test-pipeline-name
-          environment: test
-          region: us-west-2
-          service: collector
-      telemetryExternalConfig:
-        type: "prometheus"
-    asserts:
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'prometheusremotewrite:'
-      # Test ALL external labels are present in transform processor
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'transform/external_labels:'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["collector_name"\], "\${env:COLLECTOR_NAME}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pod_name"\], "\${env:MY_POD_NAME}"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_id"\], "test-pipeline-456"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["pipeline_name"\], "test-pipeline-name"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["environment"\], "test"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["region"\], "us-west-2"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["service"\], "collector"\)'
-
-  # Test 5: telemetryConfig helper merges configurations correctly
-  - it: should merge haproxy config when enabled
+  - it: should still merge haproxy telemetry config when enabled
     set:
       prometheusremotewrite:
         endpoint: https://test.example.com
@@ -171,13 +87,34 @@ tests:
           path: data["telemetry-config.yaml"]
           pattern: '(?ms)^\s+metrics/haproxy:\n\s+exporters:\n\s+- routing\n\s+- forward\n\s+processors:\n\s+- memory_limiter\n\s+- batch\n\s+receivers:\n\s+- prometheus/haproxy\n'
 
-  # Test 6: telemetryConfig helper handles arrow configuration
-  - it: should use arrow config when type is arrow
+  - it: should not render Prometheus remote write external_labels when labels are null
+    set:
+      prometheusremotewrite:
+        endpoint: https://test.example.com
+        external_labels: null
+      telemetryExternalConfig:
+        type: "prometheus"
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'prometheusremotewrite:'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'collector_id:'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'pod_name:'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'context: datapoint'
+
+  - it: should keep datapoint transform labels for arrow telemetry
     set:
       prometheusremotewrite:
         endpoint: https://test.example.com
         external_labels:
           collector_id: ${env:COLLECTOR_ID}
+          pipeline_id: test-pipeline-123
       telemetryExternalConfig:
         type: "arrow"
     asserts:
@@ -186,62 +123,17 @@ tests:
           pattern: 'metrics/external/otelarrow:'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'exporters:'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: '- otelarrow'
-
-  # Test 7: Both datapoint and resource contexts get labels
-  - it: should apply external labels to both datapoint and resource contexts
-    set:
-      prometheusremotewrite:
-        endpoint: https://test.example.com
-        external_labels:
-          test_label: test_value
-      telemetryExternalConfig:
-        type: "prometheus"
-    asserts:
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["test_label"\], "test_value"\)'
+          pattern: 'transform/external_labels:'
       - matchRegex:
           path: data["telemetry-config.yaml"]
           pattern: 'context: datapoint'
-
-  # Test 8: External labels override existing processor config
-  - it: should override existing transform processor configuration
-    set:
-      prometheusremotewrite:
-        endpoint: https://test.example.com
-        external_labels:
-          new_label: new_value
-      telemetryConfig:
-        processors:
-          transform/external_labels:
-            error_mode: propagate
-            metric_statements:
-              - context: datapoint
-                statements:
-                  - set(attributes["old_label"], "old_value")
-      telemetryExternalConfig:
-        type: "prometheus"
-    asserts:
-      # Should use error_mode: ignore (from helper) not propagate (from original config)
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'error_mode: ignore'
-      - notMatchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'error_mode: propagate'
-      # Should have new labels, not old ones
+          pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["new_label"\], "new_value"\)'
-      - notMatchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["old_label"\], "old_value"\)'
+          pattern: 'set\(attributes\["pipeline_id"\], "test-pipeline-123"\)'
 
-  # Test 9: Configuration without telemetryConfig should not fail
   - it: should handle missing telemetryConfig gracefully
     set:
       prometheusremotewrite:
@@ -254,10 +146,9 @@ tests:
           path: data
       - notMatchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '\S'  # Should be empty or whitespace only
+          pattern: '\S'
 
-  # Test 10: Complex external labels with special characters
-  - it: should handle complex external labels with special characters
+  - it: should handle complex Prometheus remote write external labels
     set:
       prometheusremotewrite:
         endpoint: https://test.example.com
@@ -270,10 +161,13 @@ tests:
     asserts:
       - matchRegex:
           path: data["telemetry-config.yaml"]
+          pattern: 'label-with-dash: value-with-dash'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'label_with_underscore: value_with_underscore'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'label\.with\.dots: value\.with\.dots'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
           pattern: 'set\(attributes\["label-with-dash"\], "value-with-dash"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["label_with_underscore"\], "value_with_underscore"\)'
-      - matchRegex:
-          path: data["telemetry-config.yaml"]
-          pattern: 'set\(attributes\["label\.with\.dots"\], "value\.with\.dots"\)' 

--- a/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
+++ b/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
@@ -66,6 +66,38 @@ tests:
           path: data["telemetry-config.yaml"]
           pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
 
+  - it: should preserve custom Prometheus remote write pipelines that reference transform labels
+    set:
+      prometheusremotewrite:
+        endpoint: https://test.example.com
+        external_labels:
+          collector_id: ${env:COLLECTOR_ID}
+          custom_label: custom-value
+      telemetryConfig:
+        processors:
+          filter/custom_keep:
+            metrics:
+              metric:
+                - 'name == "custom_metric"'
+        service:
+          pipelines:
+            metrics/external/prometheusremotewrite:
+              receivers: [forward]
+              processors: [transform/external_labels, filter/custom_keep]
+              exporters: [prometheusremotewrite]
+      telemetryExternalConfig:
+        type: "prometheus"
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- transform/external_labels\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'context: datapoint'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'set\(attributes\["custom_label"\], "custom-value"\)'
+
   - it: should merge chart labels with existing Prometheus remote write external_labels
     set:
       prometheusremotewrite:

--- a/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
+++ b/helm-charts/sawmills-collector/tests/helpers_external_labels_test.yaml
@@ -36,6 +36,36 @@ tests:
           path: data["telemetry-config.yaml"]
           pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
 
+  - it: should keep transform labels for custom Prometheus telemetry pipelines that reference them
+    set:
+      prometheusremotewrite:
+        endpoint: https://test.example.com
+        external_labels:
+          collector_id: ${env:COLLECTOR_ID}
+          custom_label: custom-value
+      telemetryConfig:
+        service:
+          pipelines:
+            metrics/custom_prometheus:
+              receivers: [forward]
+              processors: [transform/external_labels]
+              exporters: [prometheus]
+      telemetryExternalConfig:
+        type: "prometheus"
+    asserts:
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/custom_prometheus:\n\s+exporters:\n\s+- prometheus\n\s+processors:\n\s+- transform/external_labels\n\s+receivers:\n\s+- forward\n'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'context: datapoint'
+      - matchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: 'set\(attributes\["custom_label"\], "custom-value"\)'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+
   - it: should merge chart labels with existing Prometheus remote write external_labels
     set:
       prometheusremotewrite:

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -211,10 +211,10 @@ tests:
           pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 9\n\s+queue_size: 123\n\s+storage: file_storage/prw\n\s+retry_on_failure:\n\s+enabled: true\n\s+initial_interval: 2s\n\s+max_elapsed_time: 5s\n\s+max_interval: 5s\n\s+timeout: 45s\n'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
-      - notMatchRegex:
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- transform/external_labels\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
+      - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+          pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
 
   - it: preserves inherited remote-write queue extras and custom processors
     template: load-balancer-telemetry-configmap.yaml
@@ -235,10 +235,10 @@ tests:
           pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+inherited_label: inherited_value\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+max_batch_request_parallelism: 1\n\s+max_batch_size_bytes: 6000000\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 4\n\s+queue_size: 500\n\s+storage: file_storage/prw\n'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/lb_remote_write\n\s+- filter/inherited_keep\n\s+receivers:\n\s+- forward\n'
-      - notMatchRegex:
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/lb_remote_write\n\s+- transform/external_labels\n\s+- filter/inherited_keep\n\s+receivers:\n\s+- forward\n'
+      - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
+          pattern: 'set\(attributes\["collector_id"\], "\${env:COLLECTOR_ID}"\)'
 
   - it: exposes the pressure endpoint port on the LB telemetry collector
     template: load-balancer.yaml

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -208,10 +208,13 @@ tests:
           pattern: 'queue_size: 500'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 9\n\s+queue_size: 123\n\s+storage: file_storage/prw\n\s+retry_on_failure:\n\s+enabled: true\n\s+initial_interval: 2s\n\s+max_elapsed_time: 5s\n\s+max_interval: 5s\n\s+timeout: 45s\n'
+          pattern: '(?ms)^\s*prometheusremotewrite:\n\s+endpoint: \$\{env:PROMETHEUS_REMOTE_WRITE_ENDPOINT\}\n\s+external_labels:\n\s+collector_id: \$\{env:COLLECTOR_ID\}\n\s+collector_name: \$\{env:COLLECTOR_NAME\}\n\s+pod_name: \$\{env:MY_POD_NAME\}\n\s+headers:\n\s+X-API-KEY: \$\{env:PROMETHEUS_REMOTE_WRITE_API_KEY\}\n\s+remote_write_queue:\n\s+enabled: true\n\s+num_consumers: 9\n\s+queue_size: 123\n\s+storage: file_storage/prw\n\s+retry_on_failure:\n\s+enabled: true\n\s+initial_interval: 2s\n\s+max_elapsed_time: 5s\n\s+max_interval: 5s\n\s+timeout: 45s\n'
       - matchRegex:
           path: data["telemetry-config.yaml"]
-          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- transform/external_labels\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n\s+exporters:\n\s+- prometheusremotewrite\n\s+processors:\n\s+- filter/custom_keep\n\s+receivers:\n\s+- forward\n'
+      - notMatchRegex:
+          path: data["telemetry-config.yaml"]
+          pattern: '(?ms)^\s*metrics/external/prometheusremotewrite:\n(?:.*\n)*?\s+- transform/external_labels\n'
 
   - it: preserves inherited remote-write queue extras and custom processors
     template: load-balancer-telemetry-configmap.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -913,7 +913,6 @@ telemetryExternalConfig:
       pipelines:
         metrics/external/prometheusremotewrite:
           receivers: [forward]
-          processors: [transform/external_labels]
           exporters: [prometheusremotewrite]
   arrowConfig:
     service:


### PR DESCRIPTION
sawmills-collector: Use PRW external labels

TLDR: Moves Prometheus remote write telemetry labels from a transform processor into exporter-level `external_labels`. This keeps the default PRW LB telemetry path slim while preserving Arrow/custom telemetry pipelines that still reference `transform/external_labels`.

Description:
- Render `prometheusremotewrite.external_labels` for PRW telemetry and omit `transform/external_labels` from the default transform-only PRW path.
- Keep/generated `transform/external_labels` when a remaining pipeline actually references it, covering Arrow, custom Prometheus telemetry pipelines, and custom PRW processor chains.
- Adds red/green Helm unittest coverage for PRW, custom Prometheus transform compatibility, custom PRW processor-chain compatibility, Arrow, LB pressure readiness adjacency, and full chart validation.

Version Impact:
- `version:patch`
- Backward compatible for existing custom pipelines that reference `transform/external_labels`.

Verification:
- Red: `helm unittest helm-charts/sawmills-collector -f 'tests/helpers_external_labels_test.yaml'` failed before the original PRW fix because PRW exporter labels were missing and PRW still used `transform/external_labels`.
- Red: custom Prometheus pipeline regression test failed after cubic identified the first compatibility risk because the custom pipeline referenced `transform/external_labels` but the processor stayed empty.
- Red: custom PRW processor-chain tests failed after cubic identified the second compatibility risk because the PRW pipeline transform was stripped ahead of custom processors.
- Green: `helm unittest helm-charts/sawmills-collector -f 'tests/helpers_external_labels_test.yaml' -f 'tests/load_balancer_pressure_readiness_test.yaml' -f 'tests/telemetry_exporter_resilience_test.yaml' -f 'tests/telemetry_keda_overlay_test.yaml'` passed, 78/78.
- Green: `./helm-charts/sawmills-collector/tests/run-tests.sh` passed, 276/276.
- Green: `helm lint helm-charts/sawmills-collector` passed.
- Green: `trunk check --fix` passed.
- Green: `git diff --check origin/main` passed.
- Adversarial review: PASS before PR; cubic follow-up compatibility findings fixed in commits `1c15e4a` and `4e44f7a`.

Refs SAW-7500
