### PR TITLE
sawmills-collector: Keep LB ready during HAProxy fallback

### DIFF
--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -3,6 +3,13 @@
 {{- $healthcheck := .Values.haproxy.healthcheck | default dict -}}
 {{- $forwardingHealth := $healthcheck.forwarding_health | default dict -}}
 {{- $forwardingHealthEnabled := $forwardingHealth.enabled | default false -}}
+{{- $localBackendHealthcheck := .Values.haproxy.local_backend_healthcheck | default dict -}}
+{{- $localBackendHealthcheckEnabled := $localBackendHealthcheck.enabled | default false -}}
+{{- $localBackendHealthcheckPort := $localBackendHealthcheck.port | default 13137 -}}
+{{- $localBackendHealthcheckPath := $localBackendHealthcheck.path | default "/ready" -}}
+{{- $localBackendHealthcheckInterval := $localBackendHealthcheck.interval | default 3000 -}}
+{{- $localBackendHealthcheckRise := $localBackendHealthcheck.rise | default 2 -}}
+{{- $localBackendHealthcheckFall := $localBackendHealthcheck.fall | default 2 -}}
 {{- $readinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy -}}
 
 global
@@ -192,13 +199,16 @@ frontend logs_http_frontend_{{ $config.from }}
 
 backend logs_http_{{ $config.from }}
   mode {{ if eq $mode "grpc" }}http{{ else }}{{ $mode }}{{ end }}
+  {{- $localBackendHealthcheckApplies := and $localBackendHealthcheckEnabled (ne $mode "tcp") }}
   {{- if and ($refusalFastFail.enabled | default false) $siblingEnabled (ne $mode "tcp") }}
   retry-on 503
   {{- end }}
   {{- range $option := $config.backend_options }}
   option {{ $option }}
   {{- end }}
-  {{- if not $config.backend_options }}
+  {{- if $localBackendHealthcheckApplies }}
+  option httpchk GET {{ $localBackendHealthcheckPath }}
+  {{- else if not $config.backend_options }}
   {{- if not (eq $mode "grpc") }}
   option httpchk GET /healthcheck
   {{- end }}
@@ -226,7 +236,11 @@ backend logs_http_{{ $config.from }}
   # Tag request as sibling-forwarded before sending to sibling tier
   http-request set-header X-Sibling-Hop 1
   {{- end }}
