### PR TITLE
fix(sawmills-collector): extend startup probe budget

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -652,7 +652,7 @@ rollout:
       startup:
         enabled: true
         periodSeconds: 5
-        failureThreshold: 12
+        failureThreshold: 24  # 120s budget for the 60s fail-closed startup config scan
     drain:
       enabled: true
       configSource: overlay

--- a/helm-charts/sawmills-collector/templates/deployment.yaml
+++ b/helm-charts/sawmills-collector/templates/deployment.yaml
@@ -353,7 +353,7 @@ spec:
               port: 13133
             initialDelaySeconds: {{ default 0 $mainStartupProbe.initialDelaySeconds }}
             periodSeconds: {{ default 5 $mainStartupProbe.periodSeconds }}
-            failureThreshold: {{ default 12 $mainStartupProbe.failureThreshold }}
+            failureThreshold: {{ default 24 $mainStartupProbe.failureThreshold }}
           {{- end }}
           {{- if $mainCollectorDrainEnabled }}
           lifecycle:

--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -221,7 +221,7 @@ spec:
               port: 13133
             initialDelaySeconds: {{ default 0 $lbStartupProbe.initialDelaySeconds }}
             periodSeconds: {{ default 5 $lbStartupProbe.periodSeconds }}
-            failureThreshold: {{ default 12 $lbStartupProbe.failureThreshold }}
+            failureThreshold: {{ default 24 $lbStartupProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.rollout.loadBalancer.preStopSleepSeconds }}
           lifecycle:

--- a/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
+++ b/helm-charts/sawmills-collector/tests/backend_drain_test.yaml
@@ -39,6 +39,12 @@ tests:
           path: spec.template.spec.containers[1].startupProbe.httpGet.path
           value: /healthcheck
       - equal:
+          path: spec.template.spec.containers[1].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.failureThreshold
+          value: 24
+      - equal:
           path: spec.template.spec.containers[1].lifecycle.preStop.exec.command[0]
           value: /bin/sh
       - equal:

--- a/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_pressure_readiness_test.yaml
@@ -29,6 +29,12 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /healthcheck
       - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 24
+      - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: 13137
       - equal:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -94,7 +94,8 @@ rollout:
         enabled: true
         initialDelaySeconds: 0
         periodSeconds: 5
-        failureThreshold: 12
+        # 120s budget: twice the hotreload processor's 60s fail-closed startup scan.
+        failureThreshold: 24
     # Sleep-based fallback used when backend drain mode is disabled or the
     # deployment is not using the loadBalancer topology.
     preStopSleepSeconds: 15
@@ -171,7 +172,8 @@ rollout:
         enabled: true
         initialDelaySeconds: 0
         periodSeconds: 5
-        failureThreshold: 12
+        # 120s budget: twice the hotreload processor's 60s fail-closed startup scan.
+        failureThreshold: 24
     preStopSleepSeconds: 20
 
 # Pod disruption budget to keep collectors available during rollouts


### PR DESCRIPTION
## Summary
- increase worker and load-balancer startup probe budgets from 60s to 120s
- keep the probe budget at 2x the hotreload fail-closed startup scan budget
- pin both defaults with Helm unit tests

## Incident evidence
BigID had 6 of 228 new workers restart during the recovery scale-up because the S3-backed hotreload startup scan hit its deadline. The collector fix raises that scan budget to 60s and adds bounded SDK retries; this chart change prevents Kubernetes from killing the process while those retries are still valid.

## Verification
- helm lint helm-charts/sawmills-collector
- helm template sawmills-collector helm-charts/sawmills-collector
- cd helm-charts/sawmills-collector && ./tests/run-tests.sh (305 tests)
- trunk check
- autoreview clean
- Claude Fable architecture review: APPROVE, no blockers

Linear: SAW-7944

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the startup probe budget for worker and load-balancer collectors to 120s to prevent restarts while the fail-closed startup config scan runs. Addresses SAW-7944 by keeping pods alive during BigID-scale recovery and startup retries.

- **Bug Fixes**
  - Bump startupProbe failureThreshold from 12 to 24 (5s period = 120s) for both worker and LB; keeps 2x headroom over the 60s hotreload scan.
  - Update `values.yaml`, deployment and LB templates; README reflects the new default.
  - Add Helm unit tests to pin the 5s period and 24 failureThreshold for both pods.

<sup>Written for commit 96a2a32ba59d18f65784ffb64dbbd5ac48ee6df1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

