### PR TITLE
sawmills-collector: Preserve live KEDA replicas during upgrades

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -279,16 +279,17 @@ keda:
         targetValue: "300"
 ```
 
-When `keda.enabled: true`, live Helm upgrades preserve the current Deployment
-replica count so Helm does not reset an actively scaled collector while KEDA
-reconciles. Client-side renders, where the live Deployment is unavailable, leave
-`Deployment.spec.replicas` unset so GitOps workflows do not fight KEDA.
+When collector autoscaling is enabled, live Helm upgrades preserve the current
+Deployment replica count so Helm does not reset an actively scaled collector
+while KEDA or the standard HPA reconciles. Client-side renders, where the live
+Deployment is unavailable, leave `Deployment.spec.replicas` unset so GitOps
+workflows do not fight the autoscaler.
 
 Helm stores the preserved count in each release revision. A rollback can
-therefore briefly restore that revision's historical count, and changing from
-KEDA to the standard HPA can briefly default the Deployment to one replica while
-the new HPA reconciles. Treat either operation as a capacity-sensitive rollout:
-observe collector readiness and queue age until the autoscaler has converged.
+therefore briefly restore that revision's historical count; rollback to a
+pre-2.17.2 revision that omitted the field can briefly default the Deployment to
+one replica. Treat rollback as a capacity-sensitive rollout: observe collector
+readiness and queue age until the autoscaler has converged.
 
 For central queue autoscaling, use KEDA's `metrics-api` scaler so KEDA can create the HPA from static trigger metadata and read queue values over the scaler pod's monitoring HTTP endpoint:
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -279,9 +279,10 @@ keda:
         targetValue: "300"
 ```
 
-When `keda.enabled: true`, the chart leaves `Deployment.spec.replicas` unset so
-the KEDA-owned HPA retains replica ownership during Helm upgrades. This avoids
-temporarily resetting an active deployment to the static `replicaCount`.
+When `keda.enabled: true`, live Helm upgrades preserve the current Deployment
+replica count so Helm does not reset an actively scaled collector while KEDA
+reconciles. Client-side renders, where the live Deployment is unavailable, leave
+`Deployment.spec.replicas` unset so GitOps workflows do not fight KEDA.
 
 For central queue autoscaling, use KEDA's `metrics-api` scaler so KEDA can create the HPA from static trigger metadata and read queue values over the scaler pod's monitoring HTTP endpoint:
 

--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -284,6 +284,12 @@ replica count so Helm does not reset an actively scaled collector while KEDA
 reconciles. Client-side renders, where the live Deployment is unavailable, leave
 `Deployment.spec.replicas` unset so GitOps workflows do not fight KEDA.
 