+  {{- if $localBackendHealthcheckApplies }}
+  server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port {{ $localBackendHealthcheckPort }} inter {{ $localBackendHealthcheckInterval }} rise {{ $localBackendHealthcheckRise }} fall {{ $localBackendHealthcheckFall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $errorLimit }} on-error mark-down{{ if ne $slowstart "" }} slowstart {{ $slowstart }}{{ end }}
+  {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port 13133 inter {{ $interval }} rise {{ $rise }} fall {{ $fall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $errorLimit }} on-error mark-down{{ if ne $slowstart "" }} slowstart {{ $slowstart }}{{ end }}
+  {{- end }}
   {{- if $siblingEnabled }}
   {{- $sf := $.Values.haproxy.sibling_fallback }}
   # Sibling tier: round-robin across other LB pods via headless service DNS
@@ -242,7 +256,11 @@ backend logs_http_{{ $config.from }}
   server fallback {{ $to.fallback_endpoint }} {{ $proto }} backup {{ if (or (not (hasKey $to "fallback_ssl")) $to.fallback_ssl) }}ssl verify none{{ end }}
   {{- end }}
   {{- else }}
+  {{- if $localBackendHealthcheckApplies }}
+  server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port {{ $localBackendHealthcheckPort }} inter {{ $localBackendHealthcheckInterval }} rise {{ $localBackendHealthcheckRise }} fall {{ $localBackendHealthcheckFall }}
+  {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check {{ if not (eq $mode "grpc") }}port 13133{{ end }}
+  {{- end }}
   {{- end }}
 
 {{- if and $to.metrics_proxy_endpoint (ne $mode "tcp") }}
@@ -259,7 +277,9 @@ backend logs_http_{{ $config.from }}_direct
   {{- range $option := $config.backend_options }}
   option {{ $option }}
   {{- end }}
-  {{- if not $config.backend_options }}
+  {{- if $localBackendHealthcheckApplies }}
+  option httpchk GET {{ $localBackendHealthcheckPath }}
+  {{- else if not $config.backend_options }}
   {{- if not (eq $mode "grpc") }}
   option httpchk GET /healthcheck
   {{- end }}
@@ -283,7 +303,11 @@ backend logs_http_{{ $config.from }}_direct
   {{- $directErrorLimit = ($refusalFastFail.error_limit | default 20) }}
   {{- $directSlowstart = ($refusalFastFail.slowstart | default "") }}
   {{- end }}
+  {{- if $localBackendHealthcheckApplies }}
+  server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port {{ $localBackendHealthcheckPort }} inter {{ $localBackendHealthcheckInterval }} rise {{ $localBackendHealthcheckRise }} fall {{ $localBackendHealthcheckFall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $directErrorLimit }} on-error mark-down{{ if ne $directSlowstart "" }} slowstart {{ $directSlowstart }}{{ end }}
+  {{- else }}
   server otel "$MY_POD_IP":{{ $to.port }} {{ $proto }} check port 13133 inter {{ $interval }} rise {{ $rise }} fall {{ $fall }} observe {{ if eq $mode "http" }}layer7{{ else }}layer4{{ end }} error-limit {{ $directErrorLimit }} on-error mark-down{{ if ne $directSlowstart "" }} slowstart {{ $directSlowstart }}{{ end }}
+  {{- end }}
   {{- if and $externalFallbackEnabled $to.fallback_endpoint }}
   server fallback {{ $to.fallback_endpoint }} {{ $proto }} backup {{ if (or (not (hasKey $to "fallback_ssl")) $to.fallback_ssl) }}ssl verify none{{ end }}
   {{- end }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -199,7 +199,7 @@ frontend logs_http_frontend_{{ $config.from }}
 
 backend logs_http_{{ $config.from }}
   mode {{ if eq $mode "grpc" }}http{{ else }}{{ $mode }}{{ end }}
-  {{- $localBackendHealthcheckApplies := and $localBackendHealthcheckEnabled (ne $mode "tcp") }}
+  {{- $localBackendHealthcheckApplies := and $localBackendHealthcheckEnabled (eq $mode "http") }}
   {{- if and ($refusalFastFail.enabled | default false) $siblingEnabled (ne $mode "tcp") }}
   retry-on 503
   {{- end }}

--- a/helm-charts/sawmills-collector/templates/_haproxy.tpl
+++ b/helm-charts/sawmills-collector/templates/_haproxy.tpl
@@ -2,9 +2,9 @@
 {{- $refusalFastFail := .Values.haproxy.refusal_fast_fail | default dict -}}
 {{- $healthcheck := .Values.haproxy.healthcheck | default dict -}}
 {{- $forwardingHealth := $healthcheck.forwarding_health | default dict -}}
-{{- $forwardingHealthEnabled := $forwardingHealth.enabled | default false -}}
 {{- $localBackendHealthcheck := .Values.haproxy.local_backend_healthcheck | default dict -}}
 {{- $localBackendHealthcheckEnabled := $localBackendHealthcheck.enabled | default false -}}
+{{- $forwardingHealthEnabled := or ($forwardingHealth.enabled | default false) $localBackendHealthcheckEnabled -}}
 {{- $localBackendHealthcheckPort := $localBackendHealthcheck.port | default 13137 -}}
 {{- $localBackendHealthcheckPath := $localBackendHealthcheck.path | default "/ready" -}}
 {{- $localBackendHealthcheckInterval := $localBackendHealthcheck.interval | default 3000 -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -1064,6 +1064,17 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- $readinessType := (dig "probes" "readiness" "type" "http" $root.Values.haproxy) | toString | lower -}}
 {{- $readinessPort := dig "probes" "readiness" "port" 13135 $root.Values.haproxy -}}
 {{- $readinessPath := dig "probes" "readiness" "path" "/ready" $root.Values.haproxy -}}
+{{- $localBackendHealthcheck := $root.Values.haproxy.local_backend_healthcheck | default dict -}}
+{{- if ($localBackendHealthcheck.enabled | default false) -}}
+{{- $readinessType = "http" -}}
+{{- if eq $livenessType "http" -}}
+{{- $readinessPort = $livenessPort -}}
+{{- $readinessPath = $livenessPath -}}
+{{- else -}}
+{{- $readinessPort = ($root.Values.haproxy.healthcheck.port | default 13135) -}}
+{{- $readinessPath = "/healthcheck" -}}
+{{- end -}}
+{{- end -}}
 {{- $defaultSecurityContext := dict "runAsNonRoot" true "runAsUser" 99 "runAsGroup" 99 -}}
 {{- $securityContext := mergeOverwrite (deepCopy $defaultSecurityContext) (default dict $root.Values.haproxy.securityContext) -}}
 {{- if not (or (eq $livenessType "http") (eq $livenessType "tcp")) -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -1065,7 +1065,14 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- $readinessPort := dig "probes" "readiness" "port" 13135 $root.Values.haproxy -}}
 {{- $readinessPath := dig "probes" "readiness" "path" "/ready" $root.Values.haproxy -}}
 {{- $localBackendHealthcheck := $root.Values.haproxy.local_backend_healthcheck | default dict -}}
-{{- if ($localBackendHealthcheck.enabled | default false) -}}
+{{- $lbPressureReadiness := $root.Values.loadBalancer.pressureReadiness | default dict -}}
+{{- $lbPressureReadinessUseForPodReadiness := true -}}
+{{- if hasKey $lbPressureReadiness "useForPodReadiness" -}}
+{{- $lbPressureReadinessUseForPodReadiness = $lbPressureReadiness.useForPodReadiness -}}
+{{- end -}}
+{{- $pressureKeepsPodReady := and $root.Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) (not $lbPressureReadinessUseForPodReadiness) -}}
+{{- if or ($localBackendHealthcheck.enabled | default false) $pressureKeepsPodReady -}}
+{{- /* Keep HAProxy's Kubernetes readiness shallow when HAProxy owns fallback decisions. */ -}}
 {{- $readinessType = "http" -}}
 {{- if eq $livenessType "http" -}}
 {{- $readinessPort = $livenessPort -}}

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -1052,6 +1052,23 @@ Fail fast for known invalid combinations.
 {{- end -}}
 
 {{/*
+Validate local backend healthcheck has a chart-rendered backend_drain endpoint.
+*/}}
+{{- define "sawmills-collector.validateHaproxyLocalBackendHealthcheck" -}}
+{{- $localBackendHealthcheck := .Values.haproxy.local_backend_healthcheck | default dict -}}
+{{- if ($localBackendHealthcheck.enabled | default false) -}}
+{{- $lbPressureReadiness := .Values.loadBalancer.pressureReadiness | default dict -}}
+{{- $mainDrain := .Values.rollout.main.drain | default dict -}}
+{{- $mainDrainConfigSource := default "overlay" $mainDrain.configSource -}}
+{{- $lbPressureBackendDrainRendered := and .Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) -}}
+{{- $mainDrainBackendDrainRendered := and .Values.loadBalancer.enabled ($mainDrain.enabled | default false) (eq $mainDrainConfigSource "overlay") -}}
+{{- if not (or $lbPressureBackendDrainRendered $mainDrainBackendDrainRendered) -}}
+{{- fail "haproxy.local_backend_healthcheck.enabled requires chart-rendered backend_drain via loadBalancer.pressureReadiness.enabled=true or rollout.main.drain.enabled=true with configSource=overlay" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 HAProxy container spec (shared between native sidecar and regular container paths).
 Caller passes context via dict with "root" (top-level context) and "nativeSidecar" (bool).
 */}}
@@ -1073,13 +1090,13 @@ Caller passes context via dict with "root" (top-level context) and "nativeSideca
 {{- $pressureKeepsPodReady := and $root.Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) (not $lbPressureReadinessUseForPodReadiness) -}}
 {{- if or ($localBackendHealthcheck.enabled | default false) $pressureKeepsPodReady -}}
 {{- /* Keep HAProxy's Kubernetes readiness shallow when HAProxy owns fallback decisions. */ -}}
