### PR TITLE
sawmills-collector: Preserve KEDA replica ownership

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -279,6 +279,10 @@ keda:
         targetValue: "300"
 ```
 
+When `keda.enabled: true`, the chart leaves `Deployment.spec.replicas` unset so
+the KEDA-owned HPA retains replica ownership during Helm upgrades. This avoids
+temporarily resetting an active deployment to the static `replicaCount`.
+
 For central queue autoscaling, use KEDA's `metrics-api` scaler so KEDA can create the HPA from static trigger metadata and read queue values over the scaler pod's monitoring HTTP endpoint:
 
 ```yaml

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -37,7 +37,7 @@ metadata:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
   {{- if eq .Values.mode "deployment" }}
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not (or .Values.autoscaling.enabled .Values.keda.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:

--- a/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
@@ -16,6 +16,18 @@ tests:
       - notExists:
           path: spec.replicas
 
+  - it: omits static replicas when the standard HPA owns collector scaling
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: true
+      keda.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.replicas
+
   - it: keeps static replicas when collector autoscaling is disabled
     set:
       mode: deployment

--- a/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
@@ -1,0 +1,30 @@
+suite: KEDA Replica Ownership Tests
+templates:
+  - templates/deployment.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: omits static replicas when KEDA owns collector scaling
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: false
+      keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.replicas
+
+  - it: keeps static replicas when collector autoscaling is disabled
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: false
+      keda.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.replicas
+          value: 3


### PR DESCRIPTION
Prevents Helm upgrades from resetting KEDA-managed collector deployments to the static replica count. This closes the deployment failure mode observed during the SAW-7944 BigID rollout.

Description
- omit `Deployment.spec.replicas` when top-level KEDA autoscaling is enabled
- preserve static replicas when neither HPA nor KEDA owns scaling
- add regression coverage and document the upgrade behavior

Refs: SAW-7944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Helm upgrades from resetting HPA/KEDA-managed collector replicas by omitting `Deployment.spec.replicas` when `keda.enabled` or `autoscaling.enabled` is true. Keeps live scaling stable and avoids the SAW-7944 BigID rollout failure mode.

- **Bug Fixes**
  - Omit `spec.replicas` when `keda.enabled` or standard HPA `autoscaling.enabled` is true; HPA retains replica ownership during upgrades.
  - Keep `spec.replicas` when both autoscalers are disabled, respecting `replicaCount`.
  - Added helm-unittest coverage for KEDA and standard HPA ownership; updated README to document the behavior.

<sup>Written for commit 6bb4e11f2e3dc354256e87db3822191bd679ce86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KEDA autoscaling behavior by preserving replica ownership with KEDA during Helm upgrades.
  - Prevented temporary resets to the configured static replica count when KEDA autoscaling is enabled.
  - Preserved static replica-count behavior when KEDA is disabled and standard autoscaling is not active.

- **Documentation**
  - Updated the Helm chart documentation to clarify replica management when KEDA is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->