### PR TITLE
sawmills-collector: Serialize pod disruptions

### DIFF
--- a/helm-charts/sawmills-collector/README.md
+++ b/helm-charts/sawmills-collector/README.md
@@ -745,11 +745,14 @@ Keep `rollout.main.drain.duration + rollout.main.drain.shutdownReserve` below `r
 ```yaml
 podDisruptionBudget:
   enabled: true
-  minAvailable: null  # defaults to replicaCount-1 when ≤ 5, otherwise ceil(0.8 * replicaCount)
-  autoscaledMaxUnavailable: "10%"  # default budget when keda or autoscaling is enabled
+  minAvailable: null
+  maxUnavailable: null  # defaults to 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
 ```
 
-When the collector (or the LB) is autoscaled — `keda.enabled`, `autoscaling.enabled`, `loadBalancer.keda.enabled`, or `loadBalancer.autoscaling.enabled` — the static replica-derived default is meaningless: the real pod count is set by the autoscaler, not `replicaCount`. In that case the chart defaults to percentage-based `maxUnavailable` (`autoscaledMaxUnavailable`, `10%`), which Kubernetes evaluates against the current scale, so a node drain can never take a large fleet at once. Explicit `minAvailable`/`maxUnavailable` values always win over the default. Percentages round up, so a fleet scaled down to a single pod still permits eviction of that pod — the same tradeoff as the chart's static single-replica default, chosen so a PDB never blocks node upgrades outright; set `minAvailable` explicitly when a scale-to-1 fleet must block voluntary disruption instead.
+Worker and load balancer PDBs default to `maxUnavailable: 1`, for both static and autoscaled fleets. This serializes healthy-pod eviction during voluntary disruptions and prevents a node drain from removing a percentage of a large ingest tier at once. On Kubernetes 1.27+, `unhealthyPodEvictionPolicy: AlwaysAllow` lets an already-unhealthy pod be evicted without consuming the healthy-pod budget, preventing drains from deadlocking behind a failed pod.
+
+Explicit `minAvailable` or `maxUnavailable` values override the default. For autoscaled workloads only, the deprecated `autoscaledMaxUnavailable` key remains a lower-precedence compatibility alias for existing releases; use `maxUnavailable` for new configuration. Static workloads ignore the legacy alias. Raising the value makes planned node maintenance faster at the direct cost of more simultaneous ingest capacity loss. PDBs govern Eviction API requests such as node drains and Karpenter consolidation; they do not limit Deployment or StatefulSet rolling updates, which are controlled by each workload's rollout strategy. Involuntary node loss, including an expired Spot interruption window, can bypass a PDB.
 
 When `kedaScaler.enabled: true`, the chart protects the single-replica KEDA otel scaler with a `karpenter.sh/do-not-disrupt: "true"` pod annotation by default, because losing the scaler leaves the HPA without its external metric. The scaler intentionally remains single-replica: it holds an in-memory metric store, so multiple replicas behind the Service would split OTLP streams and undercount the fleet. Its PDB defaults to `maxUnavailable: 1` and, on Kubernetes 1.27+, `unhealthyPodEvictionPolicy: AlwaysAllow`, allowing deliberate node drains and upgrades even when the scaler is unhealthy instead of making its node permanently undrainable. The chart automatically omits the newer field on older supported clusters. At one replica, this PDB does not block eviction of a healthy scaler; the Karpenter annotation provides the default voluntary-disruption protection. Generic `podAnnotations` cannot override that shield; set `kedaScaler.doNotDisrupt: false` to opt out explicitly. Explicit `minAvailable` or `maxUnavailable` values override the PDB default, and an empty `unhealthyPodEvictionPolicy` omits that field.
 
@@ -869,7 +872,7 @@ pre-2.17.3 chart can briefly default an autoscaled load balancer Deployment or
 StatefulSet to one replica, so observe load balancer readiness and queue age
 until the autoscaler has converged.
 
-When `loadBalancer.keda.enabled: true` (or `loadBalancer.autoscaling.enabled: true`), the LB PDB defaults to `maxUnavailable: 10%` (`loadBalancer.podDisruptionBudget.autoscaledMaxUnavailable`) instead of the static replica-derived `minAvailable`, since percentages track the actual scaled pod count. Set `minAvailable`/`maxUnavailable` explicitly to override.
+The LB PDB uses the same `maxUnavailable: 1` default as the worker tier. Set `loadBalancer.podDisruptionBudget.minAvailable` or `loadBalancer.podDisruptionBudget.maxUnavailable` explicitly only when the maintenance-throughput trade-off is understood.
 
 ```yaml
 loadBalancer:

--- a/helm-charts/sawmills-collector/templates/_helpers.tpl
+++ b/helm-charts/sawmills-collector/templates/_helpers.tpl
@@ -779,52 +779,6 @@ Default maxSurge based on replica count.
 {{- end }}
 
 {{/*
-Default PodDisruptionBudget minAvailable.
-*/}}
-{{- define "sawmills-collector.defaultPdbMinAvailable" -}}
-{{- $replicas := include "sawmills-collector.replicaCountValue" . | int -}}
-{{- if le $replicas 5 -}}
-  {{- $val := sub $replicas 1 -}}
-  {{- if lt $val 0 -}}
-0
-  {{- else -}}
-{{ $val }}
-  {{- end -}}
-{{- else -}}
-  {{- $val := div (add (mul $replicas 8) 9) 10 -}}
-  {{- if lt $val 2 -}}
-2
-  {{- else -}}
-{{ $val }}
-  {{- end -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Default LB PodDisruptionBudget minAvailable.
-For LB we always want at least 2 pods running to avoid single-point-of-failure.
-  1 replica:   0 (PDB would block all voluntary disruptions otherwise)
-  2-3 replicas: replicas - 1
-  > 3 replicas: ceil(0.66 * replicas), min 2
-*/}}
-{{- define "sawmills-collector.defaultLbPdbMinAvailable" -}}
-{{- $replicas := int (default 3 .Values.loadBalancer.replicas) -}}
-{{- if le $replicas 1 -}}
-0
-{{- else if le $replicas 3 -}}
-{{ sub $replicas 1 }}
-{{- else -}}
-  {{- $val := div (add (mul $replicas 2) 2) 3 -}}
-  {{- if lt $val 2 -}}
-2
-  {{- else -}}
-{{ $val }}
-  {{- end -}}
-{{- end -}}
-{{- end }}
-
-
-{{/*
 Compute GOMEMLIMIT as 90% of a Kubernetes memory value (e.g. "4Gi" → "3686MiB").
 Accepts Gi and Mi suffixes. Fails at template time for unrecognized formats
 to prevent invalid GOMEMLIMIT values that would crash Go pods at startup.

--- a/helm-charts/sawmills-collector/templates/poddisruptionbudget.yaml
+++ b/helm-charts/sawmills-collector/templates/poddisruptionbudget.yaml
@@ -12,14 +12,21 @@ spec:
   selector:
     matchLabels:
       {{- include "sawmills-collector.selectorLabels" . | nindent 6 }}
-  {{- if and $pdb (hasKey $pdb "minAvailable") (not (kindIs "invalid" $pdb.minAvailable)) }}
+  {{- $unhealthyPodEvictionPolicy := $pdb.unhealthyPodEvictionPolicy | default "AlwaysAllow" }}
+  {{- if and $unhealthyPodEvictionPolicy (semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version) }}
+  unhealthyPodEvictionPolicy: {{ $unhealthyPodEvictionPolicy }}
+  {{- end }}
+  {{- $minAvailableSet := and (hasKey $pdb "minAvailable") (not (kindIs "invalid" $pdb.minAvailable)) (not (and (kindIs "string" $pdb.minAvailable) (eq (trim $pdb.minAvailable) ""))) }}
+  {{- $maxUnavailableSet := and (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" $pdb.maxUnavailable)) (not (and (kindIs "string" $pdb.maxUnavailable) (eq (trim $pdb.maxUnavailable) ""))) }}
+  {{- $legacyAutoscaledMaxUnavailableSet := and (hasKey $pdb "autoscaledMaxUnavailable") (not (kindIs "invalid" $pdb.autoscaledMaxUnavailable)) (not (and (kindIs "string" $pdb.autoscaledMaxUnavailable) (eq (trim $pdb.autoscaledMaxUnavailable) ""))) }}
+  {{- if $minAvailableSet }}
   minAvailable: {{ $pdb.minAvailable }}
-  {{- else if and $pdb (hasKey $pdb "maxUnavailable") (not (kindIs "invalid" $pdb.maxUnavailable)) }}
+  {{- else if $maxUnavailableSet }}
   maxUnavailable: {{ $pdb.maxUnavailable }}
-  {{- else if $workerAutoscaled }}
-  maxUnavailable: {{ $pdb.autoscaledMaxUnavailable | default "10%" }}
+  {{- else if and $workerAutoscaled $legacyAutoscaledMaxUnavailableSet }}
+  maxUnavailable: {{ $pdb.autoscaledMaxUnavailable }}
   {{- else }}
-  minAvailable: {{ include "sawmills-collector.defaultPdbMinAvailable" . }}
+  maxUnavailable: 1
   {{- end }}
 {{- end }}
 ---
@@ -37,13 +44,20 @@ spec:
   selector:
     matchLabels:
       {{- include "sawmills-collector.loadBalancerSelectorLabels" . | nindent 6 }}
-  {{- if and $lbPdb (hasKey $lbPdb "minAvailable") (not (kindIs "invalid" $lbPdb.minAvailable)) }}
+  {{- $lbUnhealthyPodEvictionPolicy := $lbPdb.unhealthyPodEvictionPolicy | default "AlwaysAllow" }}
+  {{- if and $lbUnhealthyPodEvictionPolicy (semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version) }}
+  unhealthyPodEvictionPolicy: {{ $lbUnhealthyPodEvictionPolicy }}
+  {{- end }}
+  {{- $lbMinAvailableSet := and (hasKey $lbPdb "minAvailable") (not (kindIs "invalid" $lbPdb.minAvailable)) (not (and (kindIs "string" $lbPdb.minAvailable) (eq (trim $lbPdb.minAvailable) ""))) }}
+  {{- $lbMaxUnavailableSet := and (hasKey $lbPdb "maxUnavailable") (not (kindIs "invalid" $lbPdb.maxUnavailable)) (not (and (kindIs "string" $lbPdb.maxUnavailable) (eq (trim $lbPdb.maxUnavailable) ""))) }}
+  {{- $lbLegacyAutoscaledMaxUnavailableSet := and (hasKey $lbPdb "autoscaledMaxUnavailable") (not (kindIs "invalid" $lbPdb.autoscaledMaxUnavailable)) (not (and (kindIs "string" $lbPdb.autoscaledMaxUnavailable) (eq (trim $lbPdb.autoscaledMaxUnavailable) ""))) }}
+  {{- if $lbMinAvailableSet }}
   minAvailable: {{ $lbPdb.minAvailable }}
-  {{- else if and $lbPdb (hasKey $lbPdb "maxUnavailable") (not (kindIs "invalid" $lbPdb.maxUnavailable)) }}
+  {{- else if $lbMaxUnavailableSet }}
   maxUnavailable: {{ $lbPdb.maxUnavailable }}
-  {{- else if $lbAutoscaled }}
-  maxUnavailable: {{ $lbPdb.autoscaledMaxUnavailable | default "10%" }}
+  {{- else if and $lbAutoscaled $lbLegacyAutoscaledMaxUnavailableSet }}
+  maxUnavailable: {{ $lbPdb.autoscaledMaxUnavailable }}
   {{- else }}
-  minAvailable: {{ include "sawmills-collector.defaultLbPdbMinAvailable" . }}
+  maxUnavailable: 1
   {{- end }}
 {{- end }}

--- a/helm-charts/sawmills-collector/tests/poddisruptionbudget_test.yaml
+++ b/helm-charts/sawmills-collector/tests/poddisruptionbudget_test.yaml
@@ -1,22 +1,40 @@
 suite: pod disruption budget
 templates:
   - templates/poddisruptionbudget.yaml
+capabilities:
+  majorVersion: 1
+  minorVersion: 27
 tests:
-  - it: keeps the static replica-derived default when not autoscaled
+  - it: serializes voluntary disruptions for a large static collector fleet
     release:
       name: sawmills-collector
+    set:
+      replicaCount: 80
     asserts:
       - hasDocuments:
           count: 1
       - isKind:
           of: PodDisruptionBudget
       - equal:
-          path: spec.minAvailable
-          value: 8
-      - notExists:
           path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow
 
-  - it: defaults to percentage maxUnavailable when keda autoscales the collector
+  - it: permits one disruption for a single-replica collector
+    release:
+      name: sawmills-collector
+    set:
+      replicaCount: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: serializes disruptions when keda autoscales the collector
     release:
       name: sawmills-collector
     set:
@@ -25,11 +43,11 @@ tests:
     asserts:
       - equal:
           path: spec.maxUnavailable
-          value: 10%
+          value: 1
       - notExists:
           path: spec.minAvailable
 
-  - it: defaults to percentage maxUnavailable when native HPA autoscales the collector
+  - it: serializes disruptions when native HPA autoscales the collector
     release:
       name: sawmills-collector
     set:
@@ -38,11 +56,11 @@ tests:
     asserts:
       - equal:
           path: spec.maxUnavailable
-          value: 10%
+          value: 1
       - notExists:
           path: spec.minAvailable
 
-  - it: lets explicit minAvailable win over the autoscaled default
+  - it: lets explicit minAvailable win over all maxUnavailable settings
     release:
       name: sawmills-collector
     set:
@@ -50,6 +68,8 @@ tests:
         enabled: true
       podDisruptionBudget:
         minAvailable: 350
+        maxUnavailable: 2
+        autoscaledMaxUnavailable: 5%
     asserts:
       - equal:
           path: spec.minAvailable
@@ -57,7 +77,19 @@ tests:
       - notExists:
           path: spec.maxUnavailable
 
-  - it: honors a custom autoscaled percentage
+  - it: honors explicit maxUnavailable
+    release:
+      name: sawmills-collector
+    set:
+      podDisruptionBudget:
+        maxUnavailable: 2
+        autoscaledMaxUnavailable: 5%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+
+  - it: honors the deprecated autoscaled percentage alias
     release:
       name: sawmills-collector
     set:
@@ -70,7 +102,34 @@ tests:
           path: spec.maxUnavailable
           value: 5%
 
-  - it: defaults LB budget to percentage maxUnavailable when LB keda is enabled
+  - it: ignores the deprecated autoscaled alias for a static collector
+    release:
+      name: sawmills-collector
+    set:
+      replicaCount: 80
+      podDisruptionBudget:
+        autoscaledMaxUnavailable: 10%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: falls back to one when availability settings are blank
+    release:
+      name: sawmills-collector
+    set:
+      podDisruptionBudget:
+        minAvailable: " "
+        maxUnavailable: ""
+        autoscaledMaxUnavailable: ""
+    asserts:
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: serializes LB disruptions when LB keda is enabled
     release:
       name: sawmills-collector
     set:
@@ -83,23 +142,122 @@ tests:
           count: 2
       - equal:
           path: spec.maxUnavailable
-          value: 10%
+          value: 1
         documentIndex: 1
       - notExists:
           path: spec.minAvailable
         documentIndex: 1
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow
+        documentIndex: 1
 
-  - it: keeps the static LB default when LB is not autoscaled
+  - it: serializes disruptions for a large static LB fleet
     release:
       name: sawmills-collector
     set:
       loadBalancer:
         enabled: true
-        replicas: 6
+        replicas: 80
     asserts:
       - hasDocuments:
           count: 2
       - equal:
+          path: spec.maxUnavailable
+          value: 1
+        documentIndex: 1
+
+  - it: serializes LB disruptions when native HPA is enabled
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+        autoscaling:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+        documentIndex: 1
+
+  - it: lets explicit LB minAvailable win over maxUnavailable
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+        podDisruptionBudget:
+          minAvailable: 75
+          maxUnavailable: 2
+    asserts:
+      - equal:
           path: spec.minAvailable
-          value: 4
+          value: 75
+        documentIndex: 1
+      - notExists:
+          path: spec.maxUnavailable
+        documentIndex: 1
+
+  - it: honors explicit LB maxUnavailable over the compatibility alias
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+        podDisruptionBudget:
+          maxUnavailable: 2
+          autoscaledMaxUnavailable: 5%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+        documentIndex: 1
+
+  - it: honors the deprecated LB autoscaled percentage alias
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+        keda:
+          enabled: true
+        podDisruptionBudget:
+          autoscaledMaxUnavailable: 5%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 5%
+        documentIndex: 1
+
+  - it: ignores the deprecated autoscaled alias for a static LB
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+        replicas: 80
+        podDisruptionBudget:
+          autoscaledMaxUnavailable: 10%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+        documentIndex: 1
+
+  - it: omits unhealthy pod eviction policy before Kubernetes 1.27
+    capabilities:
+      majorVersion: 1
+      minorVersion: 26
+    release:
+      name: sawmills-collector
+    set:
+      loadBalancer:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.unhealthyPodEvictionPolicy
+        documentIndex: 0
+      - notExists:
+          path: spec.unhealthyPodEvictionPolicy
         documentIndex: 1

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -176,23 +176,20 @@ rollout:
         failureThreshold: 24
     preStopSleepSeconds: 20
 
-# Pod disruption budget to keep collectors available during rollouts
+# Pod disruption budget to keep collectors available during voluntary disruptions
 podDisruptionBudget:
   enabled: true
-  # Defaults based on replicaCount (replicaCount-1 when ≤ 5, otherwise ceil(0.8 * replicaCount)) when unset.
-  # Ignored when autoscaling (keda or autoscaling.enabled) is active — static
-  # replicaCount no longer reflects the real pod count, so the default switches
-  # to percentage-based maxUnavailable (see autoscaledMaxUnavailable).
+  # Explicit availability settings. minAvailable takes precedence over
+  # maxUnavailable. When both are unset, maxUnavailable defaults to 1 so node
+  # drains cannot remove a percentage of a large fleet at once.
   minAvailable: null
-  # Default budget when the collector is autoscaled (keda.enabled or
-  # autoscaling.enabled). Percentages track the actual scaled pod count, so a
-  # drain can never take a large fleet at once. Explicit minAvailable /
-  # maxUnavailable still win over this default.
-  # Note: percentages round up, so a fleet scaled down to 1 pod still allows
-  # that pod to be evicted — same stance as the static 1-replica default,
-  # since blocking all voluntary disruption stalls node upgrades. Set
-  # minAvailable explicitly if a scale-to-1 fleet must block drains.
-  autoscaledMaxUnavailable: "10%"
+  maxUnavailable: null
+  # Deprecated compatibility alias for autoscaled releases that previously
+  # persisted this value. Prefer maxUnavailable for new configuration.
+  autoscaledMaxUnavailable: null
+  # Let drains evict unhealthy pods without consuming the healthy-pod budget.
+  # The chart omits this field automatically before Kubernetes 1.27.
+  unhealthyPodEvictionPolicy: AlwaysAllow
 
 
 # Configuration for the Sawmills collector
@@ -1429,17 +1426,17 @@ loadBalancer:
   # from taking all LB pods offline at once.
   podDisruptionBudget:
     enabled: true
-    # Defaults based on LB replicas when unset:
-    #   1 replica  → 0 (avoids blocking voluntary disruptions like node drain)
-    #   2-3 replicas → replicas - 1
-    #   >3 replicas  → ceil(0.66 * replicas)
-    # Ignored when LB autoscaling (loadBalancer.keda or
-    # loadBalancer.autoscaling) is active — the default switches to
-    # percentage-based maxUnavailable (see autoscaledMaxUnavailable).
+    # Explicit availability settings. minAvailable takes precedence over
+    # maxUnavailable. When both are unset, maxUnavailable defaults to 1 so node
+    # drains cannot remove a percentage of a large LB fleet at once.
     minAvailable: null
-    # Default budget when the LB is autoscaled. Percentages track the actual
-    # scaled pod count. Explicit minAvailable / maxUnavailable still win.
-    autoscaledMaxUnavailable: "10%"
+    maxUnavailable: null
+    # Deprecated compatibility alias for autoscaled releases that previously
+    # persisted this value. Prefer maxUnavailable for new configuration.
+    autoscaledMaxUnavailable: null
+    # Let drains evict unhealthy pods without consuming the healthy-pod budget.
+    # The chart omits this field automatically before Kubernetes 1.27.
+    unhealthyPodEvictionPolicy: AlwaysAllow
   resources:
     requests:
       memory: 128Mi


### PR DESCRIPTION
Prevent voluntary node drains from evicting a percentage of large collector fleets at once. This is the durable chart fix for BigID incident PD #2480 / SAW-9869.

## Summary

BigID worker and load-balancer PDBs used `maxUnavailable: 10%`, allowing 8-9 concurrent Eviction API requests during Spot-backed Karpenter node drains. Backend capacity fell from 80 to 67 on mt-1 and 86 to 77 on mt-4; queue age reached 106s and receiver refusals reached 833/s. CPU, heap, mutex, and LB profiles were not saturated.

## Changes Made

- [x] Bug fix
- [x] Documentation update
- [x] Configuration change

- Default worker and load-balancer PDBs to integer `maxUnavailable: 1` for static and autoscaled fleets.
- Add Kubernetes 1.27+ `unhealthyPodEvictionPolicy: AlwaysAllow` so unhealthy pods cannot deadlock drains.
- Preserve explicit `minAvailable` / `maxUnavailable` precedence and autoscaled-only compatibility for the deprecated `autoscaledMaxUnavailable` key.
- Remove obsolete replica-derived PDB helpers and document drain-throughput, rollout, and Spot-interruption trade-offs.
- Add regression coverage for large and single-replica fleets, KEDA/HPA/static modes, legacy values, blank values, precedence, LB parity, and Kubernetes version gating.

## Version Impact

- [x] `version:minor` — safer default behavior with backwards-compatible explicit overrides.

## Testing Performed

- [x] Helm template validation
- [x] Helm lint check
- [x] Regression testing performed
- [x] Local development

Commands:

```bash
helm unittest . -f tests/poddisruptionbudget_test.yaml
./tests/run-tests.sh
helm lint .
helm template pdb-kube126 . --kube-version 1.26.15
helm template pdb-kube127 . --kube-version 1.27.0
trunk check --fix
autoreview --mode branch --base origin/main --fast --model gpt-5.5 --thinking high
```

Results:

- Focused PDB tests: 17/17 passed.
- Full chart tests: 30 suites, 366 tests passed.
- Helm lint and Kubernetes 1.26/1.27 renders passed.
- Trunk clean.
- Fable architecture review: global integer cap plus `AlwaysAllow`; explicit override retained for planned maintenance.
- Final autoreview: clean, no actionable findings.

## Breaking Changes

- [x] No breaking changes. Explicit availability settings continue to win. The default intentionally slows voluntary drain throughput to preserve ingest capacity.

## Impact Assessment

- Affected: sawmills-collector worker and LB fleets without explicit PDB availability values.
- Runtime: Eviction API disruptions serialize to one healthy pod per tier. Deployment/StatefulSet rolling strategies are unchanged.
- Rollback: set an explicit higher `maxUnavailable`, or revert the chart version. BigID's persisted values will be migrated explicitly during gradual rollout so the legacy `10%` value cannot win.

## Documentation Updated

- [x] Chart README.md updated
- [x] Configuration examples updated
- [x] Inline comments added

Linear: SAW-9869

@sawmills/engineers Please review this contribution.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize voluntary pod disruptions to prevent mass collector eviction during Spot node drains. Defaults PDBs to one healthy eviction and allows unhealthy pods to drain on Kubernetes 1.27+, addressing SAW-9869.

- **Bug Fixes**
  - Default worker and LB PDBs to maxUnavailable: 1 for static and autoscaled fleets.
  - Add unhealthyPodEvictionPolicy: AlwaysAllow on Kubernetes 1.27+ (omitted on older clusters).
  - Keep explicit minAvailable/maxUnavailable precedence; keep autoscaledMaxUnavailable as a lower‑precedence alias for autoscaled workloads (ignored for static).
  - Remove replica-derived PDB helpers; update docs on drain vs availability and rollout behavior.
  - Add Helm tests for large/single replicas, KEDA/HPA/static paths, legacy/blank values, LB parity, and version gating.

<sup>Written for commit d482e274922cd1782147bfabb21edceb3217e166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Pod Disruption Budget defaults to use `maxUnavailable: 1` for collector and load balancer workloads.
  * Added support for `unhealthyPodEvictionPolicy: AlwaysAllow` on Kubernetes 1.27 and later.
  * Clarified precedence between `minAvailable` and `maxUnavailable` settings.

* **Documentation**
  * Updated configuration guidance and examples.
  * Marked `autoscaledMaxUnavailable` as a deprecated compatibility option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->