### PR TITLE
fix(collector): forward hot-shard pressure metrics

### DIFF
--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -142,7 +142,7 @@ tests:
           pattern: '(?m)^\s*transform/keda_source:\s*$'
       - matchRegex:
           path: data["keda.yaml"]
-          pattern: 'set\(attributes\["source_pod"\], resource\.attributes\["pod"\]\)'
+          pattern: '(?s)transform/keda_source:\s*error_mode: ignore\s*metric_statements:\s*- context: datapoint\s*statements:\s*- set\(attributes\["source_pod"\], resource\.attributes\["pod"\]\) where resource\.attributes\["pod"\]\s*!= nil\s*service:'
       - matchRegex:
           path: data["keda.yaml"]
           pattern: '(?s)metrics/keda:.*processors:\s*- transform/keda_source\s*- filter/keda'

--- a/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
+++ b/helm-charts/sawmills-collector/tests/telemetry_keda_overlay_test.yaml
@@ -119,6 +119,33 @@ tests:
       - matchRegex:
           path: data["keda.yaml"]
           pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_central_queue_oldest_item_age
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_backend_inflight_oldest_age
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_backend_request_bytes_total
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_backend_timeout_total
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: not IsMatch\(name,\s*"[^"]*otelcol_loadbalancer_backend_count
+
+  - it: preserves load balancer source pod identity before the keda filter
+    template: telemetry-keda-configmap.yaml
+    set:
+      kedaScaler.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: '(?m)^\s*transform/keda_source:\s*$'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: 'set\(attributes\["source_pod"\], resource\.attributes\["pod"\]\)'
+      - matchRegex:
+          path: data["keda.yaml"]
+          pattern: '(?s)metrics/keda:.*processors:\s*- transform/keda_source\s*- filter/keda'
 
   - it: resolves keda otlp exporter endpoint and preserves literal template-like config
     template: telemetry-keda-configmap.yaml

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1199,6 +1199,7 @@ kedaScaler:
       memory: 128Mi
   telemetryConfig:
     processors:
+      # Preserve the source load-balancer pod on each KEDA datapoint before filtering.
       transform/keda_source:
         error_mode: ignore
         metric_statements:

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1199,12 +1199,18 @@ kedaScaler:
       memory: 128Mi
   telemetryConfig:
     processors:
+      transform/keda_source:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["source_pod"], resource.attributes["pod"]) where resource.attributes["pod"] != nil
       filter/keda:
         error_mode: ignore
         metrics:
           metric:
             # Drop every metric that is not in the KEDA scaler store allowlist.
-            - not IsMatch(name, "^(haproxy_server_http_responses_total|http\\.server\\.duration|otelcol_exporter_queue_size|otelcol_exporter_queue_capacity|otelcol_loadbalancer_central_queue_compressed_bytes|otelcol_loadbalancer_central_queue_compressed_capacity|otelcol_loadbalancer_central_queue_saturation|otelcol_loadbalancer_central_queue_oldest_item_age|http\\.server\\.request\\.duration)$")
+            - not IsMatch(name, "^(haproxy_server_http_responses_total|http\\.server\\.duration|otelcol_exporter_queue_size|otelcol_exporter_queue_capacity|otelcol_loadbalancer_central_queue_compressed_bytes|otelcol_loadbalancer_central_queue_compressed_capacity|otelcol_loadbalancer_central_queue_saturation|otelcol_loadbalancer_central_queue_oldest_item_age|otelcol_loadbalancer_backend_count|otelcol_loadbalancer_backend_inflight_oldest_age|otelcol_loadbalancer_backend_request_bytes_total|otelcol_loadbalancer_backend_timeout_total|http\\.server\\.request\\.duration)$")
     exporters:
       otlp/keda:
         endpoint: '{{ include "sawmills-collector.kedaScalerSvcFQDN" . }}:${env:KEDA_SCALER_OTLP_RECEIVER_PORT}'
@@ -1217,6 +1223,7 @@ kedaScaler:
           exporters:
             - otlp/keda
           processors:
+            - transform/keda_source
             - filter/keda
           receivers:
             - forward


### PR DESCRIPTION
## Summary

Forward the signal-scoped log pressure metrics to the KEDA metric store. Copy the load-balancer pod identity to each data point so endpoint rates from different source pods remain distinct.

SAW-9892: https://linear.app/sawmills/issue/SAW-9892/bigid-scale-and-rebalance-workers-on-hot-shard-pressure-and-backend

## Changes Made

- [x] Bug fix
- [x] Configuration change

## Version Impact

Patch release. Expected collector chart version: 2.19.1.

Release workflow evidence: .github/workflows/deploy-helm-chart.yml derives the next version from the latest collector-v tag after merge, updates Chart.yaml, commits that generated version update to main, and creates the collector-v tag. Chart.yaml is intentionally not bumped in feature PRs. The current collector-v2.19.0 tag also contains Chart.yaml version 2.8.1. PR 206 changed this chart without a manual Chart.yaml bump and released through the same version:patch workflow.

## Testing Performed

- [x] Regression testing performed
- [x] Local development

Command: helm unittest helm-charts/sawmills-collector

Result: 367 tests passed.

## Breaking Changes

- [x] No breaking changes

## Impact Assessment

- Affected system: collector telemetry overlay and KEDA metric store input
- Rollback: install the prior chart and keep the SAW-9892 pressure flag off

## Documentation Updated

- [x] Not applicable

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have added the appropriate version label
- [x] I have provided clear commit messages