### PR TITLE
feat(sawmills-collector): disable pod anti-affinity by default

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -13,7 +13,7 @@ The Sawmills Collector is a production-ready OpenTelemetry Collector distributio
 * **Multiple Deployment Modes**: Supports both Deployment and DaemonSet modes
 * **Autoscaling**: Built-in support for Kubernetes HPA and KEDA-based autoscaling
 * **Load Balancing**: Optional HAProxy integration for advanced load balancing
-* **High Availability**: Configurable pod anti-affinity and topology spread constraints
+* **High Availability**: Optional pod anti-affinity (disabled by default) and topology spread constraints
 * **Telemetry Collection**: Dedicated telemetry collector for internal metrics
 * **Proxy Support**: HTTP/HTTPS proxy configuration for outbound traffic
 * **Flexible Configuration**: S3-based or direct YAML configuration
@@ -109,7 +109,7 @@ Set `resourceBaseName` when the Helm release name is owned by a parent chart but
 
 Changing `resourceBaseName` on an existing release changes rendered resource names. Use it for fresh installs, or plan a rename migration when adopting it on an already-installed release.
 
-When overriding `affinity` or `loadBalancer.affinity` with `resourceBaseName` set, use the selector label values rendered by the chart: `<resourceBaseName>` for the collector and `<resourceBaseName>-lb` for the load balancer. The default affinity blocks are rewritten automatically; arbitrary custom selector values are not.
+When setting `affinity` or `loadBalancer.affinity` with `resourceBaseName` set, use the selector label values rendered by the chart: `<resourceBaseName>` for the collector and `<resourceBaseName>-lb` for the load balancer. The chart's built-in selector values (`sawmills-collector-chart` / `sawmills-collector-chart-lb`) are rewritten automatically; arbitrary custom selector values are not.
 
 ### Pin Images By Digest
 
@@ -440,7 +440,7 @@ tolerations:
     value: "value1"
     effect: "NoSchedule"
 
-# Pod anti-affinity (default spreads pods across nodes)
+# Pod anti-affinity (opt-in; disabled by default) to spread pods across nodes
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm-charts/sawmills-collector/tests/deployment_affinity_test.yaml
+++ b/helm-charts/sawmills-collector/tests/deployment_affinity_test.yaml
@@ -2,9 +2,27 @@ suite: test deployment affinity configuration
 templates:
   - deployment.yaml
 tests:
-  - it: should render default pod anti-affinity configuration
+  - it: should not render affinity by default
     values:
       - ../values.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should render opt-in pod anti-affinity configuration
+    set:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - sawmills-collector-chart
+                topologyKey: kubernetes.io/hostname
     asserts:
       - exists:
           path: spec.template.spec.affinity
@@ -33,7 +51,7 @@ tests:
       - notExists:
           path: spec.template.spec.affinity
 
-  - it: should allow adding node affinity alongside default pod anti-affinity
+  - it: should allow adding node affinity
     set:
       affinity:
         nodeAffinity:
@@ -47,16 +65,13 @@ tests:
     asserts:
       - exists:
           path: spec.template.spec.affinity.nodeAffinity
-      - exists:
+      - notExists:
           path: spec.template.spec.affinity.podAntiAffinity
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
           value: custom-node
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
-          value: 100
 
-  - it: should allow adding preferred node affinity alongside default pod anti-affinity
+  - it: should allow adding preferred node affinity
     set:
       affinity:
         nodeAffinity:
@@ -70,40 +85,34 @@ tests:
                 - high-memory
     asserts:
       - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
-      - exists:
           path: spec.template.spec.affinity.nodeAffinity
+      - notExists:
+          path: spec.template.spec.affinity.podAntiAffinity
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
           value: 80
 
-  - it: should work with daemonSet mode and default affinity
+  - it: should not render affinity by default in daemonSet mode
     set:
       mode: daemonSet
     asserts:
       - equal:
           path: kind
           value: DaemonSet
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
-          value: 100
+      - notExists:
+          path: spec.template.spec.affinity
 
-  - it: should work with deployment mode and default affinity
+  - it: should not render affinity by default in deployment mode
     set:
       mode: deployment
     asserts:
       - equal:
           path: kind
           value: Deployment
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
-          value: kubernetes.io/hostname
+      - notExists:
+          path: spec.template.spec.affinity
 
-  - it: should allow customizing the weight in default configuration
+  - it: should allow customizing the weight in opt-in configuration
     set:
       affinity:
         podAntiAffinity:
@@ -173,4 +182,4 @@ tests:
           value: 100
       - equal:
           path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].weight
-          value: 50 
+          value: 50

