### PR TITLE
feat(sawmills-collector): support additionalVolumeMounts on the load balancer

### DIFF
--- a/helm-charts/sawmills-collector/templates/load-balancer.yaml
+++ b/helm-charts/sawmills-collector/templates/load-balancer.yaml
@@ -257,6 +257,14 @@ spec:
             - name: {{ include "sawmills-collector.name" . }}-lb
               mountPath: /data
           {{- end }}
+          {{- /* LB-specific additionalVolumeMounts take precedence; global additionalVolumeMounts used as fallback (mirrors the additionalVolumes handling in the pod volumes below) */ -}}
+          {{- with .Values.loadBalancer.additionalVolumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- else }}
+          {{- with .Values.additionalVolumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
         - name: telemetry-collector
           securityContext:
             runAsNonRoot: true

--- a/helm-charts/sawmills-collector/tests/load_balancer_additional_volume_mounts_test.yaml
+++ b/helm-charts/sawmills-collector/tests/load_balancer_additional_volume_mounts_test.yaml
@@ -1,0 +1,91 @@
+suite: load balancer additionalVolumeMounts
+templates:
+  - load-balancer.yaml
+tests:
+  - it: mounts loadBalancer.additionalVolumeMounts into the LB main-collector container
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      loadBalancer.additionalVolumes:
+        - name: gcp-credentials
+          secret:
+            secretName: gcp-credentials
+      loadBalancer.additionalVolumeMounts:
+        - name: gcp-credentials
+          mountPath: /creds
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: gcp-credentials
+            mountPath: /creds
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gcp-credentials
+            secret:
+              secretName: gcp-credentials
+
+  - it: falls back to global additionalVolumeMounts on the LB when no LB-specific value is set
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      additionalVolumes:
+        - name: gcp-credentials
+          secret:
+            secretName: gcp-credentials
+      additionalVolumeMounts:
+        - name: gcp-credentials
+          mountPath: /creds
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: gcp-credentials
+            mountPath: /creds
+            readOnly: true
+
+  - it: prefers loadBalancer.additionalVolumeMounts over the global fallback
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+      additionalVolumeMounts:
+        - name: global-mount
+          mountPath: /global
+      loadBalancer.additionalVolumeMounts:
+        - name: lb-mount
+          mountPath: /lb
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: lb-mount
+            mountPath: /lb
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: global-mount
+            mountPath: /global
+
+  - it: adds no extra volume mounts to the LB main-collector by default
+    template: load-balancer.yaml
+    values:
+      - ../values.yaml
+    set:
+      loadBalancer.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="main-collector")].volumeMounts
+          content:
+            name: gcp-credentials
+            mountPath: /creds
+            readOnly: true

--- a/helm-charts/sawmills-collector/values.yaml
+++ b/helm-charts/sawmills-collector/values.yaml
@@ -1454,6 +1454,11 @@ loadBalancer:
       memory: 512Mi
       cpu: 500m
   additionalVolumes: []
+  # -- Extra volume mounts for the load balancer collector container. Falls back
+  # to the top-level `additionalVolumeMounts` when unset. Pair with
+  # `loadBalancer.additionalVolumes` (or the global `additionalVolumes`) to mount
+  # extra files — e.g. a GCP service-account key for the Pub/Sub pull receiver.
+  additionalVolumeMounts: []
   storage:
     # Required when using a persistent sending_queue (sending_queue.storage).
     # The chart mounts this PVC at /data for the load balancer collector.


### PR DESCRIPTION
## Problem

The load-balancer collector container renders a **fixed** `volumeMounts` list (config, readiness, tmp, LB storage) with **no hook** for extra mounts — while the pod-level `volumes` already support `loadBalancer.additionalVolumes` (LB-specific) with a fallback to global `additionalVolumes`.

That asymmetry means an operator can declare a volume on the LB pod but has **no way to mount it into the LB collector container**. Concretely (SAW-9889, Applied Systems): the GCP Pub/Sub **pull** receiver is hoisted onto the LB and needs a service-account key. `loadBalancer.extraEnv` set `GOOGLE_APPLICATION_CREDENTIALS=/creds/credentials.json` and `additionalVolumes` put the secret on the pod, but with no mount the file never appeared → the collector crash-looped on:
```
failed creating the gRPC client to PubSub: open /creds/credentials.json: no such file or directory
```

## Fix

Add `loadBalancer.additionalVolumeMounts`, honoring the **same precedence idiom the chart already uses for volumes** — LB-specific wins, global `additionalVolumeMounts` as fallback. Mirrors `deployment.yaml`'s existing `additionalVolumeMounts` support on the main collector. Default `[]` is a no-op.

```yaml
loadBalancer:
  additionalVolumes:
    - {name: gcp-credentials, secret: {secretName: gcp-credentials}}
  additionalVolumeMounts:
    - {name: gcp-credentials, mountPath: /creds, readOnly: true}
  extraEnv:
    - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /creds/credentials.json}
```

## Verification

- `helm lint` clean.
- Renders: LB-specific `loadBalancer.additionalVolumeMounts` mounts into the LB `main-collector`; **global `additionalVolumeMounts` also flows to the LB** via fallback (so operators who already set it globally get it on the LB automatically); default `[]` renders no stray mounts; main collector unchanged.
- No breaking change to existing `values.yaml` structure (additive key).

Ref: SAW-9889

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `loadBalancer.additionalVolumeMounts` to the load balancer collector with fallback to global `additionalVolumeMounts`, allowing extra pod volumes to be mounted into the LB container. This enables mounting a GCP service-account key for the GCP Pub/Sub Pull receiver on ILB-only collectors (SAW-9889).

- **New Features**
  - New `values.yaml` key: `loadBalancer.additionalVolumeMounts: []` with precedence `loadBalancer.additionalVolumeMounts` > `additionalVolumeMounts`; mirrors existing `additionalVolumes` behavior; default is a no-op.
  - Helm-unittest added to verify LB-specific precedence, global fallback, and default no-op on the `main-collector` container.

<sup>Written for commit 7d5f664e8139ce118ab6d40917443d92c1d28bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/helm-charts/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

