### PR TITLE
feat(sawmills-collector): preStop sleep on telemetry-collector sidecar

### DIFF
--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -237,6 +237,20 @@ spec:
               port: 13134
             initialDelaySeconds: {{ .Values.rollout.telemetry.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.rollout.telemetry.probes.readiness.periodSeconds }}
+          {{- if .Values.rollout.telemetry.preStopSleepSeconds }}
+          # Single-handler preStop: hold SIGTERM long enough for in-flight
+          # telemetry pushes to 127.0.0.1:<main OTLP port> to drain before the
+          # main-collector starts closing its receivers during scale-down /
+          # rollout. Must stay <= rollout.terminationGracePeriodSeconds.
+          # Mirrors rollout.main.preStopSleepSeconds. Exec-only (no httpGet) —
+          # K8s rejects preStop blocks with more than one handler type.
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sleep
+                  - "{{ .Values.rollout.telemetry.preStopSleepSeconds }}"
+          {{- end }}
           resources:
             {{- if .Values.telemetry.resources.requests }}
             requests:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -136,6 +136,13 @@ rollout:
       readiness:
         initialDelaySeconds: 5
         periodSeconds: 5
+    # Sleep-based preStop on the telemetry-collector sidecar. Without this,
+    # during HPA scale-down / rollout the sidecar keeps pushing to
+    # 127.0.0.1:<main-collector OTLP port> while the main-collector closes
+    # its receivers in parallel, surfacing as "connection refused" errors
+    # in customer environments. Keep <= rollout.terminationGracePeriodSeconds.
+    # Set to 0 to disable.
+    preStopSleepSeconds: 10
 
   # HAProxy specific settings
   haproxy:


### PR DESCRIPTION
## Why

During HPA scale-down / rollout, the telemetry-collector sidecar keeps pushing to `127.0.0.1:<main-collector OTLP port>` while the main-collector closes its OTLP receivers in parallel — surfacing as `dial tcp 127.0.0.1:14317: connect: connection refused` error storms.

**Observed on applied-systems prod (2026-06-01):** ~263 connect-refused events in 15 min during a 16→10 HPA scale-down. Main-collector already has `rollout.main.preStopSleepSeconds` (defaults to 15s). The telemetry sidecar has no preStop at all today.

## What

- `templates/deployment.yaml`: add `lifecycle.preStop.exec` (`/bin/sleep N`) on the telemetry-collector container, gated on `rollout.telemetry.preStopSleepSeconds`.
- `values.yaml`: new key `rollout.telemetry.preStopSleepSeconds: 10` (default). Set to `0` to disable.

Mirrors the existing fallback path on main-collector (lines 337-343 of deployment.yaml).

## Booby-trap avoided

The `deployments` table in the prod `collectors` DB shows applied-systems already hit a related failure mode on 2026-04-24 (10× failed deploys) — `spec.template.spec.containers[1].lifecycle.preStop.httpGet: Forbidden: may not specify more than 1 handler type`. K8s rejects preStop blocks that specify more than one handler. This PR is **exec-only** by construction, never `httpGet+exec`.

## Verification

```
helm lint .                # passes
helm template . | grep -A8 'name: telemetry-collector' | grep -A6 lifecycle  # renders
  lifecycle:
    preStop:
      exec:
        command:
          - /bin/sleep
          - "10"
helm template . --set rollout.telemetry.preStopSleepSeconds=0  # lifecycle block absent
```

## Rollout / risk

- Default `10s` is < `rollout.terminationGracePeriodSeconds: 150` — no risk of being killed mid-sleep.
- No effect on rolling-update speed beyond +10s per old pod (parallel with main-collector's 15s drain).
- Backward compatible: `preStopSleepSeconds: 0` reproduces today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a preStop sleep to the telemetry-collector sidecar so it can finish sending before the main collector shuts down. This reduces connection refused errors during HPA scale-down and rollouts.

- **Bug Fixes**
  - Added `lifecycle.preStop.exec` sleep on the telemetry-collector container, gated by `rollout.telemetry.preStopSleepSeconds`.
  - Default is `10s`; set `0` to disable. Mirrors `rollout.main.preStopSleepSeconds`.
  - Exec-only handler to satisfy Kubernetes’ single-handler rule and kept within `rollout.terminationGracePeriodSeconds`.

<sup>Written for commit 6c6e086fdc24d97c29bd7b9a9b7e447e2e928a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pre-stop delay for collector shutdown during rollout and scaling operations. The new setting allows you to specify a sleep duration (default: 10 seconds) to ensure graceful telemetry draining before shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->