--- a/helm-charts/sawmills-collector/tests/deployment_integration_test.yaml
+++ b/helm-charts/sawmills-collector/tests/deployment_integration_test.yaml
@@ -1,8 +1,8 @@
-suite: test deployment integration with affinity
+suite: test deployment integration with pod placement settings
 templates:
   - deployment.yaml
 tests:
-  - it: should work with default affinity and other pod placement settings
+  - it: should not render affinity by default alongside other pod placement settings
     values:
       - ../values.yaml
     set:
@@ -16,8 +16,8 @@ tests:
       topologySpreadConstraints[1]: "topology.kubernetes.io/zone"
       priorityClassName: high-priority
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - exists:
           path: spec.template.spec.nodeSelector
       - exists:
@@ -33,7 +33,7 @@ tests:
           path: spec.template.spec.priorityClassName
           value: high-priority
 
-  - it: should handle affinity with autoscaling enabled
+  - it: should not render affinity by default with autoscaling enabled
     values:
       - ../values.yaml
     set:
@@ -42,15 +42,12 @@ tests:
         minReplicas: 3
         maxReplicas: 10
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - notExists:
           path: spec.replicas
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
-          value: 100
 
-  - it: should work with KEDA autoscaling and default affinity
+  - it: should not render affinity by default with KEDA autoscaling
     values:
       - ../values.yaml
     set:
@@ -59,13 +56,10 @@ tests:
         minReplicas: 2
         maxReplicas: 20
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
-          value: sawmills-collector-chart
+      - notExists:
+          path: spec.template.spec.affinity
 
-  - it: should work with haproxy enabled and default affinity
+  - it: should not render affinity by default with haproxy enabled
     values:
       - ../values.yaml
     set:
@@ -74,8 +68,8 @@ tests:
       haproxy.mapping.http_4318.to.port: 4318
       haproxy.mapping.http_4318.to.protocol: "TCP"
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - lengthEqual:
           path: spec.template.spec.containers
           count: 3
@@ -83,7 +77,7 @@ tests:
           path: spec.template.spec.containers[0].name
           value: haproxy
 
-  - it: should work with additional containers and default affinity
+  - it: should not render affinity by default with additional containers
     values:
       - ../values.yaml
     set:
@@ -92,8 +86,8 @@ tests:
       additionalContainers.sidecar.command[1]: "-c"
       additionalContainers.sidecar.command[2]: "echo Hello && sleep 3600"
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - lengthEqual:
           path: spec.template.spec.containers
           count: 3
@@ -101,7 +95,7 @@ tests:
           path: spec.template.spec.containers[0].name
           value: sidecar
 
-  - it: should work with custom resource limits and default affinity
+  - it: should not render affinity by default with custom resource limits
     values:
       - ../values.yaml
     set:
@@ -113,8 +107,8 @@ tests:
           memory: 4Gi
           cpu: 2000m
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - equal:
           path: spec.template.spec.containers[1].resources.requests.memory
           value: 1Gi
@@ -122,7 +116,7 @@ tests:
           path: spec.template.spec.containers[1].resources.limits.cpu
           value: 2000m
 
-  - it: should work when adding node affinity alongside default pod anti-affinity
+  - it: should work when adding node affinity
     values:
       - ../values.yaml
     set:
@@ -138,13 +132,13 @@ tests:
     asserts:
       - exists:
           path: spec.template.spec.affinity.nodeAffinity
-      - exists:
+      - notExists:
           path: spec.template.spec.affinity.podAntiAffinity
       - equal:
           path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: node-type
 
-  - it: should work with service account configuration and default affinity
+  - it: should not render affinity by default with service account configuration
     values:
       - ../values.yaml
     set:
@@ -152,13 +146,13 @@ tests:
       serviceAccount.name: "custom-service-account"
       serviceAccount.annotations."eks\.amazonaws\.com/role-arn": "arn:aws:iam::123456789012:role/custom-role"
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - equal:
           path: spec.template.spec.serviceAccountName
           value: custom-service-account
 
-  - it: should work with custom rollout configuration and default affinity
+  - it: should not render affinity by default with custom rollout configuration
     values:
       - ../values.yaml
     set:
@@ -168,8 +162,8 @@ tests:
       rollout.terminationGracePeriodSeconds: 30
       rollout.minReadySeconds: 10
     asserts:
-      - exists:
-          path: spec.template.spec.affinity.podAntiAffinity
+      - notExists:
+          path: spec.template.spec.affinity
       - equal:
           path: spec.strategy.rollingUpdate.maxUnavailable
           value: 1
@@ -181,4 +175,4 @@ tests:
           value: 30
       - equal:
           path: spec.minReadySeconds
