### PR TITLE
sawmills-collector: Preserve autoscaled load balancer replicas

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -821,6 +821,13 @@ loadBalancer:
 
 `loadBalancer.autoscaling` renders a Kubernetes `HorizontalPodAutoscaler` with CPU and memory resource metrics, so the cluster must provide `metrics.k8s.io` data. Prefer `loadBalancer.keda.scaling.external` with the bundled Sawmills KEDA scaler when resource metrics are not enough. `loadBalancer.keda.scaling.prometheus` remains available as an alternative configuration path:
 
+When load balancer autoscaling is enabled, live Helm upgrades preserve the
+current Deployment or StatefulSet replica count while the HPA or KEDA
+reconciles. Client-side renders leave `spec.replicas` unset. A rollback to a
+pre-2.17.3 chart can briefly default an autoscaled load balancer Deployment or
+StatefulSet to one replica, so observe load balancer readiness and queue age
+until the autoscaler has converged.
+
 When `loadBalancer.keda.enabled: true`, set `loadBalancer.podDisruptionBudget.minAvailable` explicitly. The default is computed from static `loadBalancer.replicas`, which can be higher than the actual pod count after KEDA scales down and can block voluntary disruptions such as node drains or upgrades.
 
 ```yaml

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -19,22 +19,27 @@
 {{- $haproxyReadinessPort := dig "probes" "readiness" "port" 13135 .Values.haproxy }}
 {{- $lbAutoscalingEnabled := and .Values.loadBalancer.autoscaling (eq .Values.loadBalancer.autoscaling.enabled true) }}
 {{- $lbKedaEnabled := and .Values.loadBalancer.keda (eq .Values.loadBalancer.keda.enabled true) }}
+{{- $lbWorkloadKind := "Deployment" }}
+{{- if .Values.loadBalancer.storage.enabled }}
+{{- $lbWorkloadKind = "StatefulSet" }}
+{{- end }}
 {{- if eq $haproxyReadinessType "tcp" }}
 {{- $haproxyReadinessPort = (.Values.haproxy.healthcheck.port | default 13135) }}
 {{- end }}
 apiVersion: apps/v1
-{{- if .Values.loadBalancer.storage.enabled }}
-kind: StatefulSet
-{{- else }}
-kind: Deployment
-{{- end }}
+kind: {{ $lbWorkloadKind }}
 metadata:
   name: {{ include "sawmills-collector.fullname" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sawmills-collector.loadBalancerLabels" . | nindent 4 }}
 spec:
-  {{- if not (or $lbAutoscalingEnabled $lbKedaEnabled) }}
+  {{- if or $lbAutoscalingEnabled $lbKedaEnabled }}
+  {{- $existingLoadBalancer := lookup "apps/v1" $lbWorkloadKind .Release.Namespace (printf "%s-lb" (include "sawmills-collector.fullname" .)) }}
+  {{- if and $existingLoadBalancer $existingLoadBalancer.spec (hasKey $existingLoadBalancer.spec "replicas") }}
+  replicas: {{ $existingLoadBalancer.spec.replicas }}
+  {{- end }}
+  {{- else }}
   replicas: {{ .Values.loadBalancer.replicas }}
   {{- end }}
   {{- $lbStrategy := default (dict) .Values.loadBalancer.strategy }}

--- a/helm-charts/sawmills-collector/tests/load_balancer_replicas_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_replicas_test.yaml
@@ -3,6 +3,10 @@ templates:
   - templates/load-balancer.yaml
 values:
   - ../values.yaml
+release:
+  name: sawmills-collector
+  namespace: sawmills-o11y
+  upgrade: true
 tests:
   - it: renders replicas when load balancer scaling is not controller-managed
     set:
@@ -31,6 +35,36 @@ tests:
       - notExists:
           path: spec.replicas
 
+  - it: preserves the live load balancer replica count during HPA upgrades
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector-lb
+            namespace: sawmills-o11y
+          spec:
+            replicas: 7.0
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: true
+        keda:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 7
+
   - it: omits replicas when load balancer KEDA owns scaling
     set:
       loadBalancer:
@@ -44,7 +78,65 @@ tests:
       - notExists:
           path: spec.replicas
 
-  - it: omits replicas from StatefulSet when autoscaling owns scaling
+  - it: preserves a live zero replica count during KEDA upgrades
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector-lb
+            namespace: sawmills-o11y
+          spec:
+            replicas: 0.0
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: false
+        keda:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: leaves replicas unset when the live load balancer has no replica field
+    kubernetesProvider:
+      scheme:
+        "apps/v1/Deployment":
+          gvr:
+            group: apps
+            version: v1
+            resource: deployments
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: sawmills-collector-lb
+            namespace: sawmills-o11y
+          spec: {}
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        autoscaling:
+          enabled: true
+        keda:
+          enabled: false
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: omits replicas from an offline StatefulSet when autoscaling owns scaling
     set:
       loadBalancer:
         enabled: true
@@ -58,3 +150,35 @@ tests:
           of: StatefulSet
       - notExists:
           path: spec.replicas
+
+  - it: preserves live StatefulSet replicas when autoscaling owns scaling
+    kubernetesProvider:
+      scheme:
+        "apps/v1/StatefulSet":
+          gvr:
+            group: apps
+            version: v1
+            resource: statefulsets
+          namespaced: true
+      objects:
+        - apiVersion: apps/v1
+          kind: StatefulSet
+          metadata:
+            name: sawmills-collector-lb
+            namespace: sawmills-o11y
+          spec:
+            replicas: 6.0
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 4
+        storage:
+          enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 6


### PR DESCRIPTION
## Summary
- preserve the live load-balancer Deployment or StatefulSet replica count during HPA/KEDA Helm upgrades
- keep offline autoscaled renders owner-neutral by omitting `spec.replicas`
- add live lookup, zero, missing-field, and StatefulSet regression coverage

## Production evidence
BigID chart 2.17.2 reset the autoscaled load-balancer Deployment from 10 replicas to 1 while its HPA reconciled. Live capacity was restored to 10 and refused records remained zero. This patch applies the same server-side lookup contract already shipped for the main collector workload.

## Impact
- Version: patch (`collector-v2.17.3`)
- Breaking changes: none
- Runtime: live Helm upgrades preserve the autoscaler-owned load-balancer count instead of defaulting to one replica
- Offline/GitOps: unchanged; autoscaled renders omit `spec.replicas`
- Documentation: upgrade and rollback behavior documented

## Verification
- `./tests/run-tests.sh` (28 suites, 305 tests)
- `helm unittest helm-charts/sawmills-collector -f tests/load_balancer_replicas_test.yaml` (8 tests)
- `helm lint helm-charts/sawmills-collector`
- `trunk check` on changed files
- local and branch autoreview: clean

Refs: SAW-7944