+Helm stores the preserved count in each release revision. A rollback can
+therefore briefly restore that revision's historical count, and changing from
+KEDA to the standard HPA can briefly default the Deployment to one replica while
+the new HPA reconciles. Treat either operation as a capacity-sensitive rollout:
+observe collector readiness and queue age until the autoscaler has converged.
+
 For central queue autoscaling, use KEDA's `metrics-api` scaler so KEDA can create the HPA from static trigger metadata and read queue values over the scaler pod's monitoring HTTP endpoint:
 
 ```yaml

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -37,7 +37,12 @@ metadata:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
   {{- if eq .Values.mode "deployment" }}
-  {{- if not (or .Values.autoscaling.enabled .Values.keda.enabled) }}
+  {{- if .Values.keda.enabled }}
+  {{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace (include "sawmills-collector.fullname" .) }}
+  {{- if and $existingDeployment $existingDeployment.spec (hasKey $existingDeployment.spec "replicas") }}
+  replicas: {{ $existingDeployment.spec.replicas }}
+  {{- end }}
+  {{- else if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -37,12 +37,12 @@ metadata:
     {{- include "sawmills-collector.labels" . | nindent 4 }}
 spec:
   {{- if eq .Values.mode "deployment" }}
-  {{- if .Values.keda.enabled }}
+  {{- if or .Values.autoscaling.enabled .Values.keda.enabled }}
   {{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace (include "sawmills-collector.fullname" .) }}
   {{- if and $existingDeployment $existingDeployment.spec (hasKey $existingDeployment.spec "replicas") }}
   replicas: {{ $existingDeployment.spec.replicas }}
   {{- end }}
-  {{- else if not .Values.autoscaling.enabled }}
+  {{- else }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:

--- a/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
@@ -74,6 +74,31 @@ tests:
           path: spec.replicas
           value: 0
 
+  - it: leaves replicas unset when the live Deployment has no replica field
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector
+            namespace: sawmills-o11y
+          spec: {}
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: false
+      keda.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
   - it: omits static replicas when the standard HPA owns collector scaling
     set:
       mode: deployment
@@ -85,6 +110,33 @@ tests:
           count: 1
       - notExists:
           path: spec.replicas
+
+  - it: preserves live replicas during a KEDA to standard HPA handoff
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector
+            namespace: sawmills-o11y
+          spec:
+            replicas: 7.0
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: true
+      keda.enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 7
 
   - it: keeps static replicas when collector autoscaling is disabled
     set:

--- a/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
@@ -3,6 +3,10 @@ templates:
   - templates/deployment.yaml
 values:
   - ../values.yaml
+release:
+  name: sawmills-collector
+  namespace: sawmills-o11y
+  upgrade: true
 tests:
   - it: leaves replicas unset for offline KEDA renders
     set:
@@ -15,6 +19,60 @@ tests:
           count: 1
       - notExists:
           path: spec.replicas
+
+  - it: preserves the live KEDA-managed replica count during upgrades
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector
+            namespace: sawmills-o11y
+          spec:
+            replicas: 7.0
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: false
+      keda.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 7
+
+  - it: preserves a live zero replica count during KEDA upgrades
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector
+            namespace: sawmills-o11y
+          spec:
+            replicas: 0.0
+    set:
+      mode: deployment
+      replicaCount: 3
+      autoscaling.enabled: false
+      keda.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
 
   - it: omits static replicas when the standard HPA owns collector scaling
     set:

--- a/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
+++ b/helm-charts/sawmills-collector/tests/keda_replica_ownership_test.yaml
@@ -4,7 +4,7 @@ templates:
 values:
   - ../values.yaml
 tests:
-  - it: omits static replicas when KEDA owns collector scaling
+  - it: leaves replicas unset for offline KEDA renders
     set:
       mode: deployment
       replicaCount: 3


### PR DESCRIPTION
## Summary
- preserve the live Deployment replica count during KEDA-enabled Helm upgrades
- keep replicas unset in client-side renders so GitOps does not fight KEDA
- document and test the ownership behavior

## Production evidence
A Sawmills-owned KEDA canary upgrading to chart 2.17.1 briefly reset `spec.replicas` from 10 to 1 before KEDA reconciled. A server-side dry run of this patch against the recovered canary renders `spec.replicas: 10`. BigID remains on 2.16.1 and was not exposed to 2.17.1.

## Verification
- `./tests/run-tests.sh` — 28 suites, 297 tests pass
- `helm lint .`
- focused KEDA replica ownership tests
- server-side Helm dry-run against the live KEDA canary
- local and branch autoreview clean

Refs SAW-7944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve live autoscaled replica counts during Helm upgrades (KEDA or standard HPA) and leave `Deployment.spec.replicas` unset on client-side renders so GitOps doesn’t fight the autoscaler. This avoids scale resets on upgrade and during KEDA↔HPA handoffs, improving SAW-7944 stability for BigID.

- **Bug Fixes**
  - On server-side upgrades with `keda.enabled` or `autoscaling.enabled`, the chart uses `lookup` to copy the live `Deployment.spec.replicas` (including zero); if the live Deployment is missing or lacks the field, `replicas` is omitted.
  - README documents rollback behavior (revisions can restore historical counts; pre-2.17.2 rollbacks can briefly default to one), and tests cover offline renders, zero and missing-field cases, and KEDA→HPA handoff capacity preservation.

<sup>Written for commit 8e8c126b212543eeaf3306ba594a6f9b666960e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