-          value: 10 
+          value: 10

--- a/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
+++ b/helm-charts/sawmills-collector/tests/resource_base_name_test.yaml
@@ -41,6 +41,18 @@ tests:
       namespace: customer-ns
     set:
       resourceBaseName: coinbase-logs
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - sawmills-collector-chart
+                topologyKey: kubernetes.io/hostname
     asserts:
       - equal:
           path: metadata.name
@@ -131,7 +143,20 @@ tests:
       namespace: customer-ns
     set:
       resourceBaseName: coinbase-logs
-      loadBalancer.enabled: true
+      loadBalancer:
+        enabled: true
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                          - sawmills-collector-chart-lb
+                  topologyKey: kubernetes.io/hostname
     asserts:
       - equal:
           path: metadata.name
@@ -265,6 +290,18 @@ tests:
     set:
       resourceBaseName: coinbase-logs
       kedaScaler.enabled: true
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - sawmills-collector-chart
+                topologyKey: kubernetes.io/hostname
     asserts:
       - equal:
           path: metadata.name

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -267,23 +267,27 @@ podAnnotations: {}
 #   prometheus.io/scrape: "true"
 podLabels: {}
 
-# Node affinity settings for the Sawmills collector pods
-# Default configuration spreads pods across nodes to ensure high availability
-# If resourceBaseName is set and you override this block, use the selector label
-# value rendered by sawmills-collector.selectorName. The default value below is
-# automatically rewritten to resourceBaseName; unrelated custom values are not.
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - sawmills-collector-chart
-          topologyKey: kubernetes.io/hostname
+# Node affinity / pod anti-affinity settings for the Sawmills collector pods.
+# Disabled by default so the scheduler can bin-pack collector pods rather than
+# spreading them (avoids fighting node consolidation, e.g. Karpenter).
+# To spread pods across nodes for higher availability, replace the empty default
+# below with a block such as:
+#   podAntiAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         podAffinityTerm:
+#           labelSelector:
+#             matchExpressions:
+#               - key: app.kubernetes.io/name
+#                 operator: In
+#                 values:
+#                   - sawmills-collector-chart
+#           topologyKey: kubernetes.io/hostname
+# If resourceBaseName is set, use the selector label value rendered by
+# sawmills-collector.selectorName. The chart's built-in default selector value
+# (sawmills-collector-chart) is automatically rewritten to resourceBaseName;
+# unrelated custom values are not.
+affinity: {}
 
 # Topology spread constraints for the Sawmills collector pods
 # Example:
@@ -1228,23 +1232,26 @@ loadBalancer:
   terminationGracePeriodSeconds: 60
   nodeSelector: {}
   tolerations: []
-  # Default configuration spreads LB pods across nodes to ensure high availability
-  # If resourceBaseName is set and you override this block, use the selector
-  # label value rendered by sawmills-collector.loadBalancerSelectorName.
-  # The default value below is automatically rewritten to <resourceBaseName>-lb;
-  # unrelated custom values are not.
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                    - sawmills-collector-chart-lb
-            topologyKey: kubernetes.io/hostname
+  # Pod anti-affinity for the LB pods. Disabled by default so the scheduler can
+  # bin-pack LB pods rather than spreading them.
+  # To spread LB pods across nodes for higher availability, replace the empty
+  # default below with a block such as:
+  #   podAntiAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - weight: 100
+  #         podAffinityTerm:
+  #           labelSelector:
+  #             matchExpressions:
+  #               - key: app.kubernetes.io/name
+  #                 operator: In
+  #                 values:
+  #                   - sawmills-collector-chart-lb
+  #           topologyKey: kubernetes.io/hostname
+  # If resourceBaseName is set, use the selector label value rendered by
+  # sawmills-collector.loadBalancerSelectorName. The chart's built-in default
+  # selector value (sawmills-collector-chart-lb) is automatically rewritten to
+  # <resourceBaseName>-lb; unrelated custom values are not.
+  affinity: {}
   priorityClassName: ""
   topologySpreadConstraints: []
   additionalContainers: {}


### PR DESCRIPTION
## Summary

Turn off pod anti-affinity **by default** in the `sawmills-collector` chart. Both `affinity` and `loadBalancer.affinity` now default to `{}`, so the scheduler can bin-pack collector and LB pods instead of spreading them across nodes — this stops the default config from fighting node consolidation (e.g. Karpenter), reducing node count/cost.

The previous soft (`preferredDuringSchedulingIgnoredDuringExecution`) anti-affinity is preserved as a commented opt-in example in `values.yaml`.

Linear: SAW-7720 (`fireblocks` / `Customers`)

## Changes Made

* [ ] Feature addition
* [ ] Bug fix
* [x] Documentation update
* [ ] Breaking change
* [x] Configuration change
* [ ] Performance improvement

Detail:
- `values.yaml`: `affinity: {}` and `loadBalancer.affinity: {}` defaults; prior blocks retained as commented opt-in examples (matches the remote-operator charts).
- No template changes needed — affinity rendering is already gated on `{{- if not (empty .Values.affinity) }}` (collector `deployment.yaml`, `keda-scaler-deployment.yaml`, and `load-balancer.yaml`).
- Tests updated to assert the new default (off) while keeping opt-in/customization coverage and the `resourceBaseName` selector-rewrite tests (now set affinity explicitly).
- README updated (feature blurb, override note, example comment).

## Version Impact

**`version:minor`** label applied.

- The values interface is unchanged (no keys removed/renamed); only a default value changed. Consistent with this repo's convention (`feat` → minor; prior availability-affecting changes like the LB PDB shipped as patch).
- ⚠️ See **Breaking Changes / upgrade impact** below — reviewers may choose to escalate to `version:major` if the default placement change is considered breaking for consumers.

> Chart version is left to CI (`deploy-helm-chart.yml` derives it from the latest tag + this label). `Chart.yaml` is intentionally not edited in this PR.

## Testing Performed

* [x] Helm template validation (`helm template`)
* [x] Helm lint check (`helm lint`)
* [ ] Dry run installation
* [ ] Deployed to test environment
* [x] Manual testing completed
* [x] Regression testing performed

### Test Details

**Commands used:**

```bash
cd helm-charts/sawmills-collector
helm lint .
helm unittest .                                   # full suite
helm template t . --values values.yaml | grep -c affinity                          # default
helm template t . --values values.yaml --set loadBalancer.enabled=true | grep -c affinity   # default + LB
helm template t . --values values.yaml \
  --set 'affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight=100' # opt-in
```

**Results:**

* Expected: no affinity rendered by default (collector + LB); opt-in still renders; all unit tests pass.
* Actual: ✅ `helm lint` clean; ✅ **222/222** unit tests pass (27 suites); ✅ default render has **0** affinity lines for collector and LB; ✅ opt-in renders `podAntiAffinity` correctly.

## Breaking Changes

* [x] No breaking changes (values API unchanged)
* [ ] Contains breaking changes

**⚠️ Behavior change on upgrade:**

* **What changes:** Existing installs that rely on chart defaults (don't set `affinity`) will **stop spreading** collector/LB replicas across nodes after upgrading — replicas may co-locate on a node, increasing node-failure blast radius.
* **Migration path:** To keep HA spreading, set `affinity` (and/or `loadBalancer.affinity`) to the pod anti-affinity block documented in `values.yaml`.
* **Version compatibility:** No change to value keys; purely a default-value change.

## Impact Assessment

* **Who is affected:** Consumers upgrading on chart defaults without an explicit `affinity` override (notably the Fireblocks deployment this was requested for).
* **What systems are affected:** Collector + LB pod scheduling/placement only.
* **Rollback plan:** Pin the previous chart version, or set `affinity`/`loadBalancer.affinity` to the example block to restore spreading.

## Documentation Updated

* [x] Chart README.md updated
* [x] Configuration examples added/updated (commented opt-in in `values.yaml`)
* [ ] CHANGELOG.md updated (no chart CHANGELOG in repo)
* [x] Inline comments added for complex logic
* [ ] Not applicable

## Additional Notes

The prior anti-affinity was **soft** (`preferred…`), so it never blocked scheduling — turning it off won't resolve any `Pending`-pod symptom, but it does let the scheduler bin-pack (the likely intent for cost/consolidation). Worth confirming against the original Fireblocks symptom.

***

@sawmills/engineers Please review this contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable pod anti-affinity by default in the `sawmills-collector` Helm chart for collector and load balancer pods to enable bin-packing and reduce node count (SAW-7720). README and tests updated; `values.yaml` now documents opt-in anti-affinity and clarifies `resourceBaseName` selector rewriting for both components.

- **Migration**
  - Upgrades on defaults will stop spreading replicas across nodes.
  - To keep HA spreading, set `affinity` and/or `loadBalancer.affinity` to the opt-in pod anti-affinity block from `values.yaml`.

<sup>Written for commit 6adbbfde9937d6801b199144ae7221f3d5763728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated high availability and affinity documentation to clarify that pod anti-affinity is now opt-in and disabled by default.
  * Added guidance on re-enabling pod anti-affinity for distributing pods across nodes.

* **Configuration**
  * Pod anti-affinity is now disabled by default for both the collector and load balancer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->