+{{- if eq $livenessType "tcp" -}}
+{{- $readinessType = "tcp" -}}
+{{- $readinessPort = $livenessPort -}}
+{{- else -}}
 {{- $readinessType = "http" -}}
-{{- if eq $livenessType "http" -}}
 {{- $readinessPort = $livenessPort -}}
 {{- $readinessPath = $livenessPath -}}
-{{- else -}}
-{{- $readinessPort = ($root.Values.haproxy.healthcheck.port | default 13135) -}}
-{{- $readinessPath = "/healthcheck" -}}
 {{- end -}}
 {{- end -}}
 {{- $defaultSecurityContext := dict "runAsNonRoot" true "runAsUser" 99 "runAsGroup" 99 -}}

--- a/helm-charts/sawmills-collector/templates/haproxy-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/haproxy-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.haproxy.enabled }}
+{{- include "sawmills-collector.validateHaproxyLocalBackendHealthcheck" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -13,6 +13,9 @@
 {{- if and $hasSharedTelemetryBase (not $lbTelemetryOtelS3Path) (or (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:19465/metrics") (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:8888/metrics") (eq $pressureMetricsEndpoint "http://${env:MY_POD_IP}:${env:PROMETHEUS_PORT}/metrics")) }}
 {{- $pressureMetricsEndpoint = $defaultPressureMetricsEndpoint }}
 {{- end }}
+{{- $localBackendHealthcheck := .Values.haproxy.local_backend_healthcheck | default dict }}
+{{- $localBackendHealthcheckEnabled := $localBackendHealthcheck.enabled | default false }}
+{{- $forwardingHealth := dig "healthcheck" "forwarding_health" (dict) .Values.haproxy }}
 {{- $lbConfig := default dict .Values.loadBalancer.otelCollectorConfig }}
 {{- $serviceExtensions := list }}
 {{- if and (kindIs "map" $lbConfig) (hasKey $lbConfig "service") (kindIs "map" $lbConfig.service) (hasKey $lbConfig.service "extensions") }}
@@ -30,7 +33,9 @@
 {{- $filteredServiceExtensions = append $filteredServiceExtensions "backend_drain" }}
 {{- end }}
 {{- $healthCheckEndpoint := default "http://${env:MY_POD_IP}:13133/healthcheck" $lbPressure.healthCheckEndpoint }}
-{{- if and .Values.haproxy.enabled (eq ((dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower) "http") (not $lbPressure.healthCheckEndpoint) }}
+{{- if and .Values.haproxy.enabled $localBackendHealthcheckEnabled (not $lbPressure.healthCheckEndpoint) }}
+{{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (default 13136 $forwardingHealth.port) (default "/forwarding-health" $forwardingHealth.path) }}
+{{- else if and .Values.haproxy.enabled (eq ((dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower) "http") (not $lbPressure.healthCheckEndpoint) }}
 {{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (dig "probes" "readiness" "port" 13135 .Values.haproxy) (dig "probes" "readiness" "path" "/ready" .Values.haproxy) }}
 {{- end }}
 {{- $memoryLimitBytes := "" }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -16,6 +16,11 @@
 {{- $localBackendHealthcheck := .Values.haproxy.local_backend_healthcheck | default dict }}
 {{- $localBackendHealthcheckEnabled := $localBackendHealthcheck.enabled | default false }}
 {{- $forwardingHealth := dig "healthcheck" "forwarding_health" (dict) .Values.haproxy }}
+{{- $forwardingHealthEnabled := or ($forwardingHealth.enabled | default false) $localBackendHealthcheckEnabled }}
+{{- $forwardingHealthMetricsEndpoint := default $pressureMetricsEndpoint (get $forwardingHealth "metricsEndpoint") }}
+{{- if hasKey $forwardingHealth "metrics_endpoint" }}
+{{- $forwardingHealthMetricsEndpoint = get $forwardingHealth "metrics_endpoint" }}
+{{- end }}
 {{- $lbConfig := default dict .Values.loadBalancer.otelCollectorConfig }}
 {{- $serviceExtensions := list }}
 {{- if and (kindIs "map" $lbConfig) (hasKey $lbConfig "service") (kindIs "map" $lbConfig.service) (hasKey $lbConfig.service "extensions") }}
@@ -32,8 +37,11 @@
 {{- if not (has "backend_drain" $filteredServiceExtensions) }}
 {{- $filteredServiceExtensions = append $filteredServiceExtensions "backend_drain" }}
 {{- end }}
+{{- if and $forwardingHealthEnabled (not (has "forwarding_health" $filteredServiceExtensions)) }}
+{{- $filteredServiceExtensions = append $filteredServiceExtensions "forwarding_health" }}
+{{- end }}
 {{- $healthCheckEndpoint := default "http://${env:MY_POD_IP}:13133/healthcheck" $lbPressure.healthCheckEndpoint }}
-{{- if and .Values.haproxy.enabled $localBackendHealthcheckEnabled (not $lbPressure.healthCheckEndpoint) }}
+{{- if and .Values.haproxy.enabled $localBackendHealthcheckEnabled $forwardingHealthEnabled (not $lbPressure.healthCheckEndpoint) }}
 {{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (default 13136 $forwardingHealth.port) (default "/forwarding-health" $forwardingHealth.path) }}
 {{- else if and .Values.haproxy.enabled (eq ((dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower) "http") (not $lbPressure.healthCheckEndpoint) }}
 {{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (dig "probes" "readiness" "port" 13135 .Values.haproxy) (dig "probes" "readiness" "path" "/ready" .Values.haproxy) }}
@@ -58,6 +66,12 @@ metadata:
 data:
   config.yaml: |
     extensions:
+      {{- if $forwardingHealthEnabled }}
+      forwarding_health:
+        endpoint: ${env:MY_POD_IP}:{{ default 13136 $forwardingHealth.port }}
+        path: {{ default "/forwarding-health" $forwardingHealth.path }}
+        metrics_endpoint: {{ $forwardingHealthMetricsEndpoint }}
+      {{- end }}
       backend_drain:
         endpoint: ${env:MY_POD_IP}:{{ default 13137 $lbPressure.port }}
         readiness_path: {{ default "/ready" $lbPressure.readinessPath }}

--- a/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer-readiness-configmap.yaml
@@ -41,7 +41,7 @@
 {{- $filteredServiceExtensions = append $filteredServiceExtensions "forwarding_health" }}
 {{- end }}
 {{- $healthCheckEndpoint := default "http://${env:MY_POD_IP}:13133/healthcheck" $lbPressure.healthCheckEndpoint }}
-{{- if and .Values.haproxy.enabled $localBackendHealthcheckEnabled $forwardingHealthEnabled (not $lbPressure.healthCheckEndpoint) }}
+{{- if and .Values.haproxy.enabled $forwardingHealthEnabled (not $lbPressure.healthCheckEndpoint) }}
 {{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (default 13136 $forwardingHealth.port) (default "/forwarding-health" $forwardingHealth.path) }}
 {{- else if and .Values.haproxy.enabled (eq ((dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower) "http") (not $lbPressure.healthCheckEndpoint) }}
 {{- $healthCheckEndpoint = printf "http://${env:MY_POD_IP}:%v%v" (dig "probes" "readiness" "port" 13135 .Values.haproxy) (dig "probes" "readiness" "path" "/ready" .Values.haproxy) }}

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -10,6 +10,10 @@
 {{- $lbStartupProbe := .Values.rollout.loadBalancer.probes.startup | default dict }}
 {{- $lbPressureReadiness := .Values.loadBalancer.pressureReadiness | default dict }}
 {{- $lbPressureReadinessEnabled := and .Values.loadBalancer.enabled ($lbPressureReadiness.enabled | default false) }}
+{{- $lbPressureReadinessUseForPodReadiness := true }}
+{{- if hasKey $lbPressureReadiness "useForPodReadiness" }}
+{{- $lbPressureReadinessUseForPodReadiness = $lbPressureReadiness.useForPodReadiness }}
+{{- end }}
 {{- $haproxyReadinessType := (dig "probes" "readiness" "type" "http" .Values.haproxy) | toString | lower }}
 {{- $haproxyReadinessPath := dig "probes" "readiness" "path" "/ready" .Values.haproxy }}
 {{- $haproxyReadinessPort := dig "probes" "readiness" "port" 13135 .Values.haproxy }}
@@ -190,7 +194,10 @@ spec:
             failureThreshold: {{ .Values.rollout.loadBalancer.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
-              {{- if $lbPressureReadinessEnabled }}
+              {{- if and $lbPressureReadinessEnabled (not $lbPressureReadinessUseForPodReadiness) }}
+              path: /healthcheck
+              port: 13133
+              {{- else if $lbPressureReadinessEnabled }}
               path: {{ default "/ready" $lbPressureReadiness.readinessPath }}
               port: {{ default 13137 $lbPressureReadiness.port }}
               {{- else if .Values.haproxy.enabled }}

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -277,6 +277,36 @@ tests:
           path: spec.template.spec.containers[1].readinessProbe.httpGet.path
           value: /healthcheck
 
+  - it: should keep haproxy container readiness shallow when pressure readiness keeps pods ready
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.useForPodReadiness: false
+      haproxy.enabled: true
+      haproxy.probes.readiness.path: /ready
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthcheck
+
   - it: should keep haproxy liveness on healthcheck when forwarding health gates readiness
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -163,6 +163,43 @@ tests:
           path: spec.template.spec.containers[1].readinessProbe.httpGet.path
           value: /ready
 
+  - it: should preserve tcp haproxy readiness when pressure readiness keeps pods ready
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.useForPodReadiness: false
+      haproxy.enabled: true
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: TCP
+      haproxy.probes.liveness.type: tcp
+      haproxy.probes.liveness.port: 10000
+      haproxy.probes.readiness.type: tcp
+      haproxy.probes.readiness.port: 10000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 10000
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 10000
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthcheck
+
   - it: should route load balancer main collector readiness through custom haproxy healthcheck port with tcp haproxy probes
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
+++ b/helm-charts/sawmills-collector/tests/haproxy_probe_config_test.yaml
@@ -246,6 +246,37 @@ tests:
           content:
             "$patch": replace
 
+  - it: should keep haproxy container readiness shallow in local backend healthcheck mode
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.useForPodReadiness: false
+      haproxy.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.probes.readiness.path: /ready
+      haproxy.mapping.logs_http_10000.from: 10000
+      haproxy.mapping.logs_http_10000.to.port: 10518
+      haproxy.mapping.logs_http_10000.to.protocol: "TCP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13135
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: main-collector
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthcheck
+
   - it: should keep haproxy liveness on healthcheck when forwarding health gates readiness
     template: load-balancer.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -41,6 +41,26 @@ tests:
           path: spec.template.spec.volumes[1].name
           value: sawmills-load-balancer-readiness-config
 
+  - it: keeps Kubernetes pod readiness on collector health when pressure readiness is not used for pod readiness
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.useForPodReadiness: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].readinessProbe.httpGet.port
+          value: 13133
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].readinessProbe.httpGet.path
+          value: /healthcheck
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].args[1]
+          value: --config=file:/etc/otel/load-balancer-readiness-config.yaml
+
   - it: renders pressure_check config with queue and memory thresholds
     template: load-balancer-readiness-configmap.yaml
     values:
@@ -58,6 +78,34 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n'
+
+  - it: points backend_drain health checks at forwarding_health when HAProxy local backend checks are enabled
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.useForPodReadiness: false
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'health_check_endpoint: http://\$\{env:MY_POD_IP\}:13136/forwarding-health'
+
+  - it: preserves explicit forwarding_health endpoint for pressure readiness
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+      loadBalancer.pressureReadiness.healthCheckEndpoint: http://${env:MY_POD_IP}:13136/forwarding-health
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'health_check_endpoint: http://\$\{env:MY_POD_IP\}:13136/forwarding-health'
 
   - it: normalizes legacy explicit pressure metrics endpoints to the small pressure endpoint
     template: load-balancer-readiness-configmap.yaml

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -92,7 +92,13 @@ tests:
     asserts:
       - matchRegex:
           path: data["config.yaml"]
+          pattern: '(?ms)^extensions:\n\s+forwarding_health:\n\s+endpoint: \$\{env:MY_POD_IP\}:13136\n\s+path: /forwarding-health\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics\n\s+backend_drain:\n'
+      - matchRegex:
+          path: data["config.yaml"]
           pattern: 'health_check_endpoint: http://\$\{env:MY_POD_IP\}:13136/forwarding-health'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n\s+- forwarding_health\n'
 
   - it: preserves explicit forwarding_health endpoint for pressure readiness
     template: load-balancer-readiness-configmap.yaml

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -100,6 +100,26 @@ tests:
           path: data["config.yaml"]
           pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n\s+- forwarding_health\n'
 
+  - it: points backend_drain health checks at forwarding_health when HAProxy forwarding health is enabled
+    template: load-balancer-readiness-configmap.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      haproxy.enabled: true
+      haproxy.healthcheck.forwarding_health.enabled: true
+      loadBalancer.pressureReadiness.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^extensions:\n\s+forwarding_health:\n\s+endpoint: \$\{env:MY_POD_IP\}:13136\n\s+path: /forwarding-health\n\s+metrics_endpoint: http://\$\{env:MY_POD_IP\}:\$\{env:PRESSURE_PROMETHEUS_PORT\}/metrics\n\s+backend_drain:\n'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'health_check_endpoint: http://\$\{env:MY_POD_IP\}:13136/forwarding-health'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?ms)^service:\n\s+extensions:\n\s+- health_check\n\s+- cgroup_runtime\n\s+- backend_drain\n\s+- forwarding_health\n'
+
   - it: preserves explicit forwarding_health endpoint for pressure readiness
     template: load-balancer-readiness-configmap.yaml
     values:

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -215,6 +215,7 @@ tests:
   - it: should use local backend readiness checks when local_backend_healthcheck is enabled
     template: haproxy-configmap.yaml
     set:
+      loadBalancer.pressureReadiness.enabled: true
       haproxy.sibling_fallback.enabled: true
       haproxy.local_backend_healthcheck.enabled: true
       haproxy.mapping:
@@ -240,6 +241,7 @@ tests:
   - it: should enable forwarding health readiness when local_backend_healthcheck is enabled
     template: haproxy-configmap.yaml
     set:
+      loadBalancer.pressureReadiness.enabled: true
       haproxy.sibling_fallback.enabled: true
       haproxy.local_backend_healthcheck.enabled: true
       haproxy.mapping:
@@ -262,6 +264,7 @@ tests:
   - it: should use custom local backend readiness check settings
     template: haproxy-configmap.yaml
     set:
+      loadBalancer.pressureReadiness.enabled: true
       haproxy.sibling_fallback.enabled: true
       haproxy.local_backend_healthcheck.enabled: true
       haproxy.local_backend_healthcheck.port: 13138
@@ -278,10 +281,26 @@ tests:
     asserts:
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "option httpchk GET /local-ready"
+          pattern: "backend logs_http_4318\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /local-ready"
       - matchRegex:
           path: data["haproxy.cfg"]
-          pattern: "server otel \"\\$MY_POD_IP\":4318.*check port 13138 inter 5000 rise 3 fall 4"
+          pattern: "backend logs_http_4318\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+server otel \"\\$MY_POD_IP\":4318.*check port 13138 inter 5000 rise 3 fall 4"
+
+  - it: should fail local backend checks without chart-rendered backend_drain
+    template: haproxy-configmap.yaml
+    set:
+      rollout.main.drain.enabled: false
+      haproxy.sibling_fallback.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "haproxy.local_backend_healthcheck.enabled requires chart-rendered backend_drain via loadBalancer.pressureReadiness.enabled=true or rollout.main.drain.enabled=true with configSource=overlay"
 
   - it: should use custom max_servers for server-template
     template: haproxy-configmap.yaml
@@ -509,6 +528,30 @@ tests:
       - matchRegex:
           path: data["haproxy.cfg"]
           pattern: "backend logs_http_4317_direct"
+
+  - it: should not use local backend readiness checks for gRPC mode
+    template: haproxy-configmap.yaml
+    set:
+      loadBalancer.pressureReadiness.enabled: true
+      haproxy.sibling_fallback.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.mapping:
+        grpc_4317:
+          from: 4317
+          to:
+            port: 4317
+            mode: grpc
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "option httpchk GET /ready"
+      - notMatchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "check port 13137"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server otel \"\\$MY_POD_IP\":4317 proto h2 check port 13133"
 
   # ============================================================
   # 8. No fallback endpoint - sibling/external fallback matrix

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -212,6 +212,55 @@ tests:
           path: data["haproxy.cfg"]
           pattern: "backend logs_http_4318_direct\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /healthcheck"
 
+  - it: should use local backend readiness checks when local_backend_healthcheck is enabled
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /ready"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+server otel \"\\$MY_POD_IP\":4318.*check port 13137 inter 3000 rise 2 fall 2"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318_direct\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+option httpchk GET /ready"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend logs_http_4318_direct\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+server otel \"\\$MY_POD_IP\":4318.*check port 13137 inter 3000 rise 2 fall 2"
+
+  - it: should use custom local backend readiness check settings
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.local_backend_healthcheck.port: 13138
+      haproxy.local_backend_healthcheck.path: /local-ready
+      haproxy.local_backend_healthcheck.interval: 5000
+      haproxy.local_backend_healthcheck.rise: 3
+      haproxy.local_backend_healthcheck.fall: 4
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "option httpchk GET /local-ready"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "server otel \"\\$MY_POD_IP\":4318.*check port 13138 inter 5000 rise 3 fall 4"
+
   - it: should use custom max_servers for server-template
     template: haproxy-configmap.yaml
     set:

--- a/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
+++ b/helm-charts/sawmills-collector/tests/sibling_fallback_test.yaml
@@ -237,6 +237,28 @@ tests:
           path: data["haproxy.cfg"]
           pattern: "backend logs_http_4318_direct\\r?\\n(?:[ \\t]+.*\\r?\\n)*[ \\t]+server otel \"\\$MY_POD_IP\":4318.*check port 13137 inter 3000 rise 2 fall 2"
 
+  - it: should enable forwarding health readiness when local_backend_healthcheck is enabled
+    template: haproxy-configmap.yaml
+    set:
+      haproxy.sibling_fallback.enabled: true
+      haproxy.local_backend_healthcheck.enabled: true
+      haproxy.mapping:
+        http_4318:
+          from: 4318
+          to:
+            port: 4318
+            fallback_endpoint: vendor.example.com
+    asserts:
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "acl forwarding_health_up srv_is_up\\(forwarding_health_backend/forwarding_health\\)"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "http-request deny deny_status 503 if readiness_check !forwarding_health_up"
+      - matchRegex:
+          path: data["haproxy.cfg"]
+          pattern: "backend forwarding_health_backend\\r?\\n  mode http\\r?\\n  option httpchk GET /forwarding-health\\r?\\n  server forwarding_health \"\\$MY_POD_IP\":13136 check"
+
   - it: should use custom local backend readiness check settings
     template: haproxy-configmap.yaml
     set:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -836,6 +836,18 @@ haproxy:
       rise: 2
       fall: 2
 
+  # Optional local backend health check for HAProxy's in-pod otel server.
+  # When enabled, HAProxy marks the local collector backend DOWN by probing the
+  # collector's backend_drain readiness endpoint instead of plain health_check.
+  # This lets HAProxy fallback activate while the Kubernetes LB pod stays Ready.
+  local_backend_healthcheck:
+    enabled: false
+    port: 13137
+    path: /ready
+    interval: 3000
+    rise: 2
+    fall: 2
+
   # Sibling fallback configuration
   # When enabled, HAProxy routes to sibling LB pods (round-robin) before falling back
   # to the external vendor endpoint. This reduces unnecessary external egress during
@@ -1319,6 +1331,10 @@ loadBalancer:
   # stays on the collector health_check endpoint.
   pressureReadiness:
     enabled: false
+    # When true, Kubernetes readiness probes the backend_drain endpoint. Set
+    # false to keep the LB pod Ready via collector health_check while HAProxy
+    # uses backend_drain readiness for fallback decisions.
+    useForPodReadiness: true
     port: 13137
     readinessPath: /ready
     drainPath: /drain


### PR DESCRIPTION
sawmills-collector: Keep LB ready during HAProxy fallback

Allow HAProxy to mark its local collector backend down and use sibling/external fallback while Kubernetes keeps the LB pod Ready.

Description
- Add optional `haproxy.local_backend_healthcheck` for HAProxy local backend checks against backend_drain readiness.
- Add `loadBalancer.pressureReadiness.useForPodReadiness` so Kubernetes readiness can stay on collector health while backend_drain drives fallback decisions.
- Add Helm unit coverage for HAProxy probes, pressure readiness, and sibling fallback rendering.

Verification
- `helm lint helm-charts/sawmills-collector`
- `cd helm-charts/sawmills-collector && ./tests/run-tests.sh` -> 282/282 passed
- `trunk check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the LB pod Ready while HAProxy fails over to sibling or external backends. Adds a local backend readiness probe and routes readiness through `forwarding_health` so fallback doesn’t flip Kubernetes readiness.

- **New Features**
  - `haproxy.local_backend_healthcheck` (HTTP): probe `backend_drain` readiness (path/port/interval/rise/fall) to let HAProxy mark the in-pod collector DOWN and trigger fallback without changing pod readiness.
  - `loadBalancer.pressureReadiness.useForPodReadiness` (default true): set false to keep Kubernetes readiness on collector `health_check` while `backend_drain` drives HAProxy fallback.
  - Auto-enable `forwarding_health`, route `backend_drain` checks through it, and default pressure `healthCheckEndpoint` to it when local backend checks or `forwarding_health` are enabled; honors custom `metricsEndpoint`/`metrics_endpoint`.
  - Keep HAProxy container readiness shallow (`/healthcheck`) when local backend checks are enabled or pressure readiness isn’t used for pod readiness.
  - Expanded Helm tests for HAProxy probes, `forwarding_health` wiring, pressure readiness behavior, and sibling/external fallback rendering.

- **Bug Fixes**
  - Validate local backend checks: require a chart-rendered `backend_drain` via `loadBalancer.pressureReadiness.enabled=true` or `rollout.main.drain.enabled=true` with `configSource=overlay`; otherwise fail render.

<sup>Written for commit 6da0427320ffbea2ce5f9a7278f325f85db12376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable HAProxy local backend health checks with customizable endpoint, port, interval, rise, and fall parameters for more granular drain readiness monitoring.
  * Added load balancer pressure readiness control to independently manage whether Kubernetes pod readiness probes target backend drain or collector health